### PR TITLE
init: querydsl in springboot 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+/src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
 // swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-// queryDSL
+	//querydsl dependencies 추가(스프링부트 3.0 이상)
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
@@ -62,6 +62,32 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
-tasks.named('test') {
-	useJUnitPlatform()
+clean {
+	delete fileTree(dir: 'src/main/generated', include: '**/*.java')
+}
+
+tasks.withType(JavaCompile) {
+	options.compilerArgs += [
+			'--add-opens',
+			'java.base/java.lang=ALL-UNNAMED',
+			'--add-opens',
+			'java.base/java.util=ALL-UNNAMED'
+	]
+}
+
+
+sourceSets {
+	main {
+		java {
+			srcDirs = ['src/main/java', 'src/main/resources', 'src/main/generated']
+		}
+	}
+}
+
+def querydslSrcDir = 'src/main/generated'
+clean {
+	delete file(querydslSrcDir)
+}
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
 }

--- a/src/main/java/com/umc/linkyou/config/QueryDSLConfig.java
+++ b/src/main/java/com/umc/linkyou/config/QueryDSLConfig.java
@@ -1,0 +1,18 @@
+package com.umc.linkyou.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#6 querydsl설정 
QueryDSL을 사용하면 Java 코드로 SQL과 유사한 쿼리를 작성할 수 있습니다.
예를들어 Cursor 기반 페이지네이션(Cursor Paging)을 작성할 수 있습니다.
오프셋 기반은 페이지가 뒤로 갈수록 성능이 저하되지만, 커서 기반은 특정 기준(예: id, createdAt 등) 이후의 데이터만 조회하므로 빠른 응답이 가능합니다. 하지만 cursor 페이징은 java가 아닌 sql문으로만 작성할 수 있습니다.
QueryDSL을 활용하면 java 코드로 이를 작성할 수 있습니다.
**저희 이번에 조회기능 구현할 때 이를 활용하여 cursor페이징하면** 좋을 것 같습니다.

## 📝작업 내용
springboot 3.0이상에서는 설정이 달라서 오래 걸렸습니다.

## 참고 자료
https://lordofkangs.tistory.com/461

