### PR TITLE
Feat/#106 refresh token api

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: linkyou
 
 on:
   push:
-    branches: [ "develop", "feat/#83-email-sendgrid" ]
+    branches: [ "develop", "feat/#106-refresh-token" ]
   pull_request:
-    branches: [ "develop", "feat/#83-email-sendgrid" ]
+    branches: [ "develop", "feat/#106-refresh-token" ]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: linkyou
 
 on:
   push:
-    branches: [ "develop", "feat/#106-refresh-token" ]
+    branches: [ "develop", "feat/#106-refresh-token-api" ]
   pull_request:
-    branches: [ "develop", "feat/#106-refresh-token" ]
+    branches: [ "develop", "feat/#106-refresh-token-api" ]
   workflow_dispatch:
 
 permissions:

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
-	// runtimeOnly 'mysql:mysql-connector-java:8.0.33'
+	//runtimeOnly 'mysql:mysql-connector-java:8.0.33'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/umc/linkyou/config/properties/JwtProperties.java
+++ b/src/main/java/com/umc/linkyou/config/properties/JwtProperties.java
@@ -11,12 +11,13 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("jwt.token")
 public class JwtProperties {
     private String secretKey="";
+    private String issuer;
     private Expiration expiration;
 
     @Getter
     @Setter
     public static class Expiration{
         private Long access;
-        // TODO: refreshToken
+        private Long refresh;
     }
 }

--- a/src/main/java/com/umc/linkyou/config/properties/JwtProperties.java
+++ b/src/main/java/com/umc/linkyou/config/properties/JwtProperties.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Component;
 @Setter
 @ConfigurationProperties("jwt.token")
 public class JwtProperties {
-    private String secretKey="";
+    //private String secretKey="";
+    private Keys keys;
     private String issuer;
     private Expiration expiration;
 
@@ -19,5 +20,12 @@ public class JwtProperties {
     public static class Expiration{
         private Long access;
         private Long refresh;
+    }
+
+    @Getter
+    @Setter
+    public static class Keys {
+        private String access;
+        private String refresh;
     }
 }

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
         configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
         configuration.setAllowCredentials(true); // 쿠키 등 인증정보 허용
+        configuration.setExposedHeaders(List.of("New-Access-Token"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -57,7 +57,6 @@ public class SecurityConfig {
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP 메서드
         configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
         configuration.setAllowCredentials(true); // 쿠키 등 인증정보 허용
-        configuration.setExposedHeaders(List.of("New-Access-Token"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용

--- a/src/main/java/com/umc/linkyou/config/security/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SwaggerConfig.java
@@ -1,10 +1,14 @@
 package com.umc.linkyou.config.security;
 
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.StringSchema;
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import io.swagger.v3.oas.models.info.Info;
@@ -35,5 +39,17 @@ public class SwaggerConfig {
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    // 리프레시 토큰을 전역적으로 헤더에 추가
+    @Bean
+    public OperationCustomizer globalHeader() {
+        return (operation, handlerMethod) -> {
+            operation.addParametersItem(new Parameter()
+                    .in(ParameterIn.HEADER.toString())
+                    .schema(new StringSchema().name("Refresh-Token"))
+                    .name("Refresh-Token"));
+            return operation;
+        };
     }
 }

--- a/src/main/java/com/umc/linkyou/config/security/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SwaggerConfig.java
@@ -40,16 +40,4 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .components(components);
     }
-
-    // 리프레시 토큰을 전역적으로 헤더에 추가
-    @Bean
-    public OperationCustomizer globalHeader() {
-        return (operation, handlerMethod) -> {
-            operation.addParametersItem(new Parameter()
-                    .in(ParameterIn.HEADER.toString())
-                    .schema(new StringSchema().name("Refresh-Token"))
-                    .name("Refresh-Token"));
-            return operation;
-        };
-    }
 }

--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.umc.linkyou.config.security.jwt;
 
-import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,45 +36,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        } catch (ExpiredJwtException e) {
-            log.info("AccessToken 만료됨, RefreshToken으로 재발급 시도");
-            reissueAccessToken(request, response, e);
         } catch (Exception e) {
             request.setAttribute("exception", e);
         }
             filterChain.doFilter(request, response);
-    }
-
-
-    private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response, Exception originalException) {
-        try {
-            String oldAccessToken = resolveToken(request);
-            if (oldAccessToken != null && oldAccessToken.startsWith(Constants.TOKEN_PREFIX)) {
-                oldAccessToken = oldAccessToken.substring(Constants.TOKEN_PREFIX.length());
-            }
-
-            // Refresh Token은 Refresh-Token 헤더에서 직접 꺼냄
-            String refreshToken = request.getHeader("Refresh-Token");
-            if (refreshToken == null || oldAccessToken == null) {
-                throw originalException;
-            }
-            // Bearer 접두사 제거
-            if (refreshToken.startsWith(Constants.TOKEN_PREFIX)) {
-                refreshToken = refreshToken.substring(Constants.TOKEN_PREFIX.length());
-            }
-            jwtTokenProvider.validateRefreshToken(refreshToken, oldAccessToken);
-            String newAccessToken = jwtTokenProvider.recreateAccessToken(oldAccessToken);
-            Authentication authentication = jwtTokenProvider.getAuthentication(newAccessToken);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
-            // 새 AccessToken을 헤더로 응답에 추가
-            log.info("새로운 accesstoken 발급, 헤더에 추가");
-            response.setHeader("New-Access-Token", newAccessToken);
-
-        } catch (Exception e) {
-            request.setAttribute("exception", e);
-        }
-
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,16 @@
 package com.umc.linkyou.config.security.jwt;
 
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import com.umc.linkyou.config.properties.Constants;
@@ -14,6 +18,9 @@ import com.umc.linkyou.config.properties.Constants;
 import java.io.IOException;
 
 @RequiredArgsConstructor
+@Component
+@Order(0)
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -23,14 +30,52 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain)
             throws ServletException, IOException {
+        try {
+            String token = resolveToken(request);
 
-        String token = resolveToken(request);
-
-        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(token);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (ExpiredJwtException e) {
+            log.info("AccessToken 만료됨, RefreshToken으로 재발급 시도");
+            reissueAccessToken(request, response, e);
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
         }
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+    }
+
+
+    private void reissueAccessToken(HttpServletRequest request, HttpServletResponse response, Exception originalException) {
+        try {
+            String oldAccessToken = resolveToken(request);
+            if (oldAccessToken != null && oldAccessToken.startsWith(Constants.TOKEN_PREFIX)) {
+                oldAccessToken = oldAccessToken.substring(Constants.TOKEN_PREFIX.length());
+            }
+
+            // Refresh Token은 Refresh-Token 헤더에서 직접 꺼냄
+            String refreshToken = request.getHeader("Refresh-Token");
+            if (refreshToken == null || oldAccessToken == null) {
+                throw originalException;
+            }
+            // Bearer 접두사 제거
+            if (refreshToken.startsWith(Constants.TOKEN_PREFIX)) {
+                refreshToken = refreshToken.substring(Constants.TOKEN_PREFIX.length());
+            }
+            jwtTokenProvider.validateRefreshToken(refreshToken, oldAccessToken);
+            String newAccessToken = jwtTokenProvider.recreateAccessToken(oldAccessToken);
+            Authentication authentication = jwtTokenProvider.getAuthentication(newAccessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // 새 AccessToken을 헤더로 응답에 추가
+            log.info("새로운 accesstoken 발급, 헤더에 추가");
+            response.setHeader("New-Access-Token", newAccessToken);
+
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
+        }
+
     }
 
     private String resolveToken(HttpServletRequest request) {

--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
@@ -1,26 +1,37 @@
 package com.umc.linkyou.config.security.jwt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.domain.UserRefreshToken;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.repository.UserRefreshTokenRepository;
 import com.umc.linkyou.repository.UserRepository;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.config.properties.Constants;
 import com.umc.linkyou.config.properties.JwtProperties;
 
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Base64;
 import java.util.Date;
 import java.util.Collections;
+import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -28,6 +39,10 @@ public class JwtTokenProvider {
     private final JwtProperties jwtProperties;
 
     private final UserRepository userRepository;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
 
     private Key getSigningKey() {
         return Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes());
@@ -52,6 +67,9 @@ public class JwtTokenProvider {
                     .build()
                     .parseClaimsJws(token);
             return true;
+        } catch (ExpiredJwtException e) {
+            // AccessToken이 만료된 경우 예외를 던져서 필터에서 처리하게 함
+            throw e;
         } catch (JwtException | IllegalArgumentException e) {
             return false;
         }
@@ -90,4 +108,64 @@ public class JwtTokenProvider {
         }
         return getAuthentication(accessToken);
     }
+
+    // 리프레시 토큰 발급
+    public String createRefreshToken() {
+        return Jwts.builder()
+                .signWith(Keys.hmacShaKeyFor(jwtProperties.getSecretKey().getBytes()), SignatureAlgorithm.HS256)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getRefresh()))
+                .compact();
+    }
+
+    // 액세스 토큰 재발급
+    @Transactional
+    public String recreateAccessToken(String oldAccessToken) throws JsonProcessingException {
+        String subject = decodeJwtPayloadSubject(oldAccessToken);
+
+        return createAccessToken(subject);
+    }
+
+    // 리프레시 토큰 유효성 검증
+    @Transactional(readOnly = true)
+    public void validateRefreshToken(String refreshToken, String oldAccessToken) throws JsonProcessingException {
+        log.info("10");
+        validateAndParseToken(refreshToken);
+
+        String email = decodeJwtPayloadSubject(oldAccessToken); // subject = email
+        Long userId = userRepository.findByEmail(email)
+                .map(Users::getId)
+                .orElseThrow(() -> new IllegalStateException("User not found for email: " + email));
+        userRefreshTokenRepository.findByUserId(userId)
+                .filter(refresh -> refresh.validateRefreshToken(refreshToken))
+                .orElseThrow(() -> new ExpiredJwtException(null, null, "Refresh token expired."));
+    }
+
+    // 액세스 토큰 생성 (subject 기반)
+    public String createAccessToken(String subject) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 토큰 파싱 및 검증
+    private Jws<Claims> validateAndParseToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token);
+    }
+
+    // 액세스 토큰에서 subject 추출
+    private String decodeJwtPayloadSubject(String token) throws JsonProcessingException {
+        return objectMapper.readValue(
+                new String(Base64.getDecoder().decode(token.split("\\.")[1]), StandardCharsets.UTF_8),
+                Map.class
+        ).get("sub").toString();
+    }
+
 }

--- a/src/main/java/com/umc/linkyou/converter/UserConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/UserConverter.java
@@ -34,11 +34,12 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.LoginResultDTO toLoginResultDTO(Users user, String accessToken) {
+    public static UserResponseDTO.LoginResultDTO toLoginResultDTO(Users user, String accessToken, String refreshToken) {
 
         return new UserResponseDTO.LoginResultDTO().builder()
                 .userId(user.getId())
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .status(user.getStatus())
                 .inactiveDate(user.getInactiveDate())
                 .build();

--- a/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
+++ b/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
@@ -1,0 +1,35 @@
+package com.umc.linkyou.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class UserRefreshToken {
+    @Id
+    private Long memberId;
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private Users user;
+    private String refreshToken;
+
+    public UserRefreshToken(Users user, String refreshToken) {
+        this.user = user;
+        this.refreshToken = refreshToken;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public boolean validateRefreshToken(String refreshToken) {
+        return this.refreshToken.equals(refreshToken);
+    }
+
+}

--- a/src/main/java/com/umc/linkyou/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserRefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.umc.linkyou.repository;
+
+import com.umc.linkyou.domain.UserRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+    Optional<UserRefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -35,4 +35,6 @@ public interface UserService {
     void sendTempPassword(String email);
 
     Users withdrawUser(Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO);
+
+    String reissueRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -39,6 +39,12 @@ public class UserController {
         return ApiResponse.onSuccess(userService.loginUser(request));
     }
 
+    @Operation(summary = "토큰 재발급")
+    @PostMapping("/reissue")
+    public ApiResponse<String> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        return ApiResponse.onSuccess(userService.reissueRefreshToken(refreshToken));
+    }
+
     // 닉네임 중복확인
     @GetMapping("/check-nickname")
     public ApiResponse<String> checkNickname(@RequestParam String nickname) {

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -27,6 +27,7 @@ public class UserResponseDTO {
     public static class LoginResultDTO{
         Long userId;
         String accessToken;
+        String refreshToken; // 리프레시 토큰
         String status;
         LocalDateTime inactiveDate;
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #106

## 📝작업 내용

> 사용자의 인증 정보를 바탕으로 리프레시 토큰을 발급해, 액세스 토큰이 만료되었을 때 새로운 액세스 토큰을 재발급 받을 수 있게 한다.

- 로그인 시 리프레시 토큰 발급
- 리프레시 토큰 유효성 검증 로직 구현
- 리프레시 토큰을 통해 새로운 액세스 토큰을 발급하는 api 구현

## 💬리뷰 요구사항(선택)

jwt.token.secretKey 하나의 키만 사용할까 했는데,
보안상 동일한 키를 두 용도로 쓰면, 한쪽이 노출될 경우 다른 토큰까지 위조 가능성이 있어
Access Token용 키와 Refresh Token용 키를 분리하였습니다.

Access Token과 Refresh Token의 키를 별도로 관리 가능.
Refresh Token이 서버에 저장되더라도, Access Token 생성 키와는 독립적이므로 피해 범위 축소.
추후 필요 시 키를 각각 교체/회전(Key Rotation) 가능.
-> 이러한 효과가 있다고 합니다 !

## 참고할만한 자료(선택)
x