### PR TITLE
Feat/#209 curation api refactor v2

### DIFF
--- a/src/main/java/com/umc/linkyou/repository/CurationRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/CurationRepository.java
@@ -4,6 +4,8 @@ import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -11,4 +13,7 @@ import java.util.Optional;
 public interface CurationRepository extends JpaRepository<Curation, Long> {
     boolean existsByUserAndMonth(Users user, String month);
     Optional<Curation> findTopByUser_IdOrderByCreatedAtDesc(Long userId);
+
+    // 내 큐레이션 히스토리 조회 (최신 월 순서)
+    Page<Curation> findAllByUserOrderByMonthDesc(Users user, Pageable pageable);
 }

--- a/src/main/java/com/umc/linkyou/repository/mapping/CurationLikeRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/mapping/CurationLikeRepository.java
@@ -5,6 +5,9 @@ import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.mapping.CurationLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,7 +19,12 @@ public interface CurationLikeRepository extends JpaRepository<CurationLike, Long
 
     Optional<CurationLike> findByUserAndCuration(Users user, Curation curation);
 
+    // 좋아요한 큐레이션 top6개
     List<CurationLike> findTop6ByUserOrderByCreatedAtDesc(Users user);
 
+    // 좋아요한 큐레이션 전체 조회 (좋아요 누른 최신순)
+    // - N+1 문제 방지를 위해 curation 정보를 같이 가져옴
+    @EntityGraph(attributePaths = {"curation"})
+    Page<CurationLike> findAllByUserOrderByCreatedAtDesc(Users user, Pageable pageable);
 }
 

--- a/src/main/java/com/umc/linkyou/service/curation/CurationLikeService.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationLikeService.java
@@ -1,6 +1,10 @@
 package com.umc.linkyou.service.curation;
 
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
 import com.umc.linkyou.web.dto.curation.LikedCurationResponse;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -8,5 +12,10 @@ public interface CurationLikeService {
     void likeCuration(Long userId, Long curationId);
     void unlikeCuration(Long userId, Long curationId);
     boolean isLiked(Long userId, Long curationId);
+
+    // [기존] 기본 화면용 (최근 6개)
     List<LikedCurationResponse> getRecentLikedCurations(Long userId);
+
+    // 좋아요한 큐레이션 전체 리스트 (페이징 포함)
+    Page<CurationListResponse> getLikedCurationList(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/umc/linkyou/service/curation/CurationLikeService.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationLikeService.java
@@ -2,7 +2,6 @@ package com.umc.linkyou.service.curation;
 
 import com.umc.linkyou.web.dto.curation.CurationListResponse;
 import com.umc.linkyou.web.dto.curation.LikedCurationResponse;
-import com.umc.linkyou.web.dto.curation.CurationListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 

--- a/src/main/java/com/umc/linkyou/service/curation/CurationLikeServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationLikeServiceImpl.java
@@ -6,10 +6,16 @@ import com.umc.linkyou.domain.mapping.CurationLike;
 import com.umc.linkyou.repository.CurationRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.repository.mapping.CurationLikeRepository;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
 import com.umc.linkyou.web.dto.curation.LikedCurationResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -79,6 +85,27 @@ public class CurationLikeServiceImpl implements CurationLikeService {
                     );
                 })
                 .toList();
+    }
+
+    // [▼▼▼ 메서드 추가: 좋아요한 큐레이션 전체 보기]
+    @Override
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
+    public Page<CurationListResponse> getLikedCurationList(Long userId, Pageable pageable) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // Repository에서 데이터 가져오기 (Curation 정보 포함)
+        Page<CurationLike> likePage = curationLikeRepository.findAllByUserOrderByCreatedAtDesc(user, pageable);
+
+        // CurationLike -> Curation -> DTO 변환
+        return likePage.map(like -> {
+            Curation c = like.getCuration();
+            return CurationListResponse.builder()
+                    .curationId(c.getCurationId())
+                    .month(c.getMonth())
+                    .thumbnailUrl(c.getThumbnailUrl())
+                    .build();
+        });
     }
 
 }

--- a/src/main/java/com/umc/linkyou/service/curation/CurationLikeServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationLikeServiceImpl.java
@@ -13,9 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import com.umc.linkyou.web.dto.curation.CurationListResponse;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 

--- a/src/main/java/com/umc/linkyou/service/curation/CurationService.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationService.java
@@ -4,6 +4,9 @@ import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.web.dto.curation.CreateCurationRequest;
 import com.umc.linkyou.web.dto.curation.CurationDetailResponse;
 import com.umc.linkyou.web.dto.curation.CurationLatestResponse;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -16,4 +19,6 @@ public interface CurationService {
     void seedFebToJul2025(boolean materializeExternal);
 
     Optional<CurationLatestResponse> getLatestCuration(Long userId);
+
+    Page<CurationListResponse> getMyCurationList(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
@@ -4,7 +4,6 @@ import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.CurationMent;
 import com.umc.linkyou.domain.log.CurationTopLog;
-import com.umc.linkyou.domain.mapping.CurationLike;
 import com.umc.linkyou.repository.CurationMentRepository;
 import com.umc.linkyou.repository.mapping.CurationLikeRepository;
 import com.umc.linkyou.service.curation.gpt.GptService;

--- a/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
@@ -4,7 +4,9 @@ import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.CurationMent;
 import com.umc.linkyou.domain.log.CurationTopLog;
+import com.umc.linkyou.domain.mapping.CurationLike;
 import com.umc.linkyou.repository.CurationMentRepository;
+import com.umc.linkyou.repository.mapping.CurationLikeRepository;
 import com.umc.linkyou.service.curation.gpt.GptService;
 import com.umc.linkyou.service.curation.utils.ThumbnailUrlProvider;
 import com.umc.linkyou.service.curation.linku.ExternalRecommendMaterializer;
@@ -20,6 +22,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.time.YearMonth;
 import java.util.List;
@@ -35,6 +40,7 @@ public class CurationServiceImpl implements CurationService {
     private final CurationTopLogService curationTopLogService;
     private final ThumbnailUrlProvider thumbnailUrlProvider;
     private final ExternalRecommendMaterializer externalRecommendMaterializer;
+    private final CurationLikeRepository curationLikeRepository;
 
     /**
      * 유저의 큐레이션을 생성하고, 감정/상황 로그 기반 top3 태그를 계산해 저장한다.
@@ -229,4 +235,22 @@ public class CurationServiceImpl implements CurationService {
                 ));
     }
 
+
+    // [▼▼▼ 메서드 추가: 내 큐레이션 전체 보기]
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CurationListResponse> getMyCurationList(Long userId, Pageable pageable) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // Repository에서 페이징된 데이터 가져오기
+        Page<Curation> curationPage = curationRepository.findAllByUserOrderByMonthDesc(user, pageable);
+
+        // Entity -> DTO 변환
+        return curationPage.map(c -> CurationListResponse.builder()
+                .curationId(c.getCurationId())
+                .month(c.getMonth())
+                .thumbnailUrl(c.getThumbnailUrl())
+                .build());
+    }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/CurationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CurationController.java
@@ -16,6 +16,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import com.umc.linkyou.web.dto.curation.CurationListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -69,7 +72,7 @@ public class CurationController {
     }
 
     /**
-     * 가장 최근 큐레이션 조회
+     * [기존] 가장 최근 큐레이션 조회
      */
     @Operation(
             summary = "가장 최근 큐레이션 조회",
@@ -79,6 +82,25 @@ public class CurationController {
     public ResponseEntity<ApiResponse<CurationLatestResponse>> getLatestCuration(@PathVariable Long userId) {
         var body = curationService.getLatestCuration(userId).orElse(null);
         return ResponseEntity.ok(ApiResponse.onSuccess(body));
+    }
+
+    /**
+     * [수정] 내 큐레이션 히스토리 (전체보기 + 페이징)
+     */
+    @Operation(
+            summary = "내 큐레이션 전체 히스토리 조회",
+            description = "나의 월별 큐레이션 전체 목록을 최신순으로 페이징하여 조회합니다. (size 기본값: 10)"
+    )
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<Page<CurationListResponse>>> getMyCurationList(
+            @RequestParam Long userId,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        // 0페이지부터 시작, size 개수만큼 가져오기
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<CurationListResponse> result = curationService.getMyCurationList(userId, pageRequest);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
     /**
@@ -123,7 +145,7 @@ public class CurationController {
     }
 
     /**
-     * 큐레이션 좋아요 리스트 가져오기
+     * [기존] 큐레이션 좋아요 리스트 가져오기
      */
     @Operation(
             summary = "최근 좋아요한 큐레이션 목록",
@@ -133,6 +155,24 @@ public class CurationController {
     public ResponseEntity<ApiResponse<List<LikedCurationResponse>>> getRecentLikedCurations(@RequestParam Long userId) {
         var list = curationLikeService.getRecentLikedCurations(userId);
         return ResponseEntity.ok(ApiResponse.onSuccess(list));
+    }
+
+    /**
+     * [수정] 좋아요한 큐레이션 전체 리스트 (전체보기 + 페이징)
+     */
+    @Operation(
+            summary = "좋아요한 큐레이션 전체 조회",
+            description = "내가 좋아요를 누른 큐레이션 전체 목록을 좋아요 누른 최신순으로 페이징하여 조회합니다."
+    )
+    @GetMapping("/likes")
+    public ResponseEntity<ApiResponse<Page<CurationListResponse>>> getLikedCurationList(
+            @RequestParam Long userId,
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<CurationListResponse> result = curationLikeService.getLikedCurationList(userId, pageRequest);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
     /**

--- a/src/main/java/com/umc/linkyou/web/controller/CurationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CurationController.java
@@ -1,8 +1,7 @@
 package com.umc.linkyou.web.controller;
 
-import com.umc.linkyou.converter.LinkuConverter;
-import com.umc.linkyou.domain.Curation;
-import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.config.security.jwt.CustomUserDetails;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.service.curation.CurationLikeService;
 import com.umc.linkyou.service.curation.CurationService;
@@ -93,10 +92,12 @@ public class CurationController {
     )
     @GetMapping("/history")
     public ResponseEntity<ApiResponse<Page<CurationListResponse>>> getMyCurationList(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
+        Long userId = userDetails.getUsers().getId();
+
         // 0페이지부터 시작, size 개수만큼 가져오기
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<CurationListResponse> result = curationService.getMyCurationList(userId, pageRequest);
@@ -166,10 +167,12 @@ public class CurationController {
     )
     @GetMapping("/likes")
     public ResponseEntity<ApiResponse<Page<CurationListResponse>>> getLikedCurationList(
-            @RequestParam Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(name = "page", defaultValue = "0") int page,
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
+        Long userId = userDetails.getUsers().getId();
+
         PageRequest pageRequest = PageRequest.of(page, size);
         Page<CurationListResponse> result = curationLikeService.getLikedCurationList(userId, pageRequest);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));

--- a/src/main/java/com/umc/linkyou/web/dto/curation/CurationListResponse.java
+++ b/src/main/java/com/umc/linkyou/web/dto/curation/CurationListResponse.java
@@ -1,0 +1,16 @@
+package com.umc.linkyou.web.dto.curation;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CurationListResponse {
+    private Long curationId;
+    private String month;       // e.g., "2025-07"
+    private String thumbnailUrl;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> closes [#209]

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
- 보안 강화 (Security): 기존에 RequestParam으로 userId를 받던 방식에서, @AuthenticationPrincipal을 사용하여 JWT Token에서 사용자 정보를 직접 추출하는 방식으로 변경했습니다. 이를 통해 타인의 userId를 입력하여 데이터를 조회할 수 있는 보안 취약점(IDOR)을 해결했습니다.
- DTO 공통화: 큐레이션 리스트 조회 시 중복되는 응답 구조를 처리하기 위해 CurationListResponse DTO를 생성 및 적용했습니다.

- 성능 최적화 (@EntityGraph): 좋아요 목록 조회 시 Curation 정보를 함께 가져오도록 @EntityGraph를 적용하여 N+1 문제를 방지했습니다.

- Pagination 적용: 데이터 양이 늘어날 것에 대비하여, 단순 리스트 반환이 아닌 Spring Data JPA의 Pageable을 적용해 페이징(무한 스크롤) 처리가 가능하도록 구조를 개선했습니다.

### 2️⃣ Functional Requirement
- 내 큐레이션 히스토리 조회 API 구현 (GET /api/curations/history)
-- 사용자가 과거부터 현재까지 발급받은 월별 큐레이션 전체 목록을 최신순으로 조회합니다.

- 좋아요한 큐레이션 전체 조회 API 구현 (GET /api/curations/likes)
-- 사용자가 좋아요(스크랩)한 큐레이션 전체 목록을 좋아요 누른 최신순으로 조회합니다.
-- 기존 홈 화면용(Top 6) API와 별개로, 전체 목록을 볼 수 있는 전용 API입니다.


---

## 🧪 테스트 결과
1. 내 큐레이션 히스토리 조회 (/api/curations/history)
2. 좋아요한 큐레이션 조회 (/api/curations/likes)
---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
- API 사용 변경점: 보안 패치로 인해 API 호출 시 Query Parameter로 userId를 보낼 필요가 없어졌습니다. (헤더의 토큰으로 대체)
- Response 포맷: 프론트엔드에서의 무한 스크롤 및 페이지네이션 구현을 돕기 위해 List가 아닌 Page 객체 구조 그대로 반환하도록 설정했습니다. (content, last, totalPages 등 포함)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 개인 큐레이션 이력을 페이지 단위로 조회 가능 - 최신 월별로 정렬됨
* 좋아요 한 큐레이션 목록을 페이지 단위로 조회 가능 - 최신순으로 정렬됨
* 대량의 콘텐츠를 효율적으로 탐색할 수 있는 개선된 성능

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->