### PR TITLE
Feat/#231 termsagreement & UsersUtils.validateUser()

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -35,12 +35,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _DUPLICATE_JOIN_REQUEST(HttpStatus.CONFLICT, "USERS403", "중복된 이메일입니다."),
     _VERIFICATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS404", "인증 코드 검증 실패"),
     _USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USERS404", "사용자를 찾을 수 없습니다."),
+    _USER_INACTIVE(HttpStatus.NOT_FOUND, "USERS4042", "사용자가 INACTIVE 임시 회원탈퇴 상태입니다."),
     _PURPOSE_NOT_PROVIDED(HttpStatus.NOT_FOUND, "USERS404", "목적을 선택해야합니다."),
     _INTEREST_NOT_PROVIDED(HttpStatus.NOT_FOUND, "USERS404", "관심 분야를 선택해야합니다."),
     _NO_SUCH_ALGORITHM(HttpStatus.INTERNAL_SERVER_ERROR, "USERS500", "인증 코드 생성 실패"),
     _SEND_MAIL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS500", "인증 코드 전송 실패"),
     //소셜로그인 관련
-    // 소셜로그인 관련 추가/수정
     _AUTH_ACCOUNT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5001", "소셜 계정 연결에 실패했습니다."),
     _USER_SOCIAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5002", "소셜 사용자 생성에 실패했습니다."),
     _SOCIAL_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "USERS4003", "소셜 로그인에 이메일이 필요합니다."),

--- a/src/main/java/com/umc/linkyou/converter/TermsConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/TermsConverter.java
@@ -8,6 +8,7 @@ import com.umc.linkyou.web.dto.UserResponseDTO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -59,5 +60,20 @@ public class TermsConverter {
             case MARKETING -> false;
         };
     }
-
+    public static TermsAgreement toSingleTermAgreement(Users user, String termsTypeStr, boolean isAgreed) {
+        TermsType termsType = TermsType.valueOf(termsTypeStr);
+        return TermsAgreement.builder()
+                .user(user)
+                .termsType(termsType)
+                .isRequired(isRequiredTerms(termsType))
+                .termsVersion("v1.0")  // 기본 버전
+                .agreedAt(LocalDateTime.now())
+                .isAgreed(isAgreed)
+                .build();
+    }
+    //기존 레코드 업데이트
+    public static void updateAgreement(TermsAgreement agreement, boolean isAgreed) {
+        agreement.setIsAgreed(isAgreed);
+        agreement.setAgreedAt(LocalDateTime.now());
+    }
 }

--- a/src/main/java/com/umc/linkyou/converter/TermsConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/TermsConverter.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -20,7 +21,9 @@ public class TermsConverter {
         return agreements.stream() //순서대로 계산
                 .collect(Collectors.toMap(
                         agreement -> agreement.getTermsType().name(), //Key: "TERMS_OF_USE"
-                        TermsAgreement::getIsAgreed  // Value: true/false
+                        TermsAgreement::getIsAgreed,  // Value: true/false
+                        (existing, replacement)->replacement, //이미 같은 TermsType으로 row가 있으면 최신값으로 변경
+                        LinkedHashMap::new
                 ));  // result: {"TERMS_OF_USE":true, "MARKETING":false}
     }
     //TermsStatus response 전체 빌드

--- a/src/main/java/com/umc/linkyou/converter/TermsConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/TermsConverter.java
@@ -1,0 +1,63 @@
+package com.umc.linkyou.converter;
+
+import com.umc.linkyou.domain.TermsAgreement;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.TermsType;
+import com.umc.linkyou.web.dto.UserRequestDTO;
+import com.umc.linkyou.web.dto.UserResponseDTO;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TermsConverter {
+    //List<TermsAgreement> ->  Map<String, Boolean> 변환; key value형태로 변환해서 반환
+    public static Map<String, Boolean> toTermsStatusMap(List<TermsAgreement> agreements) {
+        return agreements.stream() //순서대로 계산
+                .collect(Collectors.toMap(
+                        agreement -> agreement.getTermsType().name(), //Key: "TERMS_OF_USE"
+                        TermsAgreement::getIsAgreed  // Value: true/false
+                ));  // result: {"TERMS_OF_USE":true, "MARKETING":false}
+    }
+    //TermsStatus response 전체 빌드
+    public static UserResponseDTO.TermsStatusDTO toTermsStatusDTO(Long userId, List<TermsAgreement> agreements) {
+        Map<String, Boolean> termsStatus = toTermsStatusMap(agreements);
+        boolean allRequiredAgreed = agreements.stream()  //필수약관 중 isRequired가 true인 것만 필터링
+                .filter(TermsAgreement::getIsRequired)
+                .allMatch(TermsAgreement::getIsAgreed); //모두 treu면 true
+        return UserResponseDTO.TermsStatusDTO.builder()
+                .userId(userId)
+                .termsStatus(termsStatus)
+                .allRequiredAgreed(allRequiredAgreed) //필수 완료 여부
+                .build();
+    }
+
+    // 전체 동의여부 TermsAgreeDTO  → List<TermsAgreement> 변환
+    public static List<TermsAgreement> toTermsAgreements(Users user, UserRequestDTO.TermsAgreeDTO request) {
+        return request.getTermsTypes().stream()
+                .map(termsTypeStr -> {
+                    TermsType termsType = TermsType.valueOf(termsTypeStr);
+                    return TermsAgreement.builder()
+                            .user(user)
+                            .termsType(termsType)
+                            .isRequired(TermsConverter.isRequiredTerms(termsType))
+                            .termsVersion(request.getTermsVersion())
+                            .agreedAt(java.time.LocalDateTime.now())
+                            .isAgreed(true)
+                            .build();
+                })
+                .toList();
+    }
+
+    // 개별 약관 상태 확인
+    private static boolean isRequiredTerms(TermsType termsType) {
+        return switch (termsType) {
+            case TERMS_OF_USE, PRIVACY_POLICY -> true;
+            case MARKETING -> false;
+        };
+    }
+
+}

--- a/src/main/java/com/umc/linkyou/converter/UserConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/UserConverter.java
@@ -75,4 +75,6 @@ public class UserConverter {
                 .inactiveDate(user.getInactiveDate())
                 .build();
     }
+
+
 }

--- a/src/main/java/com/umc/linkyou/domain/TermsAgreement.java
+++ b/src/main/java/com/umc/linkyou/domain/TermsAgreement.java
@@ -23,6 +23,7 @@ public class TermsAgreement extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private Users user;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "terms_type", length = 50, nullable = false)
     private TermsType termsType; // "TERMS_OF_USE", "PRIVACY_POLICY", "MARKETING"
 

--- a/src/main/java/com/umc/linkyou/domain/TermsAgreement.java
+++ b/src/main/java/com/umc/linkyou/domain/TermsAgreement.java
@@ -1,0 +1,40 @@
+package com.umc.linkyou.domain;
+
+import com.umc.linkyou.domain.common.BaseEntity;
+import com.umc.linkyou.domain.enums.TermsType;
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "terms_agreements")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class TermsAgreement extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "terms_agreement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Column(name = "terms_type", length = 50, nullable = false)
+    private TermsType termsType; // "TERMS_OF_USE", "PRIVACY_POLICY", "MARKETING"
+
+    @Column(name = "is_required", nullable = false)
+    private Boolean isRequired = false; // true=필수, false=선택
+
+    @Column(name = "terms_version", length = 10, nullable = false)
+    private String termsVersion; // "v1.0"
+
+    @Column(name = "agreed_at", nullable = false)
+    private LocalDateTime agreedAt;
+
+    @Column(name = "is_agreed", nullable = false)
+    private Boolean isAgreed = true;
+}

--- a/src/main/java/com/umc/linkyou/domain/enums/TermsType.java
+++ b/src/main/java/com/umc/linkyou/domain/enums/TermsType.java
@@ -1,0 +1,7 @@
+package com.umc.linkyou.domain.enums;
+
+public enum TermsType {
+    TERMS_OF_USE,        // 이용약관
+    PRIVACY_POLICY,      // 개인정보처리방침
+    MARKETING          // 마케팅수신동의
+}

--- a/src/main/java/com/umc/linkyou/repository/TermsAgreementRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/TermsAgreementRepository.java
@@ -1,0 +1,10 @@
+package com.umc.linkyou.repository;
+
+import com.umc.linkyou.domain.TermsAgreement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface TermsAgreementRepository extends JpaRepository<TermsAgreement, Long> {
+    List<TermsAgreement> findByUserId(Long id);
+}

--- a/src/main/java/com/umc/linkyou/repository/TermsAgreementRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/TermsAgreementRepository.java
@@ -1,10 +1,14 @@
 package com.umc.linkyou.repository;
 
 import com.umc.linkyou.domain.TermsAgreement;
+import com.umc.linkyou.domain.enums.TermsType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TermsAgreementRepository extends JpaRepository<TermsAgreement, Long> {
     List<TermsAgreement> findByUserId(Long id);
+
+    Optional<TermsAgreement> findByUserIdAndTermsType(Long id, TermsType termsType);
 }

--- a/src/main/java/com/umc/linkyou/repository/userRepository/UserRepositoryCustom.java
+++ b/src/main/java/com/umc/linkyou/repository/userRepository/UserRepositoryCustom.java
@@ -15,4 +15,5 @@ public interface UserRepositoryCustom {
     Optional<Users> findByEmailAndStatus(String email, UserStatus status);
     List<String> findAllPurposeNamesByUserId(Long userId);
     List<String> findAllInterestNamesByUserId(Long userId);
+    Optional<Users> findNotInactiveUserById(Long userId);
 }

--- a/src/main/java/com/umc/linkyou/repository/userRepository/UserRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/userRepository/UserRepositoryImpl.java
@@ -111,4 +111,15 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
                         .fetchOne()
         );
     }
+    @Override
+    public Optional<Users> findNotInactiveUserById(Long userId){
+        return Optional.ofNullable(
+                queryFactory.selectFrom(users)
+                        .where(
+                                users.id.eq(userId)
+                                        .and(users.status.ne(UserStatus.INACTIVE))
+                        )
+                        .fetchOne() //1개값 기대
+        );
+    }
 }

--- a/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
+++ b/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
@@ -1,0 +1,39 @@
+package com.umc.linkyou.service.users;
+
+import com.umc.linkyou.config.security.jwt.CustomUserDetails;
+import com.umc.linkyou.converter.TermsConverter;
+import com.umc.linkyou.domain.TermsAgreement;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.repository.TermsAgreementRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.web.dto.UserRequestDTO;
+import com.umc.linkyou.web.dto.UserResponseDTO;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TermsAgreementService {
+    private final UsersUtils usersUtils;
+    private final TermsAgreementRepository termsAgreementRepository;
+
+    private final UserRepository userRepository;
+    //전체 동의 여부 반환
+    @Transactional
+    public UserResponseDTO.TermsStatusDTO termsAgreeBatch(UserRequestDTO.@Valid TermsAgreeDTO request, CustomUserDetails userDetails){
+        //1. token이 올바른지, 사용자가 존재하는지, 사용자가 있다면 activated 상태인지
+        Users user = usersUtils.validateUser(userDetails, userRepository);
+        // DTO → Entity 변환 + 저장
+        List<TermsAgreement> agreements = TermsConverter.toTermsAgreements(user, request);
+        termsAgreementRepository.saveAll(agreements);
+
+        // Entity → Response 변환
+        List<TermsAgreement> saved = termsAgreementRepository.findByUserId(user.getId());
+        return TermsConverter.toTermsStatusDTO(user.getId(), saved);
+    }
+}

--- a/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
+++ b/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.TermsConverter;
 import com.umc.linkyou.domain.TermsAgreement;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.TermsType;
 import com.umc.linkyou.repository.TermsAgreementRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.utils.UsersUtils;
@@ -11,10 +12,12 @@ import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,5 +38,34 @@ public class TermsAgreementService {
         // Entity → Response 변환
         List<TermsAgreement> saved = termsAgreementRepository.findByUserId(user.getId());
         return TermsConverter.toTermsStatusDTO(user.getId(), saved);
+    }
+
+    public UserResponseDTO.TermsStatusDTO updateTermsAgree(CustomUserDetails userDetails, @NotNull String termsTypeStr, Boolean isAgreed) {
+        Users user = usersUtils.validateUser(userDetails, userRepository);
+        TermsType termsType = TermsType.valueOf(termsTypeStr);
+        //기존 레코그 조회
+        Optional<TermsAgreement> existing = termsAgreementRepository.findByUserIdAndTermsType(user.getId(), termsType);
+
+        TermsAgreement agreement;
+        if (existing.isPresent()) {
+            // 기존 업데이트
+            agreement = existing.get();
+            TermsConverter.updateAgreement(agreement, isAgreed);
+        } else {
+            // 신규 생성
+            agreement = TermsConverter.toSingleTermAgreement(user, termsTypeStr, isAgreed);
+        }
+        termsAgreementRepository.save(agreement);
+
+        List<TermsAgreement> updated = termsAgreementRepository.findByUserId(user.getId());
+        return TermsConverter.toTermsStatusDTO(user.getId(), updated);
+    }
+
+    // GET /terms/status - 약관 상태 조회
+    public UserResponseDTO.TermsStatusDTO getTermsStatus(CustomUserDetails userDetails) {
+        Users user = usersUtils.validateUser(userDetails, userRepository);
+
+        List<TermsAgreement> agreements = termsAgreementRepository.findByUserId(user.getId());
+        return TermsConverter.toTermsStatusDTO(user.getId(), agreements);
     }
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -43,6 +43,4 @@ public interface UserService {
     UserResponseDTO.TokenPair reissueRefreshToken(String refreshToken);
 
     void testImmediateDelete(Long userId);
-
-    UserResponseDTO.TermsStatusDTO termsAgreeBatch(UserRequestDTO.@Valid TermsAgreeDTO request, CustomUserDetails userDetails);
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -1,9 +1,11 @@
 package com.umc.linkyou.service.users;
 
+import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.web.dto.EmailVerificationResponse;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
+import jakarta.validation.Valid;
 
 public interface UserService {
 
@@ -41,4 +43,6 @@ public interface UserService {
     UserResponseDTO.TokenPair reissueRefreshToken(String refreshToken);
 
     void testImmediateDelete(Long userId);
+
+    UserResponseDTO.TermsStatusDTO termsAgreeBatch(UserRequestDTO.@Valid TermsAgreeDTO request, CustomUserDetails userDetails);
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
@@ -3,9 +3,12 @@ package com.umc.linkyou.service.users;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
+import com.umc.linkyou.converter.TermsConverter;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.EmailVerification;
+import com.umc.linkyou.domain.TermsAgreement;
 import com.umc.linkyou.domain.UserRefreshToken;
 import com.umc.linkyou.domain.enums.Gender;
 import com.umc.linkyou.domain.enums.UserStatus;
@@ -29,6 +32,7 @@ import com.umc.linkyou.repository.classification.CategoryRepository;
 import com.umc.linkyou.repository.classification.JobRepository;
 import com.umc.linkyou.repository.classification.PurposeRepository;
 import com.umc.linkyou.service.EmailService;
+import com.umc.linkyou.utils.UsersUtils;
 import com.umc.linkyou.web.dto.EmailVerificationResponse;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
@@ -36,6 +40,7 @@ import io.jsonwebtoken.Claims;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,6 +92,8 @@ public class UserServiceImpl implements UserService {
 
     private final UserRefreshTokenRepository userRefreshTokenRepository;
 
+    private final UsersUtils usersUtils;
+    private final TermsAgreementRepository termsAgreementRepository;
 
     @Value("${jwt.token.expiration.refresh}")
     private long refreshTtlMs;
@@ -641,6 +648,19 @@ public class UserServiceImpl implements UserService {
         });
     }
 
+    //전체 동의 여부 반환
+    @Transactional
+    public UserResponseDTO.TermsStatusDTO termsAgreeBatch(UserRequestDTO.@Valid TermsAgreeDTO request, CustomUserDetails userDetails){
+        //1. token이 올바른지, 사용자가 존재하는지, 사용자가 있다면 activated 상태인지
+        Users user = usersUtils.validateUser(userDetails, userRepository);
+        // DTO → Entity 변환 + 저장
+        List<TermsAgreement> agreements = TermsConverter.toTermsAgreements(user, request);
+        termsAgreementRepository.saveAll(agreements);
+
+        // Entity → Response 변환
+        List<TermsAgreement> saved = termsAgreementRepository.findByUserId(user.getId());
+        return TermsConverter.toTermsStatusDTO(user.getId(), saved);
+    }
 
 }
 

--- a/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
@@ -2,13 +2,10 @@ package com.umc.linkyou.service.users;
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
-import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
-import com.umc.linkyou.config.security.jwt.CustomUserDetails;
+import com.umc.linkyou.apiPayload.exception.handler.UserHandler;;
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
-import com.umc.linkyou.converter.TermsConverter;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.EmailVerification;
-import com.umc.linkyou.domain.TermsAgreement;
 import com.umc.linkyou.domain.UserRefreshToken;
 import com.umc.linkyou.domain.enums.Gender;
 import com.umc.linkyou.domain.enums.UserStatus;
@@ -32,7 +29,6 @@ import com.umc.linkyou.repository.classification.CategoryRepository;
 import com.umc.linkyou.repository.classification.JobRepository;
 import com.umc.linkyou.repository.classification.PurposeRepository;
 import com.umc.linkyou.service.EmailService;
-import com.umc.linkyou.utils.UsersUtils;
 import com.umc.linkyou.web.dto.EmailVerificationResponse;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
@@ -40,7 +36,6 @@ import io.jsonwebtoken.Claims;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,9 +56,6 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
-    @PersistenceContext
-    private EntityManager entityManager;
-    private static final String AUTH_CODE_PREFIX = "AuthCode ";
 
     private final UserRepository userRepository;
 
@@ -91,9 +83,6 @@ public class UserServiceImpl implements UserService {
     private final UsersCategoryColorRepository usersCategoryColorRepository;
 
     private final UserRefreshTokenRepository userRefreshTokenRepository;
-
-    private final UsersUtils usersUtils;
-    private final TermsAgreementRepository termsAgreementRepository;
 
     @Value("${jwt.token.expiration.refresh}")
     private long refreshTtlMs;
@@ -648,19 +637,7 @@ public class UserServiceImpl implements UserService {
         });
     }
 
-    //전체 동의 여부 반환
-    @Transactional
-    public UserResponseDTO.TermsStatusDTO termsAgreeBatch(UserRequestDTO.@Valid TermsAgreeDTO request, CustomUserDetails userDetails){
-        //1. token이 올바른지, 사용자가 존재하는지, 사용자가 있다면 activated 상태인지
-        Users user = usersUtils.validateUser(userDetails, userRepository);
-        // DTO → Entity 변환 + 저장
-        List<TermsAgreement> agreements = TermsConverter.toTermsAgreements(user, request);
-        termsAgreementRepository.saveAll(agreements);
 
-        // Entity → Response 변환
-        List<TermsAgreement> saved = termsAgreementRepository.findByUserId(user.getId());
-        return TermsConverter.toTermsStatusDTO(user.getId(), saved);
-    }
 
 }
 

--- a/src/main/java/com/umc/linkyou/utils/UsersUtils.java
+++ b/src/main/java/com/umc/linkyou/utils/UsersUtils.java
@@ -3,6 +3,8 @@ package com.umc.linkyou.utils;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.repository.userRepository.UserRepository;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,6 +21,20 @@ public class UsersUtils {
             throw new UserHandler(ErrorStatus._INVALID_TOKEN);
         }
         return userDetails.getEmail();
+    }
+    public Users validateUser(CustomUserDetails userDetails, UserRepository userRepository) {
+        if (userDetails == null) {
+            throw new UserHandler(ErrorStatus._INVALID_TOKEN);
+        }
+
+        Long userId = userDetails.getUsers().getId();
+        return userRepository.findNotInactiveUserById(userId)
+                .orElseThrow(() -> {
+                    if (!userRepository.existsById(userId)) {
+                        return new UserHandler(ErrorStatus._USER_NOT_FOUND);
+                    }
+                    return new UserHandler(ErrorStatus._USER_INACTIVE);
+                });
     }
 }
 

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -180,6 +180,21 @@ public class UserController {
         UserResponseDTO.TermsStatusDTO result = termsAgreementService.termsAgreeBatch(request,userDetails);
         return ApiResponse.onSuccess(result);
     }
+    @PatchMapping("/terms/agree")
+    @Operation(summary = "약관 개별 변경")
+    public ApiResponse<UserResponseDTO.TermsStatusDTO> updateTermsAgree(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDTO.SingleTermUpdateDTO request) {
+        return ApiResponse.onSuccess(
+                termsAgreementService.updateTermsAgree(userDetails, request.getTermsType(), request.getIsAgreed())
+        );
+    }
 
+    @GetMapping("/terms/status")
+    @Operation(summary = "약관 상태 조회")
+    public ApiResponse<UserResponseDTO.TermsStatusDTO> getTermsStatus(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(termsAgreementService.getTermsStatus(userDetails));
+    }
 
 }

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -7,6 +7,7 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.service.users.TermsAgreementService;
 import com.umc.linkyou.service.users.UserService;
 import com.umc.linkyou.utils.UsersUtils;
 import com.umc.linkyou.web.dto.EmailVerificationResponse;
@@ -29,6 +30,7 @@ public class UserController {
 
     private final UserService userService;
     private final UsersUtils usersUtils;
+    private final TermsAgreementService termsAgreementService;
 
     @Operation(
             summary = "회원 가입",
@@ -175,7 +177,7 @@ public class UserController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.TermsAgreeDTO request
     ){
-        UserResponseDTO.TermsStatusDTO result = userService.termsAgreeBatch(request,userDetails);
+        UserResponseDTO.TermsStatusDTO result = termsAgreementService.termsAgreeBatch(request,userDetails);
         return ApiResponse.onSuccess(result);
     }
 

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -164,4 +164,20 @@ public class UserController {
         Users user = userService.socialCompleteProfile(email, request);
         return ApiResponse.onSuccess(UserConverter.toJoinResultDTO(user));
     }
+
+    // 전체 약관 한번에 동의
+    @Operation(
+            summary = "약관 동의",
+            description = "TERMS_OF_USE, PRIVACY_POLICY, MARKETING를 enum으로 입력받습니다."
+    )
+    @PostMapping("/terms/agree")
+    public ApiResponse<UserResponseDTO.TermsStatusDTO> termsAgreeBatch(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDTO.TermsAgreeDTO request
+    ){
+        UserResponseDTO.TermsStatusDTO result = userService.termsAgreeBatch(request,userDetails);
+        return ApiResponse.onSuccess(result);
+    }
+
+
 }

--- a/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
@@ -110,4 +110,27 @@ public class UserRequestDTO {
         @NotNull(message = "관심사 리스트는 필수입니다")
         private List<String> interestList;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TermsAgreeDTO {
+        @Schema(example = "[\"TERMS_OF_USE\", \"PRIVACY_POLICY\", \"MARKETING\"]")
+        @NotNull(message = "약관 동의 목록은 필수입니다")
+        private List<String> termsTypes;
+
+        @Schema(example = "v1.0")
+        @NotNull(message = "약관 버전은 필수입니다")
+        private String termsVersion;
+    }
+    @Getter @Setter
+    public static class SingleTermUpdateDTO {
+        @Schema(example = "MARKETING")
+        @NotNull
+        private String termsType;
+
+        @Schema(example = "true")
+        private Boolean isAgreed;
+    }
 }

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -3,13 +3,12 @@ package com.umc.linkyou.web.dto;
 import com.umc.linkyou.domain.classification.Job;
 import com.umc.linkyou.domain.enums.Gender;
 import com.umc.linkyou.domain.enums.UserStatus;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 public class UserResponseDTO {
     @Builder
@@ -108,4 +107,41 @@ public class UserResponseDTO {
         }
     }
 
+    @Getter @Setter
+    @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "약관 동의 상태 응답 (키-값 형태)")
+    public static class TermsStatusDTO {
+
+        @Schema(description = "사용자 ID", example = "123")
+        private Long userId;
+
+        @Schema(description = "약관별 동의 상태 맵",
+                example = "{\"TERMS_OF_USE\":true,\"MARKETING\":true,\"EVENT_NOTICE\":false}")
+        private Map<String, Boolean> termsStatus;
+
+        @Schema(description = "필수 약관 모두 동의했는지 여부", example = "true")
+        private boolean allRequiredAgreed;
+    }
+
+    @Getter @Setter @Builder
+    @NoArgsConstructor @AllArgsConstructor
+    @Schema(description = "개별 약관 동의 정보")
+    public static class TermsAgreementDTO {
+
+        @Schema(description = "약관 타입", example = "TERMS_OF_USE")
+        private String termsType;
+
+        @Schema(description = "필수 약관 여부", example = "true")
+        private boolean isRequired;
+
+        @Schema(description = "약관 버전", example = "v1.0")
+        private String termsVersion;
+
+        @Schema(description = "동의 시점", example = "2026-02-12T06:28:00")
+        private LocalDateTime agreedAt;
+
+        @Schema(description = "현재 동의 상태", example = "true")
+        private boolean isAgreed;
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#231

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- **TermsAgreement 엔티티 설계**: 다중 약관 이력 관리 (필수/선택, 버전, 동의시점)
- utils/UserUtils의 UsersUtils.validateUser()를 작성함. token 정상 여부, 사용자 존재여부, 활성화된 계정 여부 체크하는 메소드
- TermsAgreementRepository에 findNotInactiveUserById() 작성함. Querydsl로 최적화 안함.

### 2️⃣ Functional Requirement
- **POST `/api/users/terms/agree`**: 약관 일괄 동의 (회원가입 후 필수+선택)
- **PATCH `/api/users/terms/agree`**: 개별 약관 변경 (마케팅 on/off)
- **GET `/api/users/terms/status`**: 약관 동의 상태 조회 (`{"TERMS_OF_USE":true}`)

### 🔧 기술 구현


## 🧪 테스트 결과
안함

---
<img width="5340" height="2092" alt="linkU-BE (2)" src="https://github.com/user-attachments/assets/32cbcc82-0859-45b2-9bab-cd5da32e8cf8" />



---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - test가능하면 해주면 감사
> - TermsAgreementRepository에 findNotInactiveUserById()를 Querydsl로 최적화 해야 할지
> - UsersUtils.validateUser() 반드시 확인할 것!!!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 약관 동의 관리 추가: 여러 약관 일괄 동의, 개별 약관 수정, 현재 동의 상태 조회(약관별 동의 여부 및 필수 약관 전체 동의 여부 포함).
* **버그 수정**
  * 비활성(임시 탈퇴) 사용자 접근 시 명확한 오류 응답 및 처리 개선으로 안내가 더 구체화됨.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->