### PR TITLE
Feat/#208 social login & mypage api url 변경

### DIFF
--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
@@ -116,8 +116,8 @@ public class JwtTokenProvider {
     private String hmac(String token) {
         try {
             var mac = javax.crypto.Mac.getInstance("HmacSHA256");
-            mac.init(new javax.crypto.spec.SecretKeySpec(hmacSecret.getBytes(), "HmacSHA256"));
-            return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes()));
+            mac.init(new javax.crypto.spec.SecretKeySpec(hmacSecret.getBytes(StandardCharsets.UTF_8),  "HmacSHA256"));
+            return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) { throw new IllegalStateException(e); }
     }
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -9,10 +9,9 @@ import com.umc.linkyou.repository.UserRefreshTokenRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;         // ← 추가!
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -105,9 +105,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 );
             }
 
-            log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
-                    redirectUrl.split("&accessToken")[0], email, user.getStatus());
-
         } catch (Exception e) {
             // 토큰 발급 / Redis 저장 중 예외 → 500 대신 FAIL 딥링크
             log.error("OAuth2SuccessHandler: token generation failed for email={}, provider={}", email, provider, e);
@@ -116,9 +113,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     deepLinkBaseUrl, provider
             );
         }
-
-        log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
-                redirectUrl.split("&accessToken")[0], email, user.getStatus());
         response.sendRedirect(redirectUrl);
     }
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -1,7 +1,12 @@
 package com.umc.linkyou.oauth;
 
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
+import com.umc.linkyou.domain.UserRefreshToken;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.oauth.utils.CustomOAuth2User;
+import com.umc.linkyou.repository.UserRefreshTokenRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
@@ -21,9 +26,17 @@ import java.nio.charset.StandardCharsets;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final UserRefreshTokenRepository userRefreshTokenRepository;
 
     @Value("${app.deeplink.base-url}")
     private String deepLinkBaseUrl;
+
+    @Value("${jwt.token.expiration.refresh}")
+    private long refreshTtlMs;
+
+    @Value("${jwt.hmac-secret}")
+    private String hmacSecret;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
@@ -32,34 +45,77 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getEmail();
+        // provider 파라미터 추출 (session 또는 request-uri 기반)
+        String requestUri = request.getRequestURI(); // /login/oauth2/code/kakao
+        String provider = extractProvider(requestUri); // "kakao", "google", ...
 
-        // JWT 생성
-        String accessToken = jwtTokenProvider.createAccessToken(email);
 
-        // session에서 targetPath 가져오기
-        HttpSession session = request.getSession(false);
+        // User 조회
+        Users user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalStateException("User not found: " + email));
 
-        String targetPath = null;
-        if (session != null) {
-            targetPath = (String) session.getAttribute("oauth_target_path");
-            session.removeAttribute("oauth_target_path");
+        String redirectUrl;
 
-            // path를 통한 보안문제
-            if (targetPath != null &&
-                    (!targetPath.startsWith("/") || targetPath.length() > 100)) {
-                targetPath = null;  // 안전하지 않음
-            }
+        if (user.getStatus() == UserStatus.TEMP) {
+            // TEMP: socialToken(accessToken)만 발급, refreshToken 없음
+            String socialToken = jwtTokenProvider.createAccessToken(email);
+
+            redirectUrl = String.format(
+                    "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
+                    deepLinkBaseUrl,
+                    provider,
+                    URLEncoder.encode(socialToken, StandardCharsets.UTF_8)
+            );
+
+        } else if (user.getStatus() == UserStatus.ACTIVE) {
+            // ACTIVE: accessToken + refreshToken 발급
+            String accessToken  = jwtTokenProvider.createAccessToken(email);
+            String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+            // refreshToken 화이트리스트 저장 (기존 토큰 교체)
+            userRefreshTokenRepository.findByUserId(user.getId())
+                    .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
+
+            String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
+            userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
+
+            redirectUrl = String.format(
+                    "%s/auth?provider=%s&result=SUCCESS&status=ACTIVE&accessToken=%s&refreshToken=%s",
+                    deepLinkBaseUrl,
+                    provider,
+                    URLEncoder.encode(accessToken,  StandardCharsets.UTF_8),
+                    URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
+            );
+
+        } else {
+            // INACTIVE 등 기타 상태 → FAIL 처리
+            redirectUrl = String.format(
+                    "%s/auth?provider=%s&result=FAIL&errorCode=INACTIVE_USER",
+                    deepLinkBaseUrl,
+                    provider
+            );
         }
 
+        log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
+                redirectUrl.split("&accessToken")[0], email, user.getStatus());
+        response.sendRedirect(redirectUrl);
+    }
 
-        // 항상 딥링크 생성 (targetPath 포함)
-        String deepLinkUrl = String.format("%s/auth?path=%s&token=%s",
-                deepLinkBaseUrl,
-                URLEncoder.encode(targetPath != null ? targetPath : "/", StandardCharsets.UTF_8),
-                URLEncoder.encode(accessToken, StandardCharsets.UTF_8)
-        );
+    /** /login/oauth2/code/{provider} URI에서 provider 추출 */
+    private String extractProvider(String requestUri) {
+        if (requestUri == null) return "unknown";
+        String[] parts = requestUri.split("/");
+        return parts[parts.length - 1]; // 마지막 세그먼트
+    }
 
-        log.info("OAuth → 딥링크: {} (user={})", deepLinkUrl, email);
-        response.sendRedirect(deepLinkUrl);
+    private String hmac(String token) {
+        try {
+            var mac = javax.crypto.Mac.getInstance("HmacSHA256");
+            mac.init(new javax.crypto.spec.SecretKeySpec(
+                    hmacSecret.getBytes(), "HmacSHA256"));
+            return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes()));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -19,6 +19,8 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -49,49 +51,69 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String provider = extractProvider(requestUri); // "kakao", "google", ...
 
 
-        // User 조회
-        Users user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalStateException("User not found: " + email));
 
-        String redirectUrl;
+        // User 조회 (방어적 처리)
+        Optional<Users> userOpt = userRepository.findByEmail(email);
+        if (userOpt.isEmpty()) {
+            // 로그 남기고 FAIL 리다이렉트
+            log.warn("OAuth2SuccessHandler: userRepository.findByEmail returned empty for email={}, provider={}",
+                    email, provider);
 
-        if (user.getStatus() == UserStatus.TEMP) {
-            // TEMP: socialToken(accessToken)만 발급, refreshToken 없음
-            String socialToken = jwtTokenProvider.createAccessToken(email);
-
-            redirectUrl = String.format(
-                    "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
-                    deepLinkBaseUrl,
-                    provider,
-                    URLEncoder.encode(socialToken, StandardCharsets.UTF_8)
-            );
-
-        } else if (user.getStatus() == UserStatus.ACTIVE) {
-            // ACTIVE: accessToken + refreshToken 발급
-            String accessToken  = jwtTokenProvider.createAccessToken(email);
-            String refreshToken = jwtTokenProvider.createRefreshToken(email);
-
-            // refreshToken 화이트리스트 저장 (기존 토큰 교체)
-            userRefreshTokenRepository.findByUserId(user.getId())
-                    .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
-
-            String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
-            userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
-
-            redirectUrl = String.format(
-                    "%s/auth?provider=%s&result=SUCCESS&status=ACTIVE&accessToken=%s&refreshToken=%s",
-                    deepLinkBaseUrl,
-                    provider,
-                    URLEncoder.encode(accessToken,  StandardCharsets.UTF_8),
-                    URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
-            );
-
-        } else {
-            // INACTIVE 등 기타 상태 → FAIL 처리
-            redirectUrl = String.format(
-                    "%s/auth?provider=%s&result=FAIL&errorCode=INACTIVE_USER",
+            String failUrl = String.format(
+                    "%s/auth?provider=%s&result=FAIL&errorCode=USER_NOT_FOUND",
                     deepLinkBaseUrl,
                     provider
+            );
+
+            response.sendRedirect(failUrl);
+            return;  // 예외 없이 종료
+        }
+
+        Users user = userOpt.get();
+        String redirectUrl;
+
+        try {
+            if (user.getStatus() == UserStatus.TEMP) {
+                String socialToken = jwtTokenProvider.createAccessToken(email);
+                redirectUrl = String.format(
+                        "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
+                        deepLinkBaseUrl, provider,
+                        URLEncoder.encode(socialToken, StandardCharsets.UTF_8)
+                );
+
+            } else if (user.getStatus() == UserStatus.ACTIVE) {
+                String accessToken  = jwtTokenProvider.createAccessToken(email);
+                String refreshToken = jwtTokenProvider.createRefreshToken(email);
+
+                userRefreshTokenRepository.findByUserId(user.getId())
+                        .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
+
+                String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
+                userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
+
+                redirectUrl = String.format(
+                        "%s/auth?provider=%s&result=SUCCESS&status=ACTIVE&accessToken=%s&refreshToken=%s",
+                        deepLinkBaseUrl, provider,
+                        URLEncoder.encode(accessToken,  StandardCharsets.UTF_8),
+                        URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
+                );
+
+            } else {
+                redirectUrl = String.format(
+                        "%s/auth?provider=%s&result=FAIL&errorCode=INACTIVE_USER",
+                        deepLinkBaseUrl, provider
+                );
+            }
+
+            log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
+                    redirectUrl.split("&accessToken")[0], email, user.getStatus());
+
+        } catch (Exception e) {
+            // 토큰 발급 / Redis 저장 중 예외 → 500 대신 FAIL 딥링크
+            log.error("OAuth2SuccessHandler: token generation failed for email={}, provider={}", email, provider, e);
+            redirectUrl = String.format(
+                    "%s/auth?provider=%s&result=FAIL&errorCode=TOKEN_GENERATION_FAILED",
+                    deepLinkBaseUrl, provider
             );
         }
 

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -133,7 +133,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         try {
             var mac = javax.crypto.Mac.getInstance("HmacSHA256");
             mac.init(new javax.crypto.spec.SecretKeySpec(
-                    hmacSecret.getBytes(), "HmacSHA256"));
+                    hmacSecret.getBytes(StandardCharsets.UTF_8),  "HmacSHA256"));
             return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes()));
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -95,8 +95,8 @@ public class UserController {
             summary = "마이페이지 조회",
             description = "사용자의 프로필 정보를 조회합니다."
     )
-    @GetMapping("/{userId}")
-    public ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("userId") Long userId) {
+    @GetMapping("/me")
+    public ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
         Long newUserId = userDetails.getUsers().getId();  //보안 문제 때문에 추가함
         return ApiResponse.onSuccess(userService.userInfo(newUserId));
     }


### PR DESCRIPTION
## 🔗 관련 이슈
#208

---

## 📌 작업 내용
> OAuth2 로그인 성공 후 딥링크 리다이렉트 URL 구조를 개선하고, 기존 targetPath 세션 로직을 제거했습니다.

### 1️⃣ Non-Functional Requirement
- **딥링크 URL 구조 표준화**: 기존 `/auth?path=...&token=...` → 신규 `/auth?provider=...&result=...&status=...&accessToken=...&refreshToken=...` 형태로 변경
- **세션 의존성 제거**: OAuth2SuccessHandler에서 `oauth_target_path` 세션 속성 사용 로직 삭제

### 2️⃣ Functional Requirement
- **딥링크 파라미터 확장**:
  - `provider` (kakao/google/apple)
  - `result` (SUCCESS/FAIL)
  - `status` (ACTIVE/TEMP/DELETED)
  - `accessToken`, `refreshToken` (status=ACTIVE일 때)
  - `socialToken` (status=TEMP일 때)
  - `error`, `errorMessage` (result=FAIL일 때)

- **targetPath 로직 제거 이유**:
  1. 새 URL 구조에 `path` 파라미터 자리가 없음
  2. 모바일 딥링크 방식에서는 앱이 네비게이션 스택을 자체 관리하므로, 서버가 path를 전달할 필요 없음
  3. `OAuthController.java`의 `oauth_target_path` 세션 저장 로직도 함께 제거됨
- **mypage api url변경**

---

참고

1️⃣ ACTIVE (기존 회원 로그인 성공)
GET https://linkuserver.store/auth

쿼리 파라미터:

provider=kakao

result=SUCCESS

status=ACTIVE

accessToken=... ← 기존 그대로 유지

refreshToken=... ← 신규 추가 (앱 자동 로그인용)

2️⃣ TEMP (신규 회원, 추가 정보 입력 필요)
GET https://linkuserver.store/auth

쿼리 파라미터:

provider=kakao

result=SUCCESS

status=TEMP

socialToken=... ← 기존 그대로 유지

userId는 URL에 포함하지 않음

이후 PATCH /api/users/social/complete 응답에서 userId를 내려받아 사용 (URL 보안 이슈 회피)

3️⃣ FAIL (로그인 실패)
GET https://linkuserver.store/auth

쿼리 파라미터:

provider=kakao

result=FAIL

errorCode=... ← 기존 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OAuth 로그인 후 사용자 상태(TEMP/ACTIVE)에 따른 맞춤 리디렉션 및 토큰 발급 흐름 추가
  * 로그인 실패 또는 오류 시 상태(FAIL)로의 명확한 리디렉션 및 에러 코드 전달

* **개선 사항**
  * 소셜 로그인 시 제공자 정보 기반 딥링크 리디렉션 지원
  * 갱신 토큰 관리 강화(기존 토큰 무효화 및 신규 토큰 적용)
  * 사용자 프로필 조회 API를 /me 엔드포인트로 단순화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->