### PR TITLE
Feat/#225 image upload resizing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,8 +80,6 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-	//implementation 'org.springframework.boot:spring-boot-starter-scheduling'
-
 	//blue-green
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
@@ -96,6 +94,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-core'
 
+	implementation 'net.coobird:thumbnailator:0.4.20'
 }
 
 clean {

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -19,6 +19,16 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "COMMON4011", "잘못된 토큰입니다."),
     _INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "COMMON4012", "잘못된 비밀번호입니다."),
 
+    // S3 관련 오류
+    _S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3404", "S3 파일을 찾을 수 없습니다."),
+    _S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3 파일 업로드에 실패했습니다."),
+    _S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35002", "S3 파일 삭제에 실패했습니다."),
+    _S3_INVALID_FILE(HttpStatus.BAD_REQUEST, "S34001", "유효하지 않은 파일입니다."),
+    _S3_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "S34002", "이미지 파일만 업로드할 수 있습니다."),
+    _S3_INVALID_URL(HttpStatus.BAD_REQUEST, "S34003", "유효하지 않은 S3 URL입니다."),
+    _S3_FILE_EMPTY(HttpStatus.BAD_REQUEST, "S34004", "업로드할 파일이 없습니다."),
+    _S3_EXTRACT_URL_FAILED(HttpStatus.BAD_REQUEST, "S34005", "URL에서 파일명을 추출할 수 없습니다."),
+
     // 로그인 회원가입 에러
     _LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "USERS4013", "이메일 주소 또는 비밀번호를 다시 확인하세요."),
     _DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "USERS403", "중복된 닉네임입니다."),

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -1,7 +1,6 @@
 package com.umc.linkyou.awsS3;
 
 import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -151,7 +150,7 @@ public class AwsS3Service {
     public void deleteFile(String fileName) {
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
-        } catch (AmazonServiceException e) {
+        } catch  (AmazonClientException e) {
             throw new GeneralException(ErrorStatus._S3_DELETE_FAILED);
         }
     }

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.awsS3;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
@@ -46,50 +47,67 @@ public class AwsS3Service {
         }
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
-        try {
-            // 바이트 검증
-            byte[] originalBytes = readToByteArray(multipartFile.getInputStream());
-            validateImageBytes(originalBytes); // 실제 이미지 검증
+        try (InputStream originalStream = multipartFile.getInputStream()) {
+            byte[] originalBytes = readToByteArray(originalStream);
+            validateImageBytes(originalBytes);
 
-            // ByteArrayInputStream으로 재생성 (InputStream 소모 방지)
-            byte[] resizedBytes = processImage(new ByteArrayInputStream(originalBytes));
+            try (InputStream resizedStream = new ByteArrayInputStream(originalBytes)) {
+                byte[] resizedBytes = processImage(resizedStream);
 
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(resizedBytes.length);
-            metadata.setContentType("image/jpeg");
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(resizedBytes.length);
+                metadata.setContentType("image/jpeg");
 
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName,
-                    new ByteArrayInputStream(resizedBytes), metadata));
+                // 🔥 컴파일 에러 해결: 단일 AmazonClientException catch
+                try {
+                    amazonS3.putObject(new PutObjectRequest(bucket, fileName,
+                            new ByteArrayInputStream(resizedBytes), metadata));
+                } catch (AmazonClientException e) {
+                    log.error("S3 업로드 실패 (클라이언트 오류): {}", fileName, e);
+                    throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
+                }
+            }
         } catch (IOException e) {
-            log.error("업로드 실패: {}", fileName, e);
+            log.error("업로드 IO 실패: {}", fileName, e);
             throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
         }
 
         return getFileUrl(fileName);
     }
 
+    /**
+     * 폴더 업로드 메서드 (두 번째 오버로드 - 완전 수정)
+     */
     public String uploadFile(MultipartFile multipartFile, String folder) {
         if (multipartFile == null || multipartFile.isEmpty()) {
             throw new GeneralException(ErrorStatus._S3_FILE_EMPTY);
         }
 
         String fileName = folder + "/" + createFileName(multipartFile.getOriginalFilename());
-        try  {
+        try (InputStream originalStream = multipartFile.getInputStream()) {
             // 바이트 검증
-            byte[] originalBytes = readToByteArray(multipartFile.getInputStream());
-            validateImageBytes(originalBytes); // 실제 이미지 검증
+            byte[] originalBytes = readToByteArray(originalStream);
+            validateImageBytes(originalBytes);
 
-            // ByteArrayInputStream으로 재생성 (InputStream 소모 방지)
-            byte[] resizedBytes = processImage(new ByteArrayInputStream(originalBytes));
+            // 리사이징 (자동 close)
+            try (InputStream resizedStream = new ByteArrayInputStream(originalBytes)) {
+                byte[] resizedBytes = processImage(resizedStream);
 
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(resizedBytes.length);
-            metadata.setContentType("image/jpeg");
+                ObjectMetadata metadata = new ObjectMetadata();
+                metadata.setContentLength(resizedBytes.length);
+                metadata.setContentType("image/jpeg");
 
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName,
-                    new ByteArrayInputStream(resizedBytes), metadata));
+                //  AmazonClientException 단일 catch
+                try {
+                    amazonS3.putObject(new PutObjectRequest(bucket, fileName,
+                            new ByteArrayInputStream(resizedBytes), metadata));
+                } catch (AmazonClientException e) {
+                    log.error("S3 폴더 업로드 실패 (클라이언트 오류): {}", fileName, e);
+                    throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
+                }
+            }
         } catch (IOException e) {
-            log.error("폴더 업로드 실패: {}", fileName, e);
+            log.error("폴더 업로드 IO 실패: {}", fileName, e);
             throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
         }
 

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -7,12 +7,15 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -40,14 +43,18 @@ public class AwsS3Service {
         }
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(multipartFile.getSize());
-        metadata.setContentType(multipartFile.getContentType());
-
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+            byte[] resizedBytes = processImage(inputStream, multipartFile.getContentType());
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(resizedBytes.length);
+            metadata.setContentType("image/jpeg");
+
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName,
+                    new ByteArrayInputStream(resizedBytes), metadata));
         } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 실패");
+            log.error("업로드 실패: {}", fileName, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 실패");
         }
 
         return getFileUrl(fileName);
@@ -59,14 +66,18 @@ public class AwsS3Service {
         }
 
         String fileName = folder + "/" + createFileName(multipartFile.getOriginalFilename());
-        ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentLength(multipartFile.getSize());
-        metadata.setContentType(multipartFile.getContentType());
-
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, metadata));
+            byte[] resizedBytes = processImage(inputStream, multipartFile.getContentType());
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(resizedBytes.length);
+            metadata.setContentType("image/jpeg");
+
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName,
+                    new ByteArrayInputStream(resizedBytes), metadata));
         } catch (IOException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 업로드 실패");
+            log.error("폴더 업로드 실패: {}", fileName, e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 실패");
         }
 
         return getFileUrl(fileName);
@@ -146,6 +157,22 @@ public class AwsS3Service {
         }
     }
 
+    /**
+     * 이미지 리사이징 공통 처리 (최대 800x800, 비율 유지)
+     */
+    private byte[] processImage(InputStream inputStream, String contentType) throws IOException {
+        if (!contentType.startsWith("image/")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지 파일만 지원합니다.");
+        }
 
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        Thumbnails.of(inputStream)
+                .size(800, 800)  // 긴 변 800px 이하, 비율 유지
+                .outputQuality(0.85)
+                .outputFormat("jpg")
+                .toOutputStream(output);
+
+        return output.toByteArray();
+    }
 
 }

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -5,14 +5,14 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.coobird.thumbnailator.Thumbnails;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -39,7 +39,7 @@ public class AwsS3Service {
      */
     public String uploadFile(MultipartFile multipartFile) {
         if (multipartFile == null || multipartFile.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "업로드할 파일이 없습니다.");
+            throw new GeneralException(ErrorStatus._S3_FILE_EMPTY);
         }
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
@@ -54,7 +54,7 @@ public class AwsS3Service {
                     new ByteArrayInputStream(resizedBytes), metadata));
         } catch (IOException e) {
             log.error("업로드 실패: {}", fileName, e);
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 실패");
+            throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
         }
 
         return getFileUrl(fileName);
@@ -62,7 +62,7 @@ public class AwsS3Service {
 
     public String uploadFile(MultipartFile multipartFile, String folder) {
         if (multipartFile == null || multipartFile.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "업로드할 파일이 없습니다.");
+            throw new GeneralException(ErrorStatus._S3_FILE_EMPTY);
         }
 
         String fileName = folder + "/" + createFileName(multipartFile.getOriginalFilename());
@@ -77,7 +77,7 @@ public class AwsS3Service {
                     new ByteArrayInputStream(resizedBytes), metadata));
         } catch (IOException e) {
             log.error("폴더 업로드 실패: {}", fileName, e);
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 업로드 실패");
+            throw new GeneralException(ErrorStatus._S3_UPLOAD_FAILED);
         }
 
         return getFileUrl(fileName);
@@ -99,7 +99,7 @@ public class AwsS3Service {
         try {
             return fileName.substring(fileName.lastIndexOf("."));
         } catch (StringIndexOutOfBoundsException e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "잘못된 파일 형식: " + fileName);
+            throw new GeneralException(ErrorStatus._S3_INVALID_FILE);
         }
     }
 
@@ -121,7 +121,7 @@ public class AwsS3Service {
         try {
             amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
         } catch (AmazonServiceException e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제 실패");
+            throw new GeneralException(ErrorStatus._S3_DELETE_FAILED);
         }
     }
 
@@ -133,7 +133,7 @@ public class AwsS3Service {
             String fileName = extractFileNameFromUrl(fileUrl);
             amazonS3.deleteObject(new DeleteObjectRequest(bucket, fileName));
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "S3 파일 삭제 실패");
+            throw new GeneralException(ErrorStatus._S3_DELETE_FAILED);
         }
     }
 
@@ -153,7 +153,7 @@ public class AwsS3Service {
             // 기존 S3 URL 호환
             return decodedUrl.substring(decodedUrl.indexOf(bucket) + bucket.length() + 1);
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "URL에서 파일명을 추출할 수 없습니다.");
+            throw new GeneralException(ErrorStatus._S3_EXTRACT_URL_FAILED);
         }
     }
 
@@ -162,7 +162,7 @@ public class AwsS3Service {
      */
     private byte[] processImage(InputStream inputStream, String contentType) throws IOException {
         if (!contentType.startsWith("image/")) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "이미지 파일만 지원합니다.");
+            throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
         }
 
         ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -14,6 +14,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -44,10 +46,13 @@ public class AwsS3Service {
         }
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
-        try (InputStream inputStream = multipartFile.getInputStream()) {
-            String safeContentType = Optional.ofNullable(multipartFile.getContentType())
-                    .orElse("image/jpeg");
-            byte[] resizedBytes = processImage(inputStream, safeContentType);
+        try {
+            // 바이트 검증
+            byte[] originalBytes = readToByteArray(multipartFile.getInputStream());
+            validateImageBytes(originalBytes); // 실제 이미지 검증
+
+            // ByteArrayInputStream으로 재생성 (InputStream 소모 방지)
+            byte[] resizedBytes = processImage(new ByteArrayInputStream(originalBytes));
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(resizedBytes.length);
@@ -69,11 +74,13 @@ public class AwsS3Service {
         }
 
         String fileName = folder + "/" + createFileName(multipartFile.getOriginalFilename());
-        try (InputStream inputStream = multipartFile.getInputStream()) {
+        try  {
+            // 바이트 검증
+            byte[] originalBytes = readToByteArray(multipartFile.getInputStream());
+            validateImageBytes(originalBytes); // 실제 이미지 검증
 
-            String safeContentType = Optional.ofNullable(multipartFile.getContentType())
-                    .orElse("image/jpeg");
-            byte[] resizedBytes = processImage(inputStream, safeContentType);
+            // ByteArrayInputStream으로 재생성 (InputStream 소모 방지)
+            byte[] resizedBytes = processImage(new ByteArrayInputStream(originalBytes));
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(resizedBytes.length);
@@ -166,19 +173,41 @@ public class AwsS3Service {
     /**
      * 이미지 리사이징 공통 처리 (최대 800x800, 비율 유지)
      */
-    private byte[] processImage(InputStream inputStream, String contentType) throws IOException {
-        if (!contentType.startsWith("image/")) {
-            throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
-        }
-
+    private byte[] processImage(InputStream inputStream) throws IOException {
+        // contentType 검증 제거 (validateImageBytes에서 이미 완료)
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         Thumbnails.of(inputStream)
-                .size(800, 800)  // 긴 변 800px 이하, 비율 유지
+                .size(800, 800)
                 .outputQuality(0.85)
                 .outputFormat("jpg")
                 .toOutputStream(output);
-
         return output.toByteArray();
+    }
+
+    // InputStream을 byte[]로 변환
+    private byte[] readToByteArray(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int nRead;
+        byte[] data = new byte[16384]; // 16KB 버퍼
+
+        while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, nRead);
+        }
+        buffer.flush();
+        return buffer.toByteArray();
+    }
+
+    // 실제 바이트로 이미지 검증 (contentType 무시)
+    private void validateImageBytes(byte[] bytes) {
+        try {
+            BufferedImage image = ImageIO.read(new ByteArrayInputStream(bytes));
+            if (image == null) {
+                throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
+            }
+            log.debug("이미지 검증 성공: {}x{}", image.getWidth(), image.getHeight());
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
+        }
     }
 
 }

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
+import java.util.Optional;
 import java.util.UUID;
 
 @Slf4j
@@ -44,7 +45,9 @@ public class AwsS3Service {
 
         String fileName = createFileName(multipartFile.getOriginalFilename());
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            byte[] resizedBytes = processImage(inputStream, multipartFile.getContentType());
+            String safeContentType = Optional.ofNullable(multipartFile.getContentType())
+                    .orElse("image/jpeg");
+            byte[] resizedBytes = processImage(inputStream, safeContentType);
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(resizedBytes.length);
@@ -67,7 +70,10 @@ public class AwsS3Service {
 
         String fileName = folder + "/" + createFileName(multipartFile.getOriginalFilename());
         try (InputStream inputStream = multipartFile.getInputStream()) {
-            byte[] resizedBytes = processImage(inputStream, multipartFile.getContentType());
+
+            String safeContentType = Optional.ofNullable(multipartFile.getContentType())
+                    .orElse("image/jpeg");
+            byte[] resizedBytes = processImage(inputStream, safeContentType);
 
             ObjectMetadata metadata = new ObjectMetadata();
             metadata.setContentLength(resizedBytes.length);

--- a/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
+++ b/src/main/java/com/umc/linkyou/awsS3/AwsS3Service.java
@@ -205,8 +205,13 @@ public class AwsS3Service {
                 throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
             }
             log.debug("이미지 검증 성공: {}x{}", image.getWidth(), image.getHeight());
-        } catch (Exception e) {
+        } catch (IOException e) {
+            // IOException만 catch → 명확한 이미지 읽기 실패
+            log.error("이미지 파싱 실패", e);
             throw new GeneralException(ErrorStatus._S3_INVALID_IMAGE);
+        } catch (GeneralException e) {
+            // 이미 GeneralException이면 그대로 re-throw (재포장 방지)
+            throw e;
         }
     }
 

--- a/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
+++ b/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
@@ -2,7 +2,6 @@ package com.umc.linkyou.awsS3.controller;
 
 import com.umc.linkyou.awsS3.AwsS3Service;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;


### PR DESCRIPTION
## 🔗 관련 이슈
#225

---

## 📌 작업 내용
**AWS S3 이미지 업로드 자동 리사이징 기능 구현**

### 1️⃣ Non-Functional Requirement
- ✅ Thumbnailator 라이브러리 추가 (`net.coobird:thumbnailator:0.4.20`)
- ✅ `ResponseStatusException` → `ErrorStatus` 통일 (ApiResponse 호환)
- ✅ 코드 중복 제거 (`processImage()` 공통화)
- ✅ **GeneralException + S3 전용 ErrorStatus 8종 추가**
- ✅ **임포트 정리** (불필요 ResponseStatusException 제거)

### 2️⃣ Functional Requirement
- **자동 리사이징**: 최대 800x800px (긴 변 기준, 원본 비율 유지)
- **이미지 검증**: `contentType.startsWith("image/")` 체크
- **압축 최적화**: JPEG 85% 품질 (10MB → ~300KB)
- **폴더 업로드**에도 동일 적용

### 3️⃣ ErrorStatus 추가
```java
// ErrorStatus.java에 추가
_S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3404", "S3 파일을 찾을 수 없습니다."),
_S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35001", "S3 파일 업로드에 실패했습니다."),
_S3_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S35002", "S3 파일 삭제에 실패했습니다."),
_S3_INVALID_FILE(HttpStatus.BAD_REQUEST, "S34001", "유효하지 않은 파일입니다."),
_S3_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "S34002", "이미지 파일만 업로드할 수 있습니다."),
_S3_INVALID_URL(HttpStatus.BAD_REQUEST, "S34003", "유효하지 않은 S3 URL입니다."),
_S3_FILE_EMPTY(HttpStatus.BAD_REQUEST, "S34004", "업로드할 파일이 없습니다."),
_S3_EXTRACT_URL_FAILED(HttpStatus.BAD_REQUEST, "S34005", "URL에서 파일명을 추출할 수 없습니다."),
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 업로드 이미지가 최대 800×800으로 자동 리사이징되어 JPEG 형식으로 저장됩니다.

* **버그 수정**
  * S3 관련 오류 응답이 정비되어 파일 조회·업로드·삭제·URL 추출 등에 대한 명확한 에러 코드와 메시지가 추가되었습니다.
  * 이미지 유효성 검사와 관련 오류 처리 강화.

* **잡무(Chores)**
  * 이미지 처리 라이브러리 추가 및 경미한 코드 정리(불필요 주석/임포트 제거) 진행.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->