### PR TITLE
Feat/#208 social login

### DIFF
--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.umc.linkyou.oauth.OAuth2UserServiceImpl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -29,6 +30,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final OAuth2UserServiceImpl oAuth2UserService;
     private final OAuth2TokenClient oAuth2TokenClient;
+    @Lazy
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -85,6 +85,9 @@ public class SecurityConfig {
                         .successHandler(oAuth2SuccessHandler)
 //                        .defaultSuccessUrl("/login/success", true)
                 )
+                .requiresChannel(channel -> channel
+                        .anyRequest().requiresSecure()
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2TokenClient.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2TokenClient.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.oauth;
 
 import com.umc.linkyou.domain.enums.Provider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -20,6 +21,7 @@ import org.springframework.web.client.RestTemplate;
 import java.net.URI;
 import java.util.*;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OAuth2TokenClient implements OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> {
@@ -63,6 +65,11 @@ public class OAuth2TokenClient implements OAuth2AccessTokenResponseClient<OAuth2
         String code = authorizationResponse.getCode();
         String redirectUri = authorizationResponse.getRedirectUri();
 
+
+        // 1. 요청 직전 데이터 확인 로그 (이미 EXIST 확인하셨다면 이 부분은 검증용)
+        log.info("Kakao Token Request - ClientID: {}, Secret: {}, RedirectURI: {}",
+                clientId, (clientSecret != null ? "EXIST" : "NULL"), redirectUri);
+
         MultiValueMap<String, String> formParameters = new LinkedMultiValueMap<>();
         formParameters.add(GRANT_TYPE, AUTHORIZATION_CODE);
         formParameters.add(CLIENT_ID, clientId);
@@ -81,15 +88,25 @@ public class OAuth2TokenClient implements OAuth2AccessTokenResponseClient<OAuth2
                 new RequestEntity<>(formParameters, headers,
                         org.springframework.http.HttpMethod.POST, URI.create(tokenUri));
 
-        ResponseEntity<Map<String, Object>> responseEntity =
-                restTemplate.exchange(requestEntity, new ParameterizedTypeReference<>() {});
+        // 2. try-catch로 감싸서 카카오의 에러 메시지를 가로챕니다.
+        try {
+            ResponseEntity<Map<String, Object>> responseEntity =
+                    restTemplate.exchange(requestEntity, new ParameterizedTypeReference<>() {});
 
-        Map<String, Object> body = responseEntity.getBody();
-        if (body == null || !body.containsKey(ACCESS_TOKEN)) {
-            throw new IllegalStateException("Invalid Kakao token response: missing access_token");
+            Map<String, Object> body = responseEntity.getBody();
+            if (body == null || !body.containsKey(ACCESS_TOKEN)) {
+                throw new IllegalStateException("Invalid Kakao token response: missing access_token");
+            }
+            return convertToAccessTokenResponse(body);
+
+        } catch (org.springframework.web.client.HttpClientErrorException e) {
+            // 카카오 서버가 400, 401 에러를 던지면 이 로그가 찍힙니다.
+            log.error("##### KAKAO API ERROR RESPONSE #####");
+            log.error("Status Code: {}", e.getStatusCode());
+            log.error("Response Body: {}", e.getResponseBodyAsString()); // 여기에 KOE010 같은 코드가 나옵니다.
+            log.error("####################################");
+            throw e;
         }
-
-        return convertToAccessTokenResponse(body);
     }
 
     private OAuth2AccessTokenResponse convertToAccessTokenResponse(Map<String, Object> body) {


### PR DESCRIPTION
## 🔗 관련 이슈
#208 

---

## 📌 작업 내용
> **구글 소셜로그인 `redirect_uri_mismatch` 해결 및 NGINX 프록시 환경 대응 설정 적용**

### 1️⃣ Non-Functional Requirement
- Docker(8080) + NGINX(443) 프록시 환경에서 Spring Security가 `{baseUrl}`을 `http`로 인식하던 문제를 수정했습니다.
- `server.forward-headers-strategy` 및 Tomcat `remoteip` 설정을 통해 `X-Forwarded-*` 헤더를 활용하도록 구성했습니다.
- OAuth2 redirect-uri를 하드코딩(`https://linkuserver.store/...`)하여 스킴 불일치 가능성을 제거했습니다.

### 2️⃣ Functional Requirement
- Google OAuth2 로그인 흐름에서 `/login/google` → `/login/oauth2/code/google` → `https://linkuserver.store/auth?path=/&token=...` 딥링크까지 정상적으로 리다이렉트되도록 수정했습니다.
- Kakao OAuth2도 동일한 redirect-uri 정책을 적용할 수 있도록 토큰 요청 클라이언트(`OAuth2TokenClient`) 구조를 정리했습니다.
- `OAuth2SuccessHandler`에 `@Lazy`를 적용하여 SecurityFilterChain 초기화 시 순환 참조/빈 초기화 문제를 방지했습니다.
- OAuth2 흐름 디버깅을 위해 토큰 요청/콜백 구간에 임시 로깅을 추가했습니다.
---

## 🧪 테스트 결과
- [x]구글로그인 이제 됨
- [x] user에 저장되었는지는 확인
<img width="2854" height="254" alt="image" src="https://github.com/user-attachments/assets/daab9302-78bc-4947-90f2-a229f1c3fba4" />
<img width="2966" height="908" alt="image" src="https://github.com/user-attachments/assets/d9690175-6a52-4244-ba06-d2dd57924194" />


- [x] 카카오 로그인 로깅 

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 자료
- https 설정파일
https://turtle0204.tistory.com/entry/08-https-%EB%8F%84%EB%A9%94%EC%9D%B8-%EC%97%B0%EA%B2%B0%ED%95%98%EA%B8%B0-Draconist

- 왜 https로 설정이 안되었느냐
https://turtle0204.tistory.com/entry/%EA%B5%AC%EA%B8%80-%EC%86%8C%EC%85%9C%EB%A1%9C%EA%B7%B8%EC%9D%B8-http%EC%97%90%EB%9F%AC-Nginx%EB%A1%9C-proxy%ED%95%98%EB%8A%94-%EC%84%9C%EB%B2%84


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 강화**
  * 모든 연결에 HTTPS 보안 프로토콜 적용

* **안정성 개선**
  * Kakao OAuth2 인증 요청 흐름 개선
  * 토큰 요청 오류 처리 강화 및 진단 로깅 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->