### PR TITLE
Feat/#50 share folder

### DIFF
--- a/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepository.java
@@ -10,7 +10,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface UsersFolderRepository extends JpaRepository<UsersFolder, Long>, UsersFolderRepositoryCustom {
-    @Query("select count(uf) > 0 from UsersFolder uf where uf.user.id = :userId and uf.folder.folderId = :folderId and uf.isOwner = true")
+    @Query("""
+            select count(uf) > 0
+            from UsersFolder uf
+            where uf.user.id = :userId
+                and uf.folder.folderId = :folderId
+                and uf.isOwner = true
+            """)
     boolean existsFolderOwner(@Param("userId") Long userId, @Param("folderId") Long folderId);
 
     List<UsersFolder> findByFolderFolderIdAndIsViewerTrue(Long folderId);
@@ -26,4 +32,14 @@ public interface UsersFolderRepository extends JpaRepository<UsersFolder, Long>,
                   and uf.isViewer = true
             """)
     List<Folder> findSharedFolders(@Param("userId") Long userId);
+
+    // 뷰어 찾기, 주인 제외
+    @Query("""
+                select uf
+                from UsersFolder uf
+                where uf.folder.folderId = :folderId
+                  and uf.isOwner = false
+                  and uf.isViewer = true
+            """)
+    List<UsersFolder> searchViewers(@Param("folderId") Long folderId);
 }

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderService.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderService.java
@@ -17,4 +17,7 @@ public interface ShareFolderService {
 
     // 특정 뷰어 권한 수정
     ShareFolderResponseDTO updateViewerPermission(Long userId, Long folderId, Long userFolderId, FolderPermissionRequestDTO request);
+
+    // 폴더 비공개 전환
+    ShareFolderResponseDTO unshare(Long ownerId, Long folderId);
 }

--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -61,4 +61,16 @@ public class ShareFolderController {
                 userDetails.getUsers().getId(), folderId, userFolderId, request);
         return ResponseEntity.ok(result);
     }
+
+    // 폴더 비공개 전환
+    @PostMapping("/{folderId}/unshare")
+    @Operation(summary = "폴더 비공개 전환")
+    public ResponseEntity<ShareFolderResponseDTO> unshareFolder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    ) {
+        // 모든 유저의 (폴더 주인 제외) 뷰어, writer 권한 false
+        ShareFolderResponseDTO result = shareFolderService.unshare(userDetails.getUsers().getId(), folderId);
+        return ResponseEntity.ok(result);
+    }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50

## 📝작업 내용

> 공유 된 폴더 비공개로 전환
삭제는 공유 받은 내역 자체를 지우고 비공개 전환은 저장 된 상태로 뷰어, writer 권한만 false로 바꿈

### 스크린샷 (선택)
<img width="969" height="566" alt="image" src="https://github.com/user-attachments/assets/a352be7d-04a2-4ca7-9918-4731ffdc02f7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 폴더를 비공개(공유 해제)로 전환하는 기능이 추가되었습니다. 이제 폴더 소유자가 모든 뷰어 및 작성자의 권한을 해제하여 폴더를 비공개로 만들 수 있습니다.
  * 공유 해제 API 엔드포인트가 추가되어, 폴더 소유자가 직접 폴더 공유를 해제할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->