### PR TITLE
#117 feat: redis 설정, refresh token 저장/검증

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,9 @@ name: linkyou
 
 on:
   push:
-    branches: [ "develop", "feat/#106-refresh-token-api" ]
+    branches: [ "develop", "feat/#117-redis-refresh" ]
   pull_request:
-    branches: [ "develop", "feat/#106-refresh-token-api" ]
+    branches: [ "develop", "feat/#117-redis-refresh" ]
   workflow_dispatch:
 
 permissions:

--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 // thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
+// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 // JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
+++ b/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
@@ -1,35 +1,30 @@
 package com.umc.linkyou.domain;
 
-import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
-import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Entity
+@RedisHash(value = "refreshToken")
 public class UserRefreshToken {
     @Id
-    private Long memberId;
-    @OneToOne(fetch = FetchType.LAZY)
-    @MapsId
-    @JoinColumn(name = "user_id")
-    private Users user;
     private String refreshToken;
+    @Indexed
+    private Long userId;
 
-    public UserRefreshToken(Users user, String refreshToken) {
-        this.user = user;
+    @TimeToLive(unit = TimeUnit.MILLISECONDS)
+    private Long ttl;
+
+    public UserRefreshToken(String refreshToken, Long userId, Long ttl) {
         this.refreshToken = refreshToken;
+        this.userId = userId;
+        this.ttl = ttl;
     }
-
-    public void updateRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
-
-    public boolean validateRefreshToken(String refreshToken) {
-        return this.refreshToken.equals(refreshToken);
-    }
-
 }

--- a/src/main/java/com/umc/linkyou/repository/UserRefreshTokenRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserRefreshTokenRepository.java
@@ -1,11 +1,14 @@
 package com.umc.linkyou.repository;
 
 import com.umc.linkyou.domain.UserRefreshToken;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
-import java.util.UUID;
 
-public interface UserRefreshTokenRepository extends JpaRepository<UserRefreshToken, Long> {
+public interface UserRefreshTokenRepository extends CrudRepository<UserRefreshToken, String> {
+    // 단일 세션 모델
     Optional<UserRefreshToken> findByUserId(Long userId);
+
+    // 여러 기기/세션 허용이면 아래처럼 쓰는 편이 안전
+    //Iterable<UserRefreshToken> findAllByUserId(Long userId);
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -36,5 +36,5 @@ public interface UserService {
 
     Users withdrawUser(Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO);
 
-    String reissueRefreshToken(String refreshToken);
+    UserResponseDTO.TokenPair reissueRefreshToken(String refreshToken);
 }

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
 
     @Operation(summary = "토큰 재발급")
     @PostMapping("/reissue")
-    public ApiResponse<String> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
+    public ApiResponse<UserResponseDTO.TokenPair> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
         return ApiResponse.onSuccess(userService.reissueRefreshToken(refreshToken));
     }
 

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -32,6 +32,13 @@ public class UserResponseDTO {
         LocalDateTime inactiveDate;
     }
 
+    // 리프레시 토큰 로테이션
+    @Getter @AllArgsConstructor
+    public static class TokenPair {
+        private final String accessToken;
+        private final String refreshToken;
+    }
+
     @Builder
     @Getter
     @NoArgsConstructor


### PR DESCRIPTION
## #️⃣연관된 이슈

> #117

## 작업 상세 내용

> rdis 설정하기
> 리프레시 토큰을 Redis에 저장, 검증
> 로컬에서 재현 가능하고, 운영 전환 시 설정만 바꾸면 되도록 구성할 예정

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

범위(스코프)
로컬: Docker로 Redis 실행, 앱 연동
-> 이렇게 했는데

운영(둘 중 선택):
EC2에 Docker로 Redis 배포(보안그룹 제한, 영속화)
ElastiCache for Redis 생성
방법이 더 있을까요..?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 리프레시 토큰 관리를 위해 Redis 연동 및 HMAC 기반 토큰 화이트리스트 방식 도입
  * 액세스 토큰과 리프레시 토큰을 함께 반환하는 TokenPair 응답 구조 추가

* **기능 개선**
  * 리프레시 토큰 재발급 시 토큰 회전 및 화이트리스트 검증 적용
  * 리프레시 토큰 저장소를 JPA에서 Redis로 변경하여 성능 및 보안 향상

* **API 변경**
  * 리프레시 토큰 재발급 API 응답이 단일 문자열에서 TokenPair 객체로 변경

* **버그 수정**
  * 사용자와 토큰 일치 여부를 명확히 검증하여 보안 강화

* **환경 구성**
  * Spring Boot Redis Starter 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->