### PR TITLE
Feat/#208 social login

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 // swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
-	//querydsl dependencies 추가(스프링부트 3.0 이상)
+//querydsl dependencies 추가(스프링부트 3.0 이상)
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
@@ -50,6 +50,10 @@ dependencies {
 // spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
+// OAuth2 클라이언트 + 리소스 서버 (소셜 로그인용)
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
 
 // thymeleaf + security
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.2.RELEASE'

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,6 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 // OAuth2 클라이언트 + 리소스 서버 (소셜 로그인용)
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 
 
 // thymeleaf + security

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ dependencies {
 
 	// Google Cloud Vertex AI (Gemini)
 	implementation 'com.google.cloud:google-cloud-vertexai:1.14.0'
+	implementation 'com.google.protobuf:protobuf-java:3.25.3'
 
 }
 

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -29,6 +29,14 @@ public enum ErrorStatus implements BaseErrorCode {
     _INTEREST_NOT_PROVIDED(HttpStatus.NOT_FOUND, "USERS404", "관심 분야를 선택해야합니다."),
     _NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "USERS500", "인증 코드 생성 실패"),
     _SEND_MAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS500", "인증 코드 전송 실패"),
+    //소셜로그인 관련
+    // 소셜로그인 관련 추가/수정
+    _AUTH_ACCOUNT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5001", "소셜 계정 연결에 실패했습니다."),
+    _USER_SOCIAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5002", "소셜 사용자 생성에 실패했습니다."),
+    // 소셜 로그인 섹션에 추가
+    _SOCIAL_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "USERS4003", "소셜 로그인에 이메일이 필요합니다."),
+    _SOCIAL_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "USERS4004", "지원하지 않는 소셜 제공자입니다."),
+
 
     //링큐 관련 코드
     _LINKU_VIDEO_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "LINKU4001", "영상 링크는 저장할 수 없습니다."),

--- a/src/main/java/com/umc/linkyou/config/security/AppConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/AppConfig.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.config.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,9 @@ public class AppConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);  // 3초 연결 타임아웃
+        factory.setReadTimeout(5000);     // 5초 응답 타임아웃
+        return new RestTemplate(factory);
     }
 }

--- a/src/main/java/com/umc/linkyou/config/security/AppConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/AppConfig.java
@@ -1,0 +1,14 @@
+package com.umc.linkyou.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.umc.linkyou.config.security;
 
 import com.umc.linkyou.config.security.jwt.JwtAuthenticationFilter;
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
+import com.umc.linkyou.config.security.oauth.OAuth2TokenClient;
+import com.umc.linkyou.config.security.oauth.OAuth2UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,6 +26,8 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final OAuth2UserServiceImpl oAuth2UserService;
+    private final OAuth2TokenClient oAuth2TokenClient;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -48,7 +52,28 @@ public class SecurityConfig {
                 )
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                )
+                .oauth2Login(oauth2 -> oauth2
+                                // /oauth2/authorization/{registrationId} 진입 URI
+                                .authorizationEndpoint(authorization -> authorization
+                                        .baseUri("/oauth2/authorization")
+                                )
+                                // /login/oauth2/code/{registrationId} 콜백 URI 패턴
+                                .redirectionEndpoint(redirection -> redirection
+                                        .baseUri("/login/oauth2/code/*")
+                                )
+                                // Authorization Code → Access Token 교환 시 사용할 클라이언트
+                                .tokenEndpoint(token -> token
+                                        .accessTokenResponseClient(oAuth2TokenClient)
+                                )
+                                // Access Token → userInfo 조회 후 Users/AuthAccount 매핑
+                                .userInfoEndpoint(userInfo -> userInfo
+                                        .userService(oAuth2UserService)
+                                )
+                        // 필요하면 여기서 JWT 발급/리다이렉트 핸들러도 추가 가능
+                        // .successHandler(oAuth2SuccessHandler)
+                        // .failureHandler(oAuth2FailureHandler)
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                                 "/actuator/**",
                                 "/error/**",
                                 "/login/kakao",
-                                "/login/google"
+                                "/login/google",
+                                "/login/naver"
                         ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -42,10 +42,11 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/*.well-known/**",
                                 "/open/**",
-                                "/oauth2/**",          // 소셜로그인 진입점
-                                "/api/oauth2/**",    // 소셜로그인 에러, 성공 콜백 url
+                                "/oauth2/**",          // 소셜 로그인 진입점 (/oauth2/authorization/{registrationId})
+                                "/api/oauth2/**",     // 소셜 로그인 에러, 성공 콜백 등
                                 "/actuator/**",
-                                "/error/**"
+                                "/error/**",
+                                "/login"              // 커스텀 로그인 페이지
                         ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
@@ -55,43 +56,47 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )
                 .oauth2Login(oauth2 -> oauth2
-                                // /oauth2/authorization/{registrationId} 진입 URI
-                                .authorizationEndpoint(authorization -> authorization
-                                        .baseUri("/oauth2/authorization")
-                                )
-                                // /login/oauth2/code/{registrationId} 콜백 URI 패턴
-                                .redirectionEndpoint(redirection -> redirection
-                                        .baseUri("/login/oauth2/code/*")
-                                )
-                                // Authorization Code → Access Token 교환 시 사용할 클라이언트
-                                .tokenEndpoint(token -> token
-                                        .accessTokenResponseClient(oAuth2TokenClient)
-                                )
-                                // Access Token → userInfo 조회 후 Users/AuthAccount 매핑
-                                .userInfoEndpoint(userInfo -> userInfo
-                                        .userService(oAuth2UserService)
-                                )
-                        // 필요하면 여기서 JWT 발급/리다이렉트 핸들러도 추가 가능
-                        // .successHandler(oAuth2SuccessHandler)
-                        // .failureHandler(oAuth2FailureHandler)
+                        // 사용자가 보는 로그인 페이지 URL (회색 "Login with OAuth 2.0" 화면)
+                        .loginPage("/login")
+
+                        // /oauth2/authorization/{registrationId} 진입 URI
+                        .authorizationEndpoint(authorization -> authorization
+                                .baseUri("/oauth2/authorization")
+                        )
+
+                        // /login/oauth2/code/{registrationId} 콜백 URI 패턴 (페이지 매핑 X, 콜백 전용)
+                        .redirectionEndpoint(redirection -> redirection
+                                .baseUri("/login/oauth2/code/*")
+                        )
+
+                        // Authorization Code → Access Token 교환 시 사용할 클라이언트
+                        .tokenEndpoint(token -> token
+                                .accessTokenResponseClient(oAuth2TokenClient)
+                        )
+
+                        // Access Token → userInfo 조회 후 Users/AuthAccount 매핑
+                        .userInfoEndpoint(userInfo -> userInfo
+                                .userService(oAuth2UserService)
+                        )
+                        .defaultSuccessUrl("/login/success", true)
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    // CORS 정책을 정의하는 빈
+    // CORS 정책 정의
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("*"));  // 모든 출처 허용
-        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS","PATCH")); // 허용할 HTTP 메서드
-        configuration.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
-        configuration.setAllowCredentials(true); // 쿠키 등 인증정보 허용
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration); // 모든 경로에 적용
-
+        source.registerCorsConfiguration("/**", configuration);
         return source;
     }
 

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -38,6 +38,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/*.well-known/**",
                                 "/open/**",
+                                "/oauth2/**",          // 소셜로그인 진입점
+                                "/api/oauth2/**",    // 소셜로그인 에러, 성공 콜백 url
                                 "/actuator/**",
                                 "/error/**"
                         ).permitAll()

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -46,19 +46,18 @@ public class SecurityConfig {
                                 "/api/oauth2/**",     // 소셜 로그인 에러, 성공 콜백 등
                                 "/actuator/**",
                                 "/error/**",
-                                "/login"              // 커스텀 로그인 페이지
+                                "/login/kakao",
+                                "/login/google"
                         ).permitAll()
                         .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        // 사용자가 보는 로그인 페이지 URL (회색 "Login with OAuth 2.0" 화면)
-                        .loginPage("/login")
-
                         // /oauth2/authorization/{registrationId} 진입 URI
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/oauth2/authorization")

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2TokenClient.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2TokenClient.java
@@ -86,7 +86,7 @@ public class OAuth2TokenClient implements OAuth2AccessTokenResponseClient<OAuth2
 
         Map<String, Object> body = responseEntity.getBody();
         if (body == null || !body.containsKey(ACCESS_TOKEN)) {
-            throw new IllegalStateException("Invalid Kakao token response: " + body);
+            throw new IllegalStateException("Invalid Kakao token response: missing access_token");
         }
 
         return convertToAccessTokenResponse(body);

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2TokenClient.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2TokenClient.java
@@ -1,0 +1,136 @@
+package com.umc.linkyou.config.security.oauth;
+
+import com.umc.linkyou.domain.enums.Provider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
+import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.net.URI;
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2TokenClient implements OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
+
+    private static final String GRANT_TYPE = "grant_type";
+    private static final String AUTHORIZATION_CODE = "authorization_code";
+    private static final String CLIENT_ID = "client_id";
+    private static final String REDIRECT_URI = "redirect_uri";
+    private static final String CODE = "code";
+    private static final String CLIENT_SECRET = "client_secret";
+
+    private static final String ACCESS_TOKEN = "access_token";
+    private static final String TOKEN_TYPE = "token_type";
+    private static final String EXPIRES_IN = "expires_in";
+    private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String SCOPE = "scope";
+
+    private final OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> delegateForDefault =
+            new DefaultAuthorizationCodeTokenResponseClient();
+
+    private final RestTemplate restTemplate;
+
+    @Override
+    public OAuth2AccessTokenResponse getTokenResponse(OAuth2AuthorizationCodeGrantRequest request) {
+        String registrationId = request.getClientRegistration().getRegistrationId();
+
+        if (Provider.KAKAO.name().equalsIgnoreCase(registrationId)) {
+            return requestKakaoToken(request);
+        }
+
+        return delegateForDefault.getTokenResponse(request);
+    }
+
+    private OAuth2AccessTokenResponse requestKakaoToken(OAuth2AuthorizationCodeGrantRequest request) {
+        var clientRegistration = request.getClientRegistration();
+        var authorizationResponse = request.getAuthorizationExchange().getAuthorizationResponse();
+
+        String tokenUri = clientRegistration.getProviderDetails().getTokenUri();
+        String clientId = clientRegistration.getClientId();
+        String clientSecret = clientRegistration.getClientSecret();
+        String code = authorizationResponse.getCode();
+        String redirectUri = authorizationResponse.getRedirectUri();
+
+        MultiValueMap<String, String> formParameters = new LinkedMultiValueMap<>();
+        formParameters.add(GRANT_TYPE, AUTHORIZATION_CODE);
+        formParameters.add(CLIENT_ID, clientId);
+        formParameters.add(REDIRECT_URI, redirectUri);
+        formParameters.add(CODE, code);
+
+        if (clientSecret != null && !clientSecret.isBlank()) {
+            formParameters.add(CLIENT_SECRET, clientSecret);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+        RequestEntity<MultiValueMap<String, String>> requestEntity =
+                new RequestEntity<>(formParameters, headers,
+                        org.springframework.http.HttpMethod.POST, URI.create(tokenUri));
+
+        ResponseEntity<Map<String, Object>> responseEntity =
+                restTemplate.exchange(requestEntity, new ParameterizedTypeReference<>() {});
+
+        Map<String, Object> body = responseEntity.getBody();
+        if (body == null || !body.containsKey(ACCESS_TOKEN)) {
+            throw new IllegalStateException("Invalid Kakao token response: " + body);
+        }
+
+        return convertToAccessTokenResponse(body);
+    }
+
+    private OAuth2AccessTokenResponse convertToAccessTokenResponse(Map<String, Object> body) {
+        OAuth2AccessTokenResponse.Builder builder = OAuth2AccessTokenResponse
+                .withToken((String) body.get(ACCESS_TOKEN))
+                .tokenType(OAuth2AccessToken.TokenType.BEARER);
+
+        Object expiresIn = body.get(EXPIRES_IN);
+        if (expiresIn != null) {
+            if (expiresIn instanceof Number number) {
+                builder.expiresIn(number.intValue());
+            } else {
+                builder.expiresIn(Integer.parseInt(expiresIn.toString()));
+            }
+        }
+
+        if (body.containsKey(REFRESH_TOKEN)) {
+            builder.refreshToken((String) body.get(REFRESH_TOKEN));
+        }
+
+        if (body.containsKey(SCOPE)) {
+            Object scopeObj = body.get(SCOPE);
+            Set<String> scopes;
+            if (scopeObj instanceof String scopeString) {
+                scopes = new HashSet<>(Arrays.asList(scopeString.split(" ")));
+            } else {
+                scopes = new HashSet<>((Collection<String>) scopeObj);
+            }
+            builder.scopes(scopes);
+        }
+
+        Map<String, Object> additional = new HashMap<>();
+        body.forEach((key, value) -> {
+            if (!Set.of(ACCESS_TOKEN, TOKEN_TYPE, EXPIRES_IN, REFRESH_TOKEN, SCOPE).contains(key)) {
+                additional.put(key, value);
+            }
+        });
+        if (!additional.isEmpty()) {
+            builder.additionalParameters(additional);
+        }
+
+        return builder.build();
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.config.security.oauth;
 
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.security.oauth.utils.CustomOAuth2User;
 import com.umc.linkyou.config.security.oauth.utils.GoogleUserInfoExtractor;
 import com.umc.linkyou.config.security.oauth.utils.KakaoUserInfoExtractor;
@@ -64,9 +66,8 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
                 email = generateTemporaryEmail(provider, externalId);
                 needsEmailUpdate = true;
             } else {
-                throw new OAuth2AuthenticationException(
-                        new OAuth2Error("email_required", "이메일이 필요합니다.", null)
-                );
+
+                throw new GeneralException(ErrorStatus._SOCIAL_EMAIL_REQUIRED);
             }
         }
 
@@ -143,18 +144,15 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
                 entityManager.flush();
                 return savedUser;
             }
-            throw new IllegalStateException("닉네임 생성 실패 (3회 재시도)");
 
+            log.error("닉네임 생성 완전 실패: email={}, 모든 후보 중복", email);
+            throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
         } catch (DataIntegrityViolationException e) {
             log.warn("닉네임 중복: email={}, error={}", email, e.getMessage());
-            throw new OAuth2AuthenticationException(
-                    new OAuth2Error("DUPLICATE_NICKNAME", "사용 가능한 닉네임을 찾을 수 없습니다.", null)
-            );
+            throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
         } catch (Exception e) {
             log.error("사용자 생성 실패: email={}", email, e);
-            throw new OAuth2AuthenticationException(
-                    new OAuth2Error("USER_CREATION_FAILED", e.getMessage(), null), e
-            );
+            throw new GeneralException(ErrorStatus._USER_SOCIAL_CREATION_FAILED);
         }
     }
 
@@ -170,10 +168,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             );
         } catch (Exception e) {
             log.error("AuthAccount 저장 실패: user.id={}, provider={}", user.getId(), provider, e);
-            throw new OAuth2AuthenticationException(
-                    new OAuth2Error("auth_account_creation_failed", "인증 계정 생성 중 오류가 발생했습니다: " + e.getMessage(), null),
-                    e
-            );
+            throw new GeneralException(ErrorStatus._AUTH_ACCOUNT_SAVE_FAILED);
         }
     }
 
@@ -182,7 +177,8 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             case "google" -> Provider.GOOGLE;
             case "kakao"  -> Provider.KAKAO;
             case "naver"  -> Provider.NAVER;
-            default -> throw new IllegalArgumentException("Unsupported provider: " + registrationId);
+
+            throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
         };
     }
 
@@ -192,7 +188,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             case KAKAO  -> kakaoUserInfoExtractor;
             case NAVER  -> naverUserInfoExtractor;
             //각 enum별로 작성하지 않으면 에러남
-            default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
+            throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
         };
     }
 

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -96,12 +96,23 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
 
             authAccount.updateToken(userRequest.getAccessToken().getTokenValue());
         } else {
-            user = createNewUser(email, name);
-            isNewUser = true;
-            createAuthAccount(user, provider, externalId, userRequest);
+            // 1. 이메일로 기존 사용자 조회
+            Optional<Users> existingUserOpt = usersRepository.findByEmail(email);
 
+            if (existingUserOpt.isPresent()) {
+                // 기존 사용자에 AuthAccount만 연결 (새 사용자 아님)
+                user = existingUserOpt.get();
+                log.info("기존 사용자에 소셜 계정 연결: userId={}, provider={}, email={}",
+                        user.getId(), provider, email);
+                createAuthAccount(user, provider, externalId, userRequest);
+                isNewUser = false;
+            } else {
+                // 진짜 새 사용자 생성
+                user = createNewUser(email, name);
+                isNewUser = true;
+                createAuthAccount(user, provider, externalId, userRequest);
+            }
         }
-
         boolean needsTermsAgreement = isNewUser;
 
         Map<String, Object> attributesWithFlag = new HashMap<>(oAuth2User.getAttributes());

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -125,7 +125,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
                 if (nickname.isBlank()) nickname = "user";
             }
 
-            // 최대 3회 시도
+            // 최대 3회 시도 (중복시 다음으로 계속)
             for (int i = 0; i < 3; i++) {
                 String finalNickname = i == 0 ? nickname : nickname + "_" + i;
 
@@ -138,17 +138,20 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
                         .status("ACTIVE")
                         .build();
 
-                Users savedUser = usersRepository.saveAndFlush(user);
-                log.info("소셜 사용자 생성: id={}, nickName={}, from={}",
-                        savedUser.getId(), finalNickname, name != null ? "name" : "email");
-                entityManager.flush();
-                return savedUser;
+                try {
+                    Users savedUser = usersRepository.saveAndFlush(user);
+                    log.info("소셜 사용자 생성: id={}, nickName={}, from={}",
+                            savedUser.getId(), finalNickname, name != null ? "name" : "email");
+                    entityManager.flush();
+                    return savedUser;
+                } catch (DataIntegrityViolationException e) {
+                    log.warn("닉네임 중복 (시도 {}/3): {}", i+1, finalNickname);
+                    if (i == 2) {
+                        log.error("닉네임 생성 완전 실패: email={}, 모든 후보 중복", email);
+                        throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
+                    }
+                }
             }
-
-            log.error("닉네임 생성 완전 실패: email={}, 모든 후보 중복", email);
-            throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
-        } catch (DataIntegrityViolationException e) {
-            log.warn("닉네임 중복: email={}, error={}", email, e.getMessage());
             throw new GeneralException(ErrorStatus._DUPLICATE_NICKNAME);
         } catch (Exception e) {
             log.error("사용자 생성 실패: email={}", email, e);

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -121,14 +121,25 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
 
     private Users createNewUser(String email, String name) {
         try {
+            // 기본 닉네임 결정
+            String baseNickname = (name != null && !name.isBlank()) ? name : "사용자";
+            String nickname = baseNickname;
+
+            // 닉네임 중복이면 뒤에 _1, _2 ... 붙이기
+            int suffix = 1;
+            while (usersRepository.existsByNickName(nickname)) {
+                nickname = baseNickname + "_" + suffix++;
+            }
+
             Users user = Users.builder()
                     .email(email)
                     .password(null)
-                    .nickName(name != null ? name : "사용자")
+                    .nickName(nickname)   // 여기서 중복 처리된 닉네임 사용
                     .gender(null)
                     .role(Role.USER)
                     .status("ACTIVE")
                     .build();
+
             user = usersRepository.save(user);
             entityManager.flush();
             return user;

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -1,0 +1,189 @@
+package com.umc.linkyou.config.security.oauth;
+
+import com.umc.linkyou.config.security.oauth.utils.CustomOAuth2User;
+import com.umc.linkyou.config.security.oauth.utils.GoogleUserInfoExtractor;
+import com.umc.linkyou.config.security.oauth.utils.KakaoUserInfoExtractor;
+import com.umc.linkyou.config.security.oauth.utils.NaverUserInfoExtractor;
+import com.umc.linkyou.config.security.oauth.utils.OAuth2UserInfoExtractor;
+import com.umc.linkyou.domain.AuthAccount;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.Provider;
+import com.umc.linkyou.domain.enums.Role;
+import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserRepository usersRepository;
+    private final AuthAccountRepository authAccountRepository;
+
+    private final GoogleUserInfoExtractor googleUserInfoExtractor;
+    private final KakaoUserInfoExtractor kakaoUserInfoExtractor;
+    private final NaverUserInfoExtractor naverUserInfoExtractor;
+
+    private final DefaultOAuth2UserService delegate = new DefaultOAuth2UserService();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        Provider provider = getProvider(registrationId);
+
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+        OAuth2UserInfoExtractor extractor = getExtractor(provider);
+
+        String externalId = extractor.getExternalId(oAuth2User);
+        String email = extractor.getEmail(oAuth2User);
+        String name = extractor.getName(oAuth2User);
+
+        boolean needsEmailUpdate = false;
+        if (email == null || email.isBlank()) {
+            if (provider == Provider.KAKAO) {
+                email = generateTemporaryEmail(provider, externalId);
+                needsEmailUpdate = true;
+            } else {
+                throw new OAuth2AuthenticationException(
+                        new OAuth2Error("email_required", "이메일이 필요합니다.", null)
+                );
+            }
+        }
+
+        Users user;
+        AuthAccount authAccount;
+        boolean isNewUser = false;
+
+        Optional<AuthAccount> authAccountOpt =
+                authAccountRepository.findByProviderAndExternalId(provider, externalId);
+
+        if (authAccountOpt.isPresent()) {
+            authAccount = authAccountOpt.get();
+            user = authAccount.getUser();
+
+            if (name != null && !name.equals(user.getNickName())) {
+                user.setNickName(name);
+            }
+
+            authAccount.updateToken(userRequest.getAccessToken().getTokenValue());
+        } else {
+            Optional<Users> userOpt = usersRepository.findByEmail(email);
+
+            if (userOpt.isPresent()) {
+                user = userOpt.get();
+                isNewUser = false;
+            } else {
+                user = createNewUser(email, name);
+                isNewUser = true;
+            }
+
+            createAuthAccount(user, provider, externalId, userRequest);
+
+        }
+
+        boolean needsTermsAgreement = isNewUser;
+
+        Map<String, Object> attributesWithFlag = new HashMap<>(oAuth2User.getAttributes());
+        if (needsEmailUpdate) {
+            attributesWithFlag.put("needsEmailUpdate", true);
+            attributesWithFlag.put("temporaryEmail", email);
+        }
+        if (needsTermsAgreement) {
+            attributesWithFlag.put("needsTermsAgreement", true);
+        }
+
+        return new CustomOAuth2User(
+                Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())),
+                attributesWithFlag,
+                "email",
+                user.getEmail()
+        );
+    }
+
+    private Users createNewUser(String email, String name) {
+        try {
+            Users user = Users.builder()
+                    .email(email)
+                    .password(null)
+                    .nickName(name != null ? name : "사용자")
+                    .gender(null)
+                    .role(Role.USER)
+                    .status("ACTIVE")
+                    .build();
+            user = usersRepository.save(user);
+            entityManager.flush();
+            return user;
+        } catch (Exception e) {
+            log.error("Users 저장 실패: email={}", email, e);
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("user_creation_failed", "사용자 생성 중 오류가 발생했습니다: " + e.getMessage(), null),
+                    e
+            );
+        }
+    }
+
+    private AuthAccount createAuthAccount(Users user, Provider provider, String externalId, OAuth2UserRequest userRequest) {
+        try {
+            return authAccountRepository.save(
+                    AuthAccount.builder()
+                            .user(user)
+                            .provider(provider)
+                            .externalId(externalId)
+                            .socialToken(userRequest.getAccessToken().getTokenValue())
+                            .build()
+            );
+        } catch (Exception e) {
+            log.error("AuthAccount 저장 실패: user.id={}, provider={}", user.getId(), provider, e);
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("auth_account_creation_failed", "인증 계정 생성 중 오류가 발생했습니다: " + e.getMessage(), null),
+                    e
+            );
+        }
+    }
+
+    private Provider getProvider(String registrationId) {
+        return switch (registrationId.toLowerCase()) {
+            case "google" -> Provider.GOOGLE;
+            case "kakao"  -> Provider.KAKAO;
+            case "naver"  -> Provider.NAVER;
+            default -> throw new IllegalArgumentException("Unsupported provider: " + registrationId);
+        };
+    }
+
+    private OAuth2UserInfoExtractor getExtractor(Provider provider) {
+        return switch (provider) {
+            case GOOGLE -> googleUserInfoExtractor;
+            case KAKAO  -> kakaoUserInfoExtractor;
+            case NAVER  -> naverUserInfoExtractor;
+            //각 enum별로 작성하지 않으면 에러남
+            default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
+        };
+    }
+
+
+    private String generateTemporaryEmail(Provider provider, String externalId) {
+        return String.format("%s_%s@%s.linkyou",
+                provider.name().toLowerCase(),
+                externalId,
+                provider.name().toLowerCase());
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -82,8 +82,16 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             authAccount = authAccountOpt.get();
             user = authAccount.getUser();
 
+            // 기존 사용자 닉네임 업데이트 (중복 체크)
             if (name != null && !name.equals(user.getNickName())) {
-                user.setNickName(name);
+                if (!usersRepository.existsByNickName(name)) {
+                    user.setNickName(name);
+                    log.info("기존 사용자 닉네임 업데이트: id={}, old={}, new={}",
+                            user.getId(), user.getNickName(), name);
+                } else {
+                    log.warn("닉네임 업데이트 스킵 (중복): userId={}, requested={}",
+                            user.getId(), name);
+                }
             }
 
             authAccount.updateToken(userRequest.getAccessToken().getTokenValue());

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -15,6 +15,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -113,33 +114,46 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
 
     private Users createNewUser(String email, String name) {
         try {
-            // 기본 닉네임 결정
-            String baseNickname = (name != null && !name.isBlank()) ? name : "사용자";
-            String nickname = baseNickname;
-
-            // 닉네임 중복이면 뒤에 _1, _2 ... 붙이기
-            int suffix = 1;
-            while (usersRepository.existsByNickName(nickname)) {
-                nickname = baseNickname + "_" + suffix++;
+            String nickname;
+            if (name != null && !name.isBlank()) {
+                nickname = name;
+            } else {
+                // email@domain.com → domain
+                String domain = email.substring(email.indexOf("@") + 1);
+                nickname = domain.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+                if (nickname.isBlank()) nickname = "user";
             }
 
-            Users user = Users.builder()
-                    .email(email)
-                    .password(null)
-                    .nickName(nickname)   // 여기서 중복 처리된 닉네임 사용
-                    .gender(null)
-                    .role(Role.USER)
-                    .status("ACTIVE")
-                    .build();
+            // 최대 3회 시도
+            for (int i = 0; i < 3; i++) {
+                String finalNickname = i == 0 ? nickname : nickname + "_" + i;
 
-            user = usersRepository.save(user);
-            entityManager.flush();
-            return user;
-        } catch (Exception e) {
-            log.error("Users 저장 실패: email={}", email, e);
+                Users user = Users.builder()
+                        .email(email)
+                        .password(null)
+                        .nickName(finalNickname)
+                        .gender(null)
+                        .role(Role.USER)
+                        .status("ACTIVE")
+                        .build();
+
+                Users savedUser = usersRepository.saveAndFlush(user);
+                log.info("소셜 사용자 생성: id={}, nickName={}, from={}",
+                        savedUser.getId(), finalNickname, name != null ? "name" : "email");
+                entityManager.flush();
+                return savedUser;
+            }
+            throw new IllegalStateException("닉네임 생성 실패 (3회 재시도)");
+
+        } catch (DataIntegrityViolationException e) {
+            log.warn("닉네임 중복: email={}, error={}", email, e.getMessage());
             throw new OAuth2AuthenticationException(
-                    new OAuth2Error("user_creation_failed", "사용자 생성 중 오류가 발생했습니다: " + e.getMessage(), null),
-                    e
+                    new OAuth2Error("DUPLICATE_NICKNAME", "사용 가능한 닉네임을 찾을 수 없습니다.", null)
+            );
+        } catch (Exception e) {
+            log.error("사용자 생성 실패: email={}", email, e);
+            throw new OAuth2AuthenticationException(
+                    new OAuth2Error("USER_CREATION_FAILED", e.getMessage(), null), e
             );
         }
     }

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -178,7 +178,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             case "kakao"  -> Provider.KAKAO;
             case "naver"  -> Provider.NAVER;
 
-            throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
+            default -> throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
         };
     }
 
@@ -187,8 +187,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
             case GOOGLE -> googleUserInfoExtractor;
             case KAKAO  -> kakaoUserInfoExtractor;
             case NAVER  -> naverUserInfoExtractor;
-            //각 enum별로 작성하지 않으면 에러남
-            throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
+            default -> throw new GeneralException(ErrorStatus._SOCIAL_UNSUPPORTED_PROVIDER);
         };
     }
 

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuth2UserServiceImpl.java
@@ -86,16 +86,8 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
 
             authAccount.updateToken(userRequest.getAccessToken().getTokenValue());
         } else {
-            Optional<Users> userOpt = usersRepository.findByEmail(email);
-
-            if (userOpt.isPresent()) {
-                user = userOpt.get();
-                isNewUser = false;
-            } else {
-                user = createNewUser(email, name);
-                isNewUser = true;
-            }
-
+            user = createNewUser(email, name);
+            isNewUser = true;
             createAuthAccount(user, provider, externalId, userRequest);
 
         }

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuthController.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuthController.java
@@ -1,0 +1,35 @@
+package com.umc.linkyou.config.security.oauth;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class OAuthController {
+
+    @GetMapping("/login")
+    public String login() {
+        // 기본 진입은 구글
+        return "redirect:/oauth2/authorization/google";
+    }
+
+    @GetMapping("/login/google")
+    public String googleLogin() {
+        return "redirect:/oauth2/authorization/google";
+    }
+
+    @GetMapping("/login/kakao")
+    public String kakaoLogin() {
+        return "redirect:/oauth2/authorization/kakao";
+    }
+
+    @GetMapping("/login/naver")
+    public String naverLogin() {
+        return "redirect:/oauth2/authorization/naver";
+    }
+
+    @GetMapping("/login/success")
+    public String loginSuccess() {
+        return "login-success"; // src/main/resources/templates/login-success.html
+    }
+}
+

--- a/src/main/java/com/umc/linkyou/config/security/oauth/OAuthController.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/OAuthController.java
@@ -6,12 +6,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 public class OAuthController {
 
-    @GetMapping("/login")
-    public String login() {
-        // 기본 진입은 구글
-        return "redirect:/oauth2/authorization/google";
-    }
-
     @GetMapping("/login/google")
     public String googleLogin() {
         return "redirect:/oauth2/authorization/google";

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/CustomOAuth2User.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/CustomOAuth2User.java
@@ -1,0 +1,42 @@
+package com.umc.linkyou.config.security.oauth.utils;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+    private final String email;
+
+    public CustomOAuth2User(
+            Collection<? extends GrantedAuthority> authorities,
+            Map<String, Object> attributes,
+            String nameAttributeKey,
+            String email
+    ) {
+        this.authorities = authorities;
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.email = email;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return email;
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/GoogleUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/GoogleUserInfoExtractor.java
@@ -1,0 +1,24 @@
+
+package com.umc.linkyou.config.security.oauth.utils;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleUserInfoExtractor implements OAuth2UserInfoExtractor {
+
+    @Override
+    public String getExternalId(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute("sub");
+    }
+
+    @Override
+    public String getEmail(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute("email");
+    }
+
+    @Override
+    public String getName(OAuth2User oAuth2User) {
+        return oAuth2User.getAttribute("name");
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/KakaoUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/KakaoUserInfoExtractor.java
@@ -1,0 +1,34 @@
+package com.umc.linkyou.config.security.oauth.utils;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class KakaoUserInfoExtractor implements OAuth2UserInfoExtractor {
+
+    @Override
+    public String getExternalId(OAuth2User oAuth2User) {
+        return Objects.requireNonNull(oAuth2User.getAttribute("id")).toString();
+    }
+
+    @Override
+    public String getEmail(OAuth2User oAuth2User) {
+        Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+        if (kakaoAccount != null) {
+            return (String) kakaoAccount.get("email");
+        }
+        return null;
+    }
+
+    @Override
+    public String getName(OAuth2User oAuth2User) {
+        Map<String, Object> properties = oAuth2User.getAttribute("properties");
+        if (properties != null) {
+            return (String) properties.get("nickname");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/NaverUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/NaverUserInfoExtractor.java
@@ -1,0 +1,38 @@
+package com.umc.linkyou.config.security.oauth.utils;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Objects;
+
+@Component
+public class NaverUserInfoExtractor implements OAuth2UserInfoExtractor {
+
+    @Override
+    public String getExternalId(OAuth2User oAuth2User) {
+        Map<String, Object> response = oAuth2User.getAttribute("response");
+        if (response != null) {
+            return Objects.requireNonNull(response.get("id")).toString();
+        }
+        return null;
+    }
+
+    @Override
+    public String getEmail(OAuth2User oAuth2User) {
+        Map<String, Object> response = oAuth2User.getAttribute("response");
+        if (response != null) {
+            return (String) response.get("email");
+        }
+        return null;
+    }
+
+    @Override
+    public String getName(OAuth2User oAuth2User) {
+        Map<String, Object> response = oAuth2User.getAttribute("response");
+        if (response != null) {
+            return (String) response.get("nickname");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/NaverUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/NaverUserInfoExtractor.java
@@ -13,9 +13,13 @@ public class NaverUserInfoExtractor implements OAuth2UserInfoExtractor {
     public String getExternalId(OAuth2User oAuth2User) {
         Map<String, Object> response = oAuth2User.getAttribute("response");
         if (response != null) {
-            return Objects.requireNonNull(response.get("id")).toString();
+            Object id = response.get("id");
+            if (id == null) {
+                throw new IllegalStateException("Naver 응답에 id가 없습니다");
+            }
+            return id.toString();
         }
-        return null;
+        throw new IllegalStateException("Naver 응답 데이터가 없습니다");
     }
 
     @Override

--- a/src/main/java/com/umc/linkyou/config/security/oauth/utils/OAuth2UserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/config/security/oauth/utils/OAuth2UserInfoExtractor.java
@@ -1,0 +1,12 @@
+package com.umc.linkyou.config.security.oauth.utils;
+
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+public interface OAuth2UserInfoExtractor {
+
+    String getExternalId(OAuth2User oAuth2User);
+
+    String getEmail(OAuth2User oAuth2User);
+
+    String getName(OAuth2User oAuth2User);
+}

--- a/src/main/java/com/umc/linkyou/domain/AuthAccount.java
+++ b/src/main/java/com/umc/linkyou/domain/AuthAccount.java
@@ -5,7 +5,10 @@ import com.umc.linkyou.domain.enums.*;
 import jakarta.persistence.*;
 import lombok.*;
 @Entity
-@Table(name = "auth_account")
+@Table(name = "auth_account",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"provider", "external_id"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor

--- a/src/main/java/com/umc/linkyou/domain/AuthAccount.java
+++ b/src/main/java/com/umc/linkyou/domain/AuthAccount.java
@@ -1,0 +1,38 @@
+package com.umc.linkyou.domain;
+
+import com.umc.linkyou.domain.common.BaseEntity;
+import com.umc.linkyou.domain.enums.*;
+import jakarta.persistence.*;
+import lombok.*;
+@Entity
+@Table(name = "auth_account")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class AuthAccount extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "social_account_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "provider", nullable = false, length = 50)
+    private Provider provider;   // GOOGLE, KAKAO 등
+
+    @Column(name = "external_id", nullable = false, length = 255)
+    private String externalId;   // sub, kakao id 등
+
+    @Column(name = "social_token", length = 255)
+    private String socialToken;
+
+
+    public void updateToken(String token) {
+        this.socialToken = token;
+    }
+}

--- a/src/main/java/com/umc/linkyou/domain/AuthAccount.java
+++ b/src/main/java/com/umc/linkyou/domain/AuthAccount.java
@@ -25,11 +25,12 @@ public class AuthAccount extends BaseEntity {
     @Column(name = "provider", nullable = false, length = 50)
     private Provider provider;   // GOOGLE, KAKAO 등
 
-    @Column(name = "external_id", nullable = false, length = 255)
+    @Column(name = "external_id", nullable = false, columnDefinition = "TEXT")
     private String externalId;   // sub, kakao id 등
 
-    @Column(name = "social_token", length = 255)
+    @Column(name = "social_token", columnDefinition = "TEXT")
     private String socialToken;
+
 
 
     public void updateToken(String token) {

--- a/src/main/java/com/umc/linkyou/domain/Users.java
+++ b/src/main/java/com/umc/linkyou/domain/Users.java
@@ -30,7 +30,7 @@ public class Users extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/umc/linkyou/domain/enums/Provider.java
+++ b/src/main/java/com/umc/linkyou/domain/enums/Provider.java
@@ -1,0 +1,8 @@
+package com.umc.linkyou.domain.enums;
+
+public enum Provider {
+    GENERAL,    // 일반 로그인
+    KAKAO,      // 카카오 로그인
+    GOOGLE,      // 구글 로그인
+    NAVER
+}

--- a/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepository.java
@@ -1,0 +1,7 @@
+package com.umc.linkyou.repository.authAccountRepository;
+
+import com.umc.linkyou.domain.AuthAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuthAccountRepository extends JpaRepository<AuthAccount, Long>, AuthAccountRepositoryCustom {
+}

--- a/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepositoryCustom.java
+++ b/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.umc.linkyou.repository.authAccountRepository;
+
+import com.umc.linkyou.domain.AuthAccount;
+import com.umc.linkyou.domain.enums.Provider;
+
+import java.util.Optional;
+
+public interface AuthAccountRepositoryCustom {
+
+    Optional<AuthAccount> findByProviderAndExternalId(Provider provider, String externalId);
+}

--- a/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/authAccountRepository/AuthAccountRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.umc.linkyou.repository.authAccountRepository;
+
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.linkyou.domain.AuthAccount;
+import com.umc.linkyou.domain.QAuthAccount;
+import com.umc.linkyou.domain.enums.Provider;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+public class AuthAccountRepositoryImpl implements AuthAccountRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<AuthAccount> findByProviderAndExternalId(Provider provider, String externalId) {
+        QAuthAccount authAccount = QAuthAccount.authAccount;
+
+        AuthAccount result = queryFactory
+                .selectFrom(authAccount)
+                .where(
+                        authAccount.provider.eq(provider),
+                        authAccount.externalId.eq(externalId)
+                )
+                .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+}

--- a/src/main/java/com/umc/linkyou/repository/userRepository/UserRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/userRepository/UserRepository.java
@@ -13,4 +13,6 @@ public interface UserRepository extends JpaRepository<Users, Long>,UserRepositor
     Optional<Users> findByNickName(String nickName);
     Optional<Users> findByEmail(String email);
     Optional<Users> findById(Long id);
+
+    boolean existsByNickName(String nickname);
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
@@ -188,7 +188,8 @@ public class UserServiceImpl implements UserService {
         Users user = userRepository.findByEmail(request.getEmail())
                 .orElseThrow(()-> new UserHandler(ErrorStatus._LOGIN_FAILED));
 
-        if(!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+        // social login은 password null, jwt login은 password null이면 error(NPE 방지 코드)
+        if (user.getPassword() == null || !passwordEncoder.matches(request.getPassword(), user.getPassword())) {
             throw new UserHandler(ErrorStatus._LOGIN_FAILED);
         }
 

--- a/src/main/resources/templates/login-success.html
+++ b/src/main/resources/templates/login-success.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>로그인 완료</title>
+</head>
+<body>
+<h1>로그인 되었습니다.</h1>
+</body>
+</html>


### PR DESCRIPTION
## 🔗 관련 이슈

> closes [#208](https://github.com/LinkYou-2025/LinkU_backend/issues/208)

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement

### 2️⃣ Functional Requirement

- Google / Kakao / Naver OAuth2 소셜 로그인 플로우 구현  
  - 진입점  
    - 앱·웹에서 `{baseurl}/login/kakao`, `{baseurl}/login/google`, `{baseurl}/login/naver` 로 접근하도록 구성  
    - `OAuthController` 가 각각 `redirect:/oauth2/authorization/{provider}` 로 넘기도록 구현  
  - 서버 내부 기전  
    - `/oauth2/authorization/{provider}` → 각 소셜 로그인/동의 화면으로 이동  
    - 소셜에서 `{baseurl}/login/oauth2/code/{provider}?code=...` 로 콜백  
    - Spring OAuth2 클라이언트를 통해 Authorization Code → Access Token 교환 후, `OAuth2UserServiceImpl` 에서 사용자 매핑 및 도메인 저장 처리
  - OAuth2UserServiceImpl
    - `OAuth2UserServiceImpl` 에서 provider 별 UserInfoExtractor(Google/Kakao/Naver)를 통해 외부 ID, 이메일, 이름 추출  
    - `AuthAccountRepository.findByProviderAndExternalId` 로 기존 소셜 계정 매핑 여부 확인  
    - 소셜 계정 미존재 시 이메일 기준 Users 조회, 없으면 Users 신규 생성  
    - AuthAccount 생성 및 Access Token(`socialToken`) 저장, 이후 CustomOAuth2User 로 Security 컨텍스트에 탑재
<img width="1387" height="858" alt="image" src="https://github.com/user-attachments/assets/9790086c-6d44-45ff-a354-22c1030e03ed" />


- user 관련 로직 및 테이블 수정
  - **닉네임 중복 시 `_1`, `_2` suffix 를 붙여 유니크 닉네임 생성 후 저장**  
  - **password  속성 not null로 변경**



- 로그인 완료 페이지 처리  
  - `SecurityConfig` 에서 `oauth2Login().defaultSuccessUrl("/login/success", true)` 설정으로 OAuth2 로그인 성공 시 `/login/success` 로 이동, `login-success.html` 로 “로그인 되었습니다.” 페이지 보여주게 함.
  - 후에 프론트와 협의하여 딥링크 처리해야 함.

- 비밀번호 없는 소셜 계정 지원  
  - Users 엔티티의 `password` 컬럼을 `nullable = true` 로 변경하여, 순수 소셜 계정(비밀번호 미보유)도 저장 가능하도록 수정

- Security 설정 정리  
  - `/oauth2/**`, `/api/oauth2/**`, `/login/google`, `/login/kakao`, `/login/naver` 등을 permitAll 로 허용  
  - `oauth2Login()` 에 authorizationEndpoint, redirectionEndpoint, tokenEndpoint, userInfoEndpoint, `defaultSuccessUrl` 설정 추가  
  - CORS 설정을 통일된 Bean(`corsConfigurationSource`)으로 정리

> ⚙️ 이후 확장 계획
1. 앱에서 https://linkuserver.store/login/kakao 이나 https://linkuserver.store/login/google로 이동한다.(웹 페이지로 이동)

2. 서버 내부 기전
서버가 redirect:/oauth2/authorization/kakao
→ 카카오 로그인/동의
→ 카카오가 https://linkuserver.store/login/oauth2/code/kakao?code=... 로 콜백
→ 스프링이 로그인 처리 (User/토큰 생성)

3. 마지막에 앱 딥링크로 리다이렉트하려는데 안드에서 이미 다른 기능에 딥링크 쓰고 있으므로 담당자과 이야기하기 바람

4. 서버에서는 안드 팀이 정해준 딥링크 base URL 한 줄 받고
OAuth2SuccessHandler 에서 로그인 성공 시 그 딥링크 + ?token=... 으로 redirect
만 해 주면 된다.
---

## 🧪 테스트 결과

- 로컬 및 배포 환경에서 `/login/google`, `/login/kakao`, `/login/naver` 접근 시  
  - 각 Provider 로그인 화면 정상 노출  
  - 로그인/동의 후 `/login/oauth2/code/{provider}` 콜백 수신 및 OAuth2 토큰 교환 성공[web:244]  
  - Users / AuthAccount INSERT 및 `socialToken` 저장 로그로 확인  
- Kakao 계정 중 이메일 미제공 케이스에서  
  - `${provider}_${externalId}@${provider}.linkyou` 형식의 임시 이메일 생성 및 저장 정상 동작  
- 닉네임 중복 상황에서 `_1`, `_2` 증가 로직이 정상 동작하고, DB 유니크 제약 위반 없이 저장되는지 검증  
- 직접 `/login/oauth2/code/{provider}` 로 진입 시에는 에러,  
  `/login/{provider}` → `/oauth2/authorization/{provider}` 경로로만 OAuth2 플로우가 정상 진행되는지 브라우저로 확인

---

## 📸 스크린샷 (선택)
<img width="5340" height="2092" alt="image" src="https://github.com/user-attachments/assets/4c2a261d-c25d-4e0e-a031-b5df53923c24" />

<img width="852" height="213" alt="image" src="https://github.com/user-attachments/assets/ebfd6e5c-607e-4f36-af16-555bbf4e36ff" />


---

## 📎 참고 사항 (선택)

https://turtle0204.tistory.com/entry/%EA%B5%AC%EA%B8%80-%EC%86%8C%EC%85%9C%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0-%EC%9B%B9%EC%9C%BC%EB%A1%9C-%EB%A6%AC%EB%8B%A4%EC%9D%B4%EB%A0%89%ED%8A%B8

https://turtle0204.tistory.com/entry/%EC%B9%B4%EC%B9%B4%EC%98%A4-%EA%B5%AC%EA%B8%80-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EA%B5%AC%ED%98%84

내부자료) https://www.notion.so/2e493020f655801092affad433c07552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Google/Kakao/Naver 소셜 로그인 지원 추가(토큰 교환, 사용자 매핑 및 계정 연결)
  * 소셜 로그인 리다이렉트 엔드포인트 및 로그인 성공 페이지 추가
  * 외부 토큰 호출용 HTTP 클라이언트 및 OAuth2 클라이언트 의존성·protobuf 런타임 추가
  * 소셜 계정 도메인·저장소·프로바이더(enum) 도입

* **버그 수정**
  * 비밀번호가 없는 소셜 계정 로그인 시 발생하던 NPE 방지

* **기타**
  * 소셜 로그인 관련 오류 상태 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->