### PR TITLE
feat #217 oac

### DIFF
--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -28,6 +28,9 @@ public class AwsS3Service {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudfrontDomain;
+
     private final AmazonS3 amazonS3;
 
     /**
@@ -44,8 +47,7 @@ public class AwsS3Service {
         metadata.setContentType(multipartFile.getContentType());
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata)
-                    .withCannedAcl(CannedAccessControlList.PublicRead));
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 실패");
         }
@@ -64,8 +66,7 @@ public class AwsS3Service {
         metadata.setContentType(multipartFile.getContentType());
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata)
-                    .withCannedAcl(CannedAccessControlList.PublicRead));
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 실패");
         }
@@ -97,8 +98,7 @@ public class AwsS3Service {
      * S3에 업로드된 파일의 URL 반환
      */
     public String getFileUrl(String fileName) {
-        URL url = amazonS3.getUrl(bucket, fileName);
-        return url.toString();
+        return cloudfrontDomain + "/" + fileName;
     }
 
     /**


### PR DESCRIPTION
## 🔗 관련 이슈
#217

## 📌 작업 내용
> AWS S3 Public 업로드를 **Private S3 + CloudFront OAC**로 전환하여 보안 강화 및 CDN 성능 최적화

### 1️⃣ Non-Functional Requirement
- **S3 보안 강화**: PublicRead ACL 제거 + Block Public Access 활성화
- **CDN 성능 최적화**: CloudFront 도메인 `d3f9zmi4jicqrs.cloudfront.net` 연동
- **서버 부하 감소**: Presigned URL 재생성 로직 제거

### 2️⃣ Functional Requirement
- **AwsS3Service 수정**:
  - `cloud.aws.cloudfront.domain` 프로퍼티 추가
  - `uploadFile()` PublicRead ACL 제거 (Private 업로드)
  - `getFileUrl()` S3 URL → CloudFront URL 반환 변경
- **application.properties**에 CloudFront 도메인 설정 추가
- **기존 이미지 마이그레이션**: DB URL 일괸 REPLACE SQL 제공
---

## 📎 참고 자료



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 개선**
  * 파일 업로드 시 접근 제어가 강화되었습니다.

* **성능 개선**
  * 파일 제공 인프라가 최적화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->