### PR TITLE
Feat/#184 ai article exist

### DIFF
--- a/src/main/java/com/umc/linkyou/domain/mapping/UsersLinku.java
+++ b/src/main/java/com/umc/linkyou/domain/mapping/UsersLinku.java
@@ -38,6 +38,7 @@ public class UsersLinku extends BaseEntity {
     @JoinColumn(name = "linku_id", nullable = false)
     private Linku linku;
 
+    @Builder.Default
     @Column(name = "is_ai_exist", nullable = false)
     private Boolean isAiExist = false;
 }

--- a/src/main/java/com/umc/linkyou/domain/mapping/UsersLinku.java
+++ b/src/main/java/com/umc/linkyou/domain/mapping/UsersLinku.java
@@ -37,4 +37,7 @@ public class UsersLinku extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "linku_id", nullable = false)
     private Linku linku;
+
+    @Column(name = "is_ai_exist", nullable = false)
+    private Boolean isAiExist = false;
 }

--- a/src/main/java/com/umc/linkyou/service/AiArticleServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleServiceImpl.java
@@ -128,6 +128,12 @@ public class AiArticleServiceImpl implements AiArticleService {
         UsersLinku usersLinku = usersLinkuRepository.findByUserAndLinku(user, linku)
                 .orElse(null);
 
+        //ai 생성여부
+        if (usersLinku != null) {
+            usersLinku.setIsAiExist(true);
+            usersLinkuRepository.save(usersLinku);
+        }
+
         // 10. DTO 반환
         return AiArticleConverter.toDto(
                 saved,
@@ -171,7 +177,9 @@ public class AiArticleServiceImpl implements AiArticleService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus._USER_NOT_FOUND));
         UsersLinku usersLinku = usersLinkuRepository.findByUserAndLinku(user, linku)
                 .orElse(null);
-
+        if (usersLinku.getIsAiExist() == null || !usersLinku.getIsAiExist()) {
+            throw new GeneralException(ErrorStatus._AI_ARTICLE_NOT_FOUND);
+        }
         Situation situation = article.getSituation();
         Emotion emotion = null;
         if (article.getAiFeelingId() != null)

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuServiceImpl.java
@@ -119,6 +119,9 @@ public class LinkuServiceImpl implements LinkuService {
         // 9) UsersLinku 생성 & 저장
         UsersLinku usersLinku = createUsersLinku(user, linku, emotion, dto.getMemo(), imageUrl);
 
+        // 9-1) 링크 생성 후 "최근 열람 링크"에도 기록 추가
+        updateRecentViewedLinku(userId, linku.getLinkuId());
+
         // 10) 폴더 조회 또는 신규 생성
         Folder folder = findOrCreateFolder(userId, category);
 
@@ -454,7 +457,7 @@ public class LinkuServiceImpl implements LinkuService {
     } //링크 수정
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> recommendLinku(
             Long userId, Long situationId, Long emotionId, int page, int size) {
 

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuServiceImpl.java
@@ -284,7 +284,7 @@ public class LinkuServiceImpl implements LinkuService {
         LinkuFolder linkuFolder =
                 linkuFolderRepository.findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()).orElse(null);
         AiArticle aiArticle = aiArticleRepository.findByLinku(linku).orElse(null);
-        boolean aiArticleExists = aiArticle != null && aiArticle.getTitle() != null && !aiArticle.getTitle().isBlank();
+        boolean aiArticleExists = Boolean.TRUE.equals(usersLinku.getIsAiExist());
 
         String keyword = null;
         String summary = null;
@@ -356,7 +356,7 @@ public class LinkuServiceImpl implements LinkuService {
                     .orElseThrow(() -> new GeneralException(ErrorStatus._USER_LINKU_NOT_FOUND));
 
 
-            boolean aiArticleExists = aiArticleExistsMap.getOrDefault(linku.getLinkuId(), false);
+            boolean aiArticleExists = Boolean.TRUE.equals(usersLinku.getIsAiExist());
             Domain domain = linku.getDomain();
 
             LinkuResponseDTO.LinkuSimpleDTO dto = toLinkuSimpleDTO(linku, usersLinku, domain, aiArticleExists);
@@ -569,7 +569,7 @@ public class LinkuServiceImpl implements LinkuService {
                     Linku linku = userLinku.getLinku();
                     Domain domain = linku.getDomain();
 
-                    boolean aiArticleExists = aiArticleExistsMap.getOrDefault(linku.getLinkuId(), false);
+                    boolean aiArticleExists = Boolean.TRUE.equals(userLinku.getIsAiExist());
 
                     return LinkuConverter.toLinkuSimpleDTO(
                             linku,


### PR DESCRIPTION
## #️⃣연관된 이슈

#184

## 📝작업 내용

## 어떤 기능인가요?

AIARTICLE 존재여부를 userLinku 테이블에 isAiExist를 추가하는 것으로 변경하였습니다. 
<img width="5340" height="2092" alt="Image" src="https://github.com/user-attachments/assets/960867b3-da46-4b75-b223-7a9e43daa1d4" />

## 작업 상세 내용

- [x] aiArticle 생성시 userLinku에 aiArticle존재여부 기록
- [x] aiArticle 존재여부 가져오는 get 요청들 in linkuService 처리
/api/linku/{userId}/{linkuid}
/api/linku//{linkuid}
/api/linku/recommend
/api/linku/recent

- [ ] 내가 생성한 ai 요약 개수 가져오는 거 query 수정
- [x] localhost 테스트

## 💬이어서 할사람
Feat/#184 ai article exist 브랜치에서 
내가 생성한 ai 요약 개수 가져오는 api에서  userLinku 테이블의 isAiExist를 가져오도록 query 수정을 해주세요! @Hajin99 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - AI 콘텐츠 존재 여부를 단일 플래그로 관리하여 상세, 목록, 최근 보기에서 일관된 표시 제공
  - 새 링크 생성 시 해당 항목이 자동으로 ‘최근 본’ 목록에 반영
- 버그 수정
  - AI 글이 없는 경우 조회 시 명확한 오류 처리로 잘못된 노출 방지
- 리팩터링
  - AI 콘텐츠 존재 여부 판단 로직을 통합해 화면 표시 기준을 일원화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->