### PR TITLE
feat: 커스텀 예외 설정, 폴더 응답에 북마크 추가 #105

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -47,8 +47,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _EMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "EMOTION4041", "해당하는 감정을 찾을 수 없습니다."),
     //도메인 관련 에러
     _DOMAIN_NOT_FOUND(HttpStatus.NOT_FOUND, "DOMAIN4041", "해당하는 도메인을 찾을 수 없습니다."),
-    //폴더 관련 에러
-    _FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4041", "해당하는 폴더를 찾을 수 없습니다."),
 
     //Situation 상황 관련 오류
     _SITUATION_NOT_FOUND(HttpStatus.NOT_FOUND, "Situation4041", "해당하는 상황을 찾을 수 없습니다."),
@@ -57,6 +55,20 @@ public enum ErrorStatus implements BaseErrorCode {
     _RECOMMEND_LINKU_NO_RECOMMENDATION(HttpStatus.BAD_REQUEST, "LINKU4004", "추천할 만한 링크가 없습니다."),
     _RECOMMEND_LINKU_NEW_USER(HttpStatus.BAD_REQUEST, "LINKU4005", "신규 사용자는 추천 기능을 이용할 수 없습니다."),
 
+    // 폴더 관련 오류
+    _FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER404", "해당하는 폴더를 찾을 수 없습니다."),
+    _FOLDER_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_PARENT404", "폴더의 부모 폴더가 없습니다."),
+    _FOLDER_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_CATEGORY404", "폴더의 카테고리가 없습니다."),
+    _FOLDER_CREATE_DUPLICATE(HttpStatus.CONFLICT, "FOLDER_CATEGORY404", "중복된 폴더명입니다."),
+    _FOLDER_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_UPDATE403", "해당하는 폴더의 수정 권한이 없습니다."),
+    _FOLDER_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_DELETE403", "해당하는 폴더의 삭제 권한이 없습니다."),
+
+    // 공유 폴더 관련 응답
+    _FOLDER_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_PERMISSION404", "해당 유저의 폴더 권한 정보를 찾을 수 없습니다."),
+    FOLDER_OWNER_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOLDER_OWNER_403", "폴더 주인의 권한은 수정할 수 없습니다."),
+
+    // 북마크 관련 오류
+    _FOLDER_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_BOOKMARK404", "해당 유저의 북마크 정보가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/SuccessStatus.java
@@ -20,7 +20,30 @@ public enum SuccessStatus implements BaseCode {
     _EMAIL_VERIFICATION_SUCCESS(HttpStatus.ACCEPTED, "EMAIL202", "이메일 인증 성공."),
     // 로그인 관련 응답
     _TEMP_PASSWORD_SENT(HttpStatus.ACCEPTED, "USER205", "임시 비밀번호 전송 성공."),
+
+    // 카테고리 관련 응답
+    _CATEGORY_OK(HttpStatus.ACCEPTED, "CATEGORY200", "카테고리 조회에 성공했습니다."),
+    _CATEGORY_COLOR_OK(HttpStatus.ACCEPTED, "CATEGORY_COLOR200", "카테고리 색상 설정을 성공했습니다."),
+
+    // 폴더 관련 응답
+    _FOLDER_OK(HttpStatus.ACCEPTED, "FOLDER200", "내 폴더 트리 조회르 성공"),
+    _FOLDER_PARENT_OK(HttpStatus.ACCEPTED, "FOLDER_PARENT200", "내 중분류 폴더 조회를 성공했습니다"),
+    _FOLDER_SUBFOLDER_OK(HttpStatus.ACCEPTED, "FOLDER_SUBFOLDER200", "하위 폴더(소분류) 조회를 성공했습니다"),
+    _FOLDER_CREATE_OK(HttpStatus.ACCEPTED, "FOLDER_CREATE200", "소분류 폴더 생성에 성공했습니다."),
+    _FOLDER_UPDATE_OK(HttpStatus.ACCEPTED, "FOLDER_UPDATE200", "소분류 폴더명 수정에 성공했습니다."),
+    _FOLDER_LINK_OK(HttpStatus.ACCEPTED, "FOLDER_LINK200", "폴더 내부 소분류 폴더+링크 목록 조회를 성공했습니다."),
+
+    // 공유 폴더 관련 응답
+    _FOLDER_SHARE_OK(HttpStatus.ACCEPTED, "FOLDER_SHARE200", "폴더를 공유했습니다."),
+    _FOLDER_UNSHARE_OK(HttpStatus.ACCEPTED, "FOLDER_UNSHARE200", "폴더를 비공개로 전환했습니다."),
+    _FOLDER_SHARED_OK(HttpStatus.ACCEPTED, "FOLDER_SHARED200", "공유 받은 폴더 목록 조회를 성공했습니다."),
+    _FOLDER_MEMBERS_OK(HttpStatus.ACCEPTED, "FOLDER_MEMBERS200", "폴더 뷰어 목록 조회를 성공했습니다"),
+    _FOLDER_PERMISSION_OK(HttpStatus.ACCEPTED, "FOLDER_PERMISSION200", "폴더 권한 수정을 성공했습니다."),
+
+    // 북마크 관련 응답
+    _FOLDER_BOOKMARK_OK(HttpStatus.ACCEPTED, "FOLDER_BOOKMARK200", "폴더 북마크 상태 변경을 성공했습니다"),
     ;
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/umc/linkyou/converter/FolderConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/FolderConverter.java
@@ -4,12 +4,17 @@ import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.mapping.folder.UsersFolder;
+import com.umc.linkyou.repository.usersFolderRepository.UsersFolderRepository;
 import com.umc.linkyou.web.dto.folder.FolderResponseDTO;
 import com.umc.linkyou.web.dto.folder.FolderTreeResponseDTO;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+@RequiredArgsConstructor
 @Component
 public class FolderConverter {
+    private final UsersFolderRepository usersFolderRepository;
+
     public FolderResponseDTO toFolderResponseDTO(Folder folder) {
         if (folder == null) {
             return null;
@@ -26,16 +31,23 @@ public class FolderConverter {
                 .build();
     }
 
-    public FolderTreeResponseDTO toFolderTreeDTO(Folder folder) {
+    public FolderTreeResponseDTO toFolderTreeDTO(Folder folder, Long userId) {
         FolderTreeResponseDTO dto = new FolderTreeResponseDTO();
 
         dto.setFolderId(folder.getFolderId());
         dto.setFolderName(folder.getFolderName());
 
+        boolean isBookmarked = usersFolderRepository
+                .findByUserIdAndFolderId(userId, folder.getFolderId())
+                .map(UsersFolder::getIsBookmarked)
+                .orElse(false);
+        dto.setIsBookmarked(isBookmarked);
+
         Category category = folder.getCategory();
         if (category != null) {
             dto.setCategoryId(category.getCategoryId());
         }
+
         return dto;
     }
 

--- a/src/main/java/com/umc/linkyou/domain/mapping/folder/UsersFolder.java
+++ b/src/main/java/com/umc/linkyou/domain/mapping/folder/UsersFolder.java
@@ -23,7 +23,7 @@ public class UsersFolder extends BaseEntity {
     private Boolean isViewer;
     private Boolean isWriter;
 
-    private Boolean isBookmarked;
+    private Boolean isBookmarked = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepositoryCustom.java
+++ b/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepositoryCustom.java
@@ -18,7 +18,7 @@ public interface UsersFolderRepositoryCustom {
 
     Optional<UsersFolder> findByUserIdAndFolderId(Long userId, Long folderId);
 
-    List<Folder> findParentFolders(Long userId);
+    List<UsersFolder> findParentFolders(Long userId);
 
     Optional<Folder> findFolderByUserIdAndFolderName(Long userId, String folderName);
 }

--- a/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/usersFolderRepository/UsersFolderRepositoryImpl.java
@@ -91,7 +91,7 @@ public class UsersFolderRepositoryImpl implements UsersFolderRepositoryCustom {
     }
 
     @Override
-    public List<Folder> findParentFolders(Long userId) {
+    public List<UsersFolder> findParentFolders(Long userId) {
         QUsersFolder usersFolder = QUsersFolder.usersFolder;
         BooleanBuilder builder = new BooleanBuilder();
 
@@ -103,7 +103,7 @@ public class UsersFolderRepositoryImpl implements UsersFolderRepositoryCustom {
         builder.and(usersFolder.folder.parentFolder.isNull());
 
         return queryFactory
-                .select(usersFolder.folder)
+                .select(usersFolder)
                 .from(usersFolder)
                 .where(builder)
                 .fetch();

--- a/src/main/java/com/umc/linkyou/service/folder/FolderService.java
+++ b/src/main/java/com/umc/linkyou/service/folder/FolderService.java
@@ -22,7 +22,7 @@ public interface FolderService {
     List<FolderListResponseDTO> getSubFolders(Long userId, Long parentFolderId);
 
     // 북마크 설정/해제
-    FolderResponseDTO updateBookmark(Long userId, Long folderId, Boolean isBookmarked);
+    BookmarkUpdateResponseDTO updateBookmark(Long userId, Long folderId, Boolean isBookmarked);
 
     // 폴더 내부 링크, 폴더 목록 조회
     FolderLinkusResponseDTO getFolderLinkus(Long userId, Long folderId, int limit, String cursor);

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.service.folder.share;
 
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.enums.PermissionType;
 import com.umc.linkyou.domain.mapping.folder.UsersFolder;
 import com.umc.linkyou.repository.FolderRepository;
@@ -67,11 +69,11 @@ public class ShareFolderServiceImpl implements ShareFolderService {
 
     // 유저의 폴더 권한 수정
     public ShareFolderResponseDTO updateViewerPermission(Long userId, Long folderId, Long userFolderId, FolderPermissionRequestDTO request) {
-        UsersFolder usersFolder = usersFolderRepository.findById(userFolderId).orElseThrow(() -> new IllegalArgumentException("해당 유저의 폴더 권한 정보가 존재하지 않습니다."));
+        UsersFolder usersFolder = usersFolderRepository.findById(userFolderId).orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_FOUND));
 
         // 오너일 경우 권한 변경 불가
         if (Boolean.TRUE.equals(usersFolder.getIsOwner())) {
-            throw new IllegalStateException("폴더 주인 권한 수정 불가");
+            throw new GeneralException(ErrorStatus.FOLDER_OWNER_UPDATE_NOT_ALLOWED);
         }
 
         PermissionType permission = request.getPermission();

--- a/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.category.CategoryService;
 import com.umc.linkyou.web.dto.category.CategoryListResponseDTO;
@@ -23,22 +25,22 @@ public class CategoryController {
     // 카테고리 목록 조회
     @GetMapping
     @Operation(summary = "카테고리 목록 조회")
-    public ResponseEntity<List<CategoryListResponseDTO>> getCategoryList(
+    public ApiResponse<List<CategoryListResponseDTO>> getCategoryList(
     ) {
         List<CategoryListResponseDTO> categoryList = categoryService.getCategories();
-        return ResponseEntity.ok(categoryList);
+        return ApiResponse.of(SuccessStatus._CATEGORY_OK, categoryList);
     }
 
     // 유저 카테고리(중분류 폴더) 색상 수정
     @PutMapping("/{categoryId}/color")
     @Operation(summary = "유저 카테고리(중분류 폴더) 색상 수정")
-    public ResponseEntity<UserCategoryColorResponseDTO> updateUserCategoryColor(
+    public ApiResponse<UserCategoryColorResponseDTO> updateUserCategoryColor(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long categoryId,
             @RequestBody UpdateCategoryColorRequestDTO request
     ) {
         UserCategoryColorResponseDTO userCategoryColor =
                 categoryService.updateUserCategoryColor(userDetails.getUsers().getId(), categoryId, request);
-        return ResponseEntity.ok(userCategoryColor);
+        return ApiResponse.of(SuccessStatus._CATEGORY_COLOR_OK, userCategoryColor);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/FolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/FolderController.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.FolderService;
 import com.umc.linkyou.web.dto.folder.*;
@@ -21,25 +23,25 @@ public class FolderController {
     // (소분류) 폴더 생성
     @PostMapping("/{parentFolderId}/subfolders")
     @Operation(summary = "소분류 폴더 생성")
-    public ResponseEntity<FolderResponseDTO> createFolder(
+    public ApiResponse<FolderResponseDTO> createFolder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long parentFolderId,
             @RequestBody FolderCreateRequestDTO request
     ) {
         FolderResponseDTO response = folderService.createFolder(userDetails.getUsers().getId(), parentFolderId, request);
-        return ResponseEntity.ok(response);
+        return ApiResponse.of(SuccessStatus._FOLDER_CREATE_OK, response);
     }
 
     // (소분류) 폴더 수정
     @PutMapping("/subfolders/{folderId}")
     @Operation(summary = "소분류 폴더 수정")
-    public ResponseEntity<FolderResponseDTO> updateFolder(
+    public ApiResponse<FolderResponseDTO> updateFolder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId,
             @RequestBody FolderUpdateRequestDTO request
     ) {
         FolderResponseDTO response = folderService.updateFolder(userDetails.getUsers().getId(), folderId, request);
-        return ResponseEntity.ok(response);
+        return ApiResponse.of(SuccessStatus._FOLDER_UPDATE_OK, response);
     }
 
     // (소분류) 폴더 삭제
@@ -56,52 +58,52 @@ public class FolderController {
     // 내 폴더 목록(트리) 조회
     @GetMapping("/my")
     @Operation(summary = "내 폴더 목록(트리) 조회")
-    public ResponseEntity<List<FolderTreeResponseDTO>> getMyFolderTree(
+    public ApiResponse<List<FolderTreeResponseDTO>> getMyFolderTree(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         List<FolderTreeResponseDTO> folderTree = folderService.getMyFolderTree(userDetails.getUsers().getId());
-        return ResponseEntity.ok(folderTree);
+        return ApiResponse.of(SuccessStatus._FOLDER_OK, folderTree);
     }
 
     // 중분류 폴더 목록 조회
     @GetMapping("/parentFolders")
     @Operation(summary = "중분류 폴더 조회")
-    public ResponseEntity<List<FolderListResponseDTO>> getParentFolderList(
+    public ApiResponse<List<FolderListResponseDTO>> getParentFolderList(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         List<FolderListResponseDTO> folderList = folderService.getParentFolders(userDetails.getUsers().getId());
-        return ResponseEntity.ok(folderList);
+        return ApiResponse.of(SuccessStatus._FOLDER_PARENT_OK, folderList);
     }
 
     // (중분류) 하위 폴더 목록 조회
     @GetMapping("/{parentFolderId}/subfolders")
     @Operation(summary = "중분류 내부의 하위 폴더 조회")
-    public ResponseEntity<List<FolderListResponseDTO>> getSubFolderList(
+    public ApiResponse<List<FolderListResponseDTO>> getSubFolderList(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long parentFolderId
     ) {
         List<FolderListResponseDTO> folderList = folderService.getSubFolders(userDetails.getUsers().getId(), parentFolderId);
-        return ResponseEntity.ok(folderList);
+        return ApiResponse.of(SuccessStatus._FOLDER_SUBFOLDER_OK, folderList);
     }
 
     // 북마크 설정/해제
-    @PutMapping("/{folderId}/bookmark")
+    @PatchMapping("/{folderId}/bookmark")
     @Operation(summary = "북마크 설정/해제")
-    public ResponseEntity<FolderResponseDTO> updateBookmark(
+    public ApiResponse<BookmarkUpdateResponseDTO> updateBookmark(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId,
             @RequestBody BookmarkUpdateRequestDTO request
     ) {
-        FolderResponseDTO response = folderService.updateBookmark(
+        BookmarkUpdateResponseDTO response = folderService.updateBookmark(
                 userDetails.getUsers().getId(), folderId, request.getIsBookmarked()
         );
-        return ResponseEntity.ok(response);
+        return ApiResponse.of(SuccessStatus._FOLDER_BOOKMARK_OK, response);
     }
 
     // 폴더 내부 링크, 폴더 목록 조회
     @GetMapping("/{folderId}/linkus")
     @Operation(summary = "폴더 내부 링크, 폴더 목록 조회")
-    public ResponseEntity<FolderLinkusResponseDTO> getFolderLinkus(
+    public ApiResponse<FolderLinkusResponseDTO> getFolderLinkus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId,
             @RequestParam(defaultValue = "20") int limit,
@@ -109,6 +111,6 @@ public class FolderController {
     ) {
         FolderLinkusResponseDTO response = folderService.getFolderLinkus(
                 userDetails.getUsers().getId(), folderId, limit, cursor);
-        return ResponseEntity.ok(response);
+        return ApiResponse.of(SuccessStatus._FOLDER_LINK_OK, response);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.share.ShareFolderService;
 import com.umc.linkyou.web.dto.folder.share.FolderPermissionRequestDTO;
@@ -24,53 +26,53 @@ public class ShareFolderController {
     // 폴더 공유 (뷰어 권한 설정)
     @PostMapping("/{folderId}")
     @Operation(summary = "폴더 공유 (뷰어 권한 설정)")
-    public ResponseEntity<ShareFolderResponseDTO> shareFolder(
+    public ApiResponse<ShareFolderResponseDTO> shareFolder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         ShareFolderRequestDTO request = new ShareFolderRequestDTO();
         request.setUserId(userDetails.getUsers().getId());
         request.setPermission("VIEWER");
-        ShareFolderResponseDTO result = shareFolderService.shareFolder(
+        ShareFolderResponseDTO response = shareFolderService.shareFolder(
                 userDetails.getUsers().getId(), folderId, request);
-        return ResponseEntity.ok(result);
+        return ApiResponse.of(SuccessStatus._FOLDER_SHARE_OK, response);
     }
 
     // 폴더 뷰어 조회
     @GetMapping("/{folderId}/members")
     @Operation(summary = "폴더 뷰어 조회")
-    public ResponseEntity<List<ViewerResponseDTO>> getFolderViewers(
+    public ApiResponse<List<ViewerResponseDTO>> getFolderViewers(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         List<ViewerResponseDTO> viewers = shareFolderService.getViewers(
                 userDetails.getUsers().getId(), folderId);
-        return ResponseEntity.ok(viewers);
+        return ApiResponse.of(SuccessStatus._FOLDER_MEMBERS_OK, viewers);
     }
 
     // 뷰어, 라이터 권한 수정
     @PutMapping("/{folderId}/members/{userFolderId}")
     @Operation(summary = "폴더 권한 수정")
-    public ResponseEntity<ShareFolderResponseDTO> updateViewerPermission(
+    public ApiResponse<ShareFolderResponseDTO> updateViewerPermission(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId,
             @PathVariable Long userFolderId,
             @Valid @RequestBody FolderPermissionRequestDTO request
     ) {
-        ShareFolderResponseDTO result = shareFolderService.updateViewerPermission(
+        ShareFolderResponseDTO response = shareFolderService.updateViewerPermission(
                 userDetails.getUsers().getId(), folderId, userFolderId, request);
-        return ResponseEntity.ok(result);
+        return ApiResponse.of(SuccessStatus._FOLDER_PERMISSION_OK, response);
     }
 
     // 폴더 비공개 전환
     @PostMapping("/{folderId}/unshare")
     @Operation(summary = "폴더 비공개 전환")
-    public ResponseEntity<ShareFolderResponseDTO> unshareFolder(
+    public ApiResponse<ShareFolderResponseDTO> unshareFolder(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         // 모든 유저의 (폴더 주인 제외) 뷰어, writer 권한 false
-        ShareFolderResponseDTO result = shareFolderService.unshare(userDetails.getUsers().getId(), folderId);
-        return ResponseEntity.ok(result);
+        ShareFolderResponseDTO response = shareFolderService.unshare(userDetails.getUsers().getId(), folderId);
+        return ApiResponse.of(SuccessStatus._FOLDER_UNSHARE_OK, response);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
@@ -1,5 +1,8 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.shared.SharedFolderService;
 import com.umc.linkyou.web.dto.folder.FolderListResponseDTO;
@@ -21,12 +24,12 @@ public class SharedFolderController {
     // 공유 받은 폴더 목록 조회
     @GetMapping
     @Operation(summary = "공유 받은 폴더 목록 조회")
-    public ResponseEntity<List<FolderListResponseDTO>> getSharedFolders(
+    public ApiResponse<List<FolderListResponseDTO>> getSharedFolders(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         // 유저 폴더 테이블에서 isOwner가 false고 isViewer가 true인 폴더들 조회
         List<FolderListResponseDTO> folderList = sharedFolderService.getSharedFolders(userDetails.getUsers().getId());
-        return ResponseEntity.ok(folderList);
+        return ApiResponse.of(SuccessStatus._FOLDER_SHARED_OK, folderList);
     }
 
     // 공유 받은 폴더 삭제

--- a/src/main/java/com/umc/linkyou/web/dto/folder/BookmarkUpdateResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/folder/BookmarkUpdateResponseDTO.java
@@ -7,10 +7,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @Builder
-public class FolderListResponseDTO {
+public class BookmarkUpdateResponseDTO {
     private Long folderId;
-    private String folderName;
-    private Long parentFolderId;
     private Boolean isBookmarked;
 }
-

--- a/src/main/java/com/umc/linkyou/web/dto/folder/FolderTreeResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/folder/FolderTreeResponseDTO.java
@@ -15,6 +15,7 @@ public class FolderTreeResponseDTO {
     private Long folderId;
     private String folderName;
     private Long categoryId;
+    private Boolean isBookmarked;
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<FolderTreeResponseDTO> children = new ArrayList<>();
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #105

## 📝작업 내용

> 커스텀 예외 설정
폴더 응답에 북마크 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 폴더 및 북마크 관련 성공/오류 응답 코드가 세분화되어 다양한 상태를 명확히 안내합니다.
  * 폴더 트리, 폴더 목록, 북마크 관련 응답에 폴더 즐겨찾기 여부(isBookmarked) 정보가 추가되었습니다.
  * 폴더 북마크 상태 변경 시 별도의 응답 객체로 결과를 제공합니다.

* **버그 수정**
  * 폴더 및 북마크 작업 중 발생하는 오류 메시지가 더욱 구체적이고 일관되게 개선되었습니다.

* **리팩터링**
  * 모든 API 응답이 통일된 형식(ApiResponse)과 성공 코드로 반환되어 사용자 경험이 일관성 있게 개선되었습니다.
  * 폴더 및 공유 폴더 관련 컨트롤러의 응답 구조가 표준화되었습니다.

* **기타**
  * 즐겨찾기 기본값이 false로 명확하게 설정되어 예기치 않은 동작을 방지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->