### PR TITLE
feat: #208 add deeplink

### DIFF
--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -2,8 +2,9 @@ package com.umc.linkyou.config.security;
 
 import com.umc.linkyou.config.security.jwt.JwtAuthenticationFilter;
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
-import com.umc.linkyou.config.security.oauth.OAuth2TokenClient;
-import com.umc.linkyou.config.security.oauth.OAuth2UserServiceImpl;
+import com.umc.linkyou.oauth.OAuth2SuccessHandler;
+import com.umc.linkyou.oauth.OAuth2TokenClient;
+import com.umc.linkyou.oauth.OAuth2UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,6 +29,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final OAuth2UserServiceImpl oAuth2UserService;
     private final OAuth2TokenClient oAuth2TokenClient;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -78,7 +80,8 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)
                         )
-                        .defaultSuccessUrl("/login/success", true)
+                        .successHandler(oAuth2SuccessHandler)
+//                        .defaultSuccessUrl("/login/success", true)
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -45,8 +45,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             session.removeAttribute("oauth_target_path");
 
             // path를 통한 보안문제
-            if (targetPath != null && !targetPath.startsWith("/") || targetPath.length() > 100) {
-                targetPath = null;
+            if (targetPath != null &&
+                    (!targetPath.startsWith("/") || targetPath.length() > 100)) {
+                targetPath = null;  // 안전하지 않음
             }
         }
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -56,7 +56,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
         );
 
-        log.info("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
+        log.debug("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
         response.sendRedirect(deepLinkUrl);
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -36,27 +36,29 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         // JWT 생성
         String accessToken = jwtTokenProvider.createAccessToken(email);
 
-        // path 파라미터
+        // session에서 targetPath 가져오기
         HttpSession session = request.getSession(false);
+
         String targetPath = null;
         if (session != null) {
             targetPath = (String) session.getAttribute("oauth_target_path");
-            session.removeAttribute("oauth_target_path");  // 보안: 사용후 삭제
+            session.removeAttribute("oauth_target_path");
+
+            // path를 통한 보안문제
+            if (targetPath != null && !targetPath.startsWith("/") || targetPath.length() > 100) {
+                targetPath = null;
+            }
         }
 
-// targetPath 있으면 리다이렉트
-        if (targetPath != null) {
-            response.sendRedirect(targetPath);
-            return;
-        }
-        // {baseurl}/auth?path=xxx&token=yyy
+
+        // 항상 딥링크 생성 (targetPath 포함)
         String deepLinkUrl = String.format("%s/auth?path=%s&token=%s",
                 deepLinkBaseUrl,
-                URLEncoder.encode(targetPath != null ? targetPath : "", StandardCharsets.UTF_8),  // 👈 targetPath로 변경
+                URLEncoder.encode(targetPath != null ? targetPath : "/", StandardCharsets.UTF_8),
                 URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
         );
 
-        log.debug("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
+        log.info("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
         response.sendRedirect(deepLinkUrl);
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
 import com.umc.linkyou.oauth.utils.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;         // ← 추가!
@@ -36,12 +37,22 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String accessToken = jwtTokenProvider.createAccessToken(email);
 
         // path 파라미터
-        String path = request.getParameter("path");
+        HttpSession session = request.getSession(false);
+        String targetPath = null;
+        if (session != null) {
+            targetPath = (String) session.getAttribute("oauth_target_path");
+            session.removeAttribute("oauth_target_path");  // 보안: 사용후 삭제
+        }
 
+// targetPath 있으면 리다이렉트
+        if (targetPath != null) {
+            response.sendRedirect(targetPath);
+            return;
+        }
         // {baseurl}/auth?path=xxx&token=yyy
         String deepLinkUrl = String.format("%s/auth?path=%s&token=%s",
                 deepLinkBaseUrl,
-                URLEncoder.encode(path != null ? path : "", StandardCharsets.UTF_8),
+                URLEncoder.encode(targetPath != null ? targetPath : "", StandardCharsets.UTF_8),  // 👈 targetPath로 변경
                 URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
         );
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -1,0 +1,51 @@
+package com.umc.linkyou.oauth;
+
+import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
+import com.umc.linkyou.oauth.utils.CustomOAuth2User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;         // ← 추가!
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${app.deeplink.base-url}")
+    private String deepLinkBaseUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        String email = oAuth2User.getEmail();
+
+        // JWT 생성
+        String accessToken = jwtTokenProvider.createAccessToken(email);
+
+        // path 파라미터
+        String path = request.getParameter("path");
+
+        // {baseurl}/auth?path=xxx&token=yyy
+        String deepLinkUrl = String.format("%s/auth?path=%s&token=%s",
+                deepLinkBaseUrl,
+                URLEncoder.encode(path != null ? path : "", StandardCharsets.UTF_8),
+                URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
+        );
+
+        log.info("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
+        response.sendRedirect(deepLinkUrl);
+    }
+}

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2TokenClient.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2TokenClient.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.config.security.oauth;
+package com.umc.linkyou.oauth;
 
 import com.umc.linkyou.domain.enums.Provider;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2UserServiceImpl.java
@@ -1,12 +1,12 @@
-package com.umc.linkyou.config.security.oauth;
+package com.umc.linkyou.oauth;
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
-import com.umc.linkyou.config.security.oauth.utils.CustomOAuth2User;
-import com.umc.linkyou.config.security.oauth.utils.GoogleUserInfoExtractor;
-import com.umc.linkyou.config.security.oauth.utils.KakaoUserInfoExtractor;
-import com.umc.linkyou.config.security.oauth.utils.NaverUserInfoExtractor;
-import com.umc.linkyou.config.security.oauth.utils.OAuth2UserInfoExtractor;
+import com.umc.linkyou.oauth.utils.CustomOAuth2User;
+import com.umc.linkyou.oauth.utils.GoogleUserInfoExtractor;
+import com.umc.linkyou.oauth.utils.KakaoUserInfoExtractor;
+import com.umc.linkyou.oauth.utils.NaverUserInfoExtractor;
+import com.umc.linkyou.oauth.utils.OAuth2UserInfoExtractor;
 import com.umc.linkyou.domain.AuthAccount;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.Provider;
@@ -23,7 +23,6 @@ import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserServ
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/main/java/com/umc/linkyou/oauth/OAuthController.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuthController.java
@@ -5,14 +5,22 @@ import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 @Controller
 public class OAuthController {
 
+    // 👇 허용된 경로 리스트 (필요시 확장)
+    private static final List<String> ALLOWED_PATHS = List.of(
+            "/", "/mypage", "/profile", "/settings", "/cart",
+            "/reservations", "/notifications", "/search"
+    );
+
     @GetMapping("/login/google")
     public String googleLogin(HttpSession session, HttpServletRequest request) {
-        // 👇 새로 추가: path를 session에 저장
-        String targetPath = request.getParameter("path");
-        if (targetPath != null && !targetPath.isEmpty()) {
+        String targetPath = validatePath(request.getParameter("path"));
+        if (targetPath != null) {
             session.setAttribute("oauth_target_path", targetPath);
         }
         return "redirect:/oauth2/authorization/google";
@@ -20,8 +28,8 @@ public class OAuthController {
 
     @GetMapping("/login/kakao")
     public String kakaoLogin(HttpSession session, HttpServletRequest request) {
-        String targetPath = request.getParameter("path");
-        if (targetPath != null && !targetPath.isEmpty()) {
+        String targetPath = validatePath(request.getParameter("path"));
+        if (targetPath != null) {
             session.setAttribute("oauth_target_path", targetPath);
         }
         return "redirect:/oauth2/authorization/kakao";
@@ -29,15 +37,38 @@ public class OAuthController {
 
     @GetMapping("/login/naver")
     public String naverLogin(HttpSession session, HttpServletRequest request) {
-        String targetPath = request.getParameter("path");
-        if (targetPath != null && !targetPath.isEmpty()) {
+        String targetPath = validatePath(request.getParameter("path"));
+        if (targetPath != null) {
             session.setAttribute("oauth_target_path", targetPath);
         }
         return "redirect:/oauth2/authorization/naver";
     }
 
-    @GetMapping("/login/success")
-    public String loginSuccess() {
-        return "login-success";
+    // 👇 핵심: path 검증 메서드
+    private String validatePath(String path) {
+        if (path == null || path.trim().isEmpty()) {
+            return null;
+        }
+
+        // 1. URL 디코드 (이중 인코딩 방지)
+        try {
+            path = java.net.URLDecoder.decode(path, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            return null;
+        }
+
+        // 2. 상대경로(/로 시작) + 허용된 경로만
+        if (!path.startsWith("/") || path.length() > 100) {  // 길이 제한
+            return null;
+        }
+
+        // 3. 허용된 경로 체크 (접두사 매칭)
+        for (String allowed : ALLOWED_PATHS) {
+            if (path.startsWith(allowed)) {
+                return path;  // 안전!
+            }
+        }
+
+        return null;  // 기본 거부
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/OAuthController.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuthController.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.config.security.oauth;
+package com.umc.linkyou.oauth;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/umc/linkyou/oauth/OAuthController.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuthController.java
@@ -1,5 +1,7 @@
 package com.umc.linkyou.oauth;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
@@ -7,23 +9,35 @@ import org.springframework.web.bind.annotation.GetMapping;
 public class OAuthController {
 
     @GetMapping("/login/google")
-    public String googleLogin() {
+    public String googleLogin(HttpSession session, HttpServletRequest request) {
+        // 👇 새로 추가: path를 session에 저장
+        String targetPath = request.getParameter("path");
+        if (targetPath != null && !targetPath.isEmpty()) {
+            session.setAttribute("oauth_target_path", targetPath);
+        }
         return "redirect:/oauth2/authorization/google";
     }
 
     @GetMapping("/login/kakao")
-    public String kakaoLogin() {
+    public String kakaoLogin(HttpSession session, HttpServletRequest request) {
+        String targetPath = request.getParameter("path");
+        if (targetPath != null && !targetPath.isEmpty()) {
+            session.setAttribute("oauth_target_path", targetPath);
+        }
         return "redirect:/oauth2/authorization/kakao";
     }
 
     @GetMapping("/login/naver")
-    public String naverLogin() {
+    public String naverLogin(HttpSession session, HttpServletRequest request) {
+        String targetPath = request.getParameter("path");
+        if (targetPath != null && !targetPath.isEmpty()) {
+            session.setAttribute("oauth_target_path", targetPath);
+        }
         return "redirect:/oauth2/authorization/naver";
     }
 
     @GetMapping("/login/success")
     public String loginSuccess() {
-        return "login-success"; // src/main/resources/templates/login-success.html
+        return "login-success";
     }
 }
-

--- a/src/main/java/com/umc/linkyou/oauth/utils/CustomOAuth2User.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/CustomOAuth2User.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.config.security.oauth.utils;
+package com.umc.linkyou.oauth.utils;
 
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -37,6 +37,10 @@ public class CustomOAuth2User implements OAuth2User {
 
     @Override
     public String getName() {
+        return email;
+    }
+
+    public String getEmail() {
         return email;
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/utils/GoogleUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/GoogleUserInfoExtractor.java
@@ -1,5 +1,5 @@
 
-package com.umc.linkyou.config.security.oauth.utils;
+package com.umc.linkyou.oauth.utils;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/umc/linkyou/oauth/utils/KakaoUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/KakaoUserInfoExtractor.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.config.security.oauth.utils;
+package com.umc.linkyou.oauth.utils;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/umc/linkyou/oauth/utils/NaverUserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/NaverUserInfoExtractor.java
@@ -1,10 +1,9 @@
-package com.umc.linkyou.config.security.oauth.utils;
+package com.umc.linkyou.oauth.utils;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
-import java.util.Objects;
 
 @Component
 public class NaverUserInfoExtractor implements OAuth2UserInfoExtractor {

--- a/src/main/java/com/umc/linkyou/oauth/utils/OAuth2UserInfoExtractor.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/OAuth2UserInfoExtractor.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.config.security.oauth.utils;
+package com.umc.linkyou.oauth.utils;
 
 import org.springframework.security.oauth2.core.user.OAuth2User;
 


### PR DESCRIPTION
📌 작업 내용
브라우저 소셜 로그인(구글/카카오) 완료 후 앱 딥링크(https://linkuserver.store/auth?path={domain}&token={token})로 자동 리다이렉트하는 기능 구현

1️⃣ Non-Functional Requirement
Spring Security OAuth2 성공 핸들러 표준화

2️⃣ Functional Requirement
OAuth2SuccessHandler 신규 구현:

로그인 성공 시 JWT Access Token 생성

app.deeplink.base-url + /auth?path={path}&token={jwt} 구성

path 파라미터 지원 (로그인 URL 쿼리에서 전달)

CustomOAuth2User 개선: getEmail() 메서드 추가

SecurityConfig 수정:

OAuth2SuccessHandler 주입 및 .successHandler() 등록

.defaultSuccessUrl("/login/success") → 핸들러로 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Google/Kakao/Naver OAuth 로그인 시작용 엔드포인트 추가(선택 경로를 세션에 저장해 인증 후 우선 적용).
  * OAuth 인증 성공 시 JWT가 포함된 딥링크로 자동 리다이렉트하도록 성공 처리기 추가.

* **리팩토링**
  * OAuth 관련 컴포넌트들의 네임스페이스 정리 및 구조 개선으로 코드 조직화 향상.

* **API 변경**
  * OAuth 사용자 정보 접근용 공개 접근자 추가(이메일 반환).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->