### PR TITLE
Feat/#208 social login

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -43,12 +43,14 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_TERMS_TYPE(HttpStatus.BAD_REQUEST, "TERMS4001", "유효하지 않은 약관 타입입니다."),
 
     //소셜로그인 관련
-    _AUTH_ACCOUNT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5001", "소셜 계정 연결에 실패했습니다."),
-    _USER_SOCIAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "USERS5002", "소셜 사용자 생성에 실패했습니다."),
-    _SOCIAL_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "USERS4003", "소셜 로그인에 이메일이 필요합니다."),
-    _SOCIAL_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "USERS4004", "지원하지 않는 소셜 제공자입니다."),
-    _SOCIAL_PROFILE_EXPIRED(HttpStatus.BAD_REQUEST, "USERS4005", "임시 프로필이 만료되었습니다."),
-    _SOCIAL_PROFILE_NOT_REQUIRED(HttpStatus.BAD_REQUEST, "USERS4006", "임시 프로필이 필요하지 않습니다."),
+    _AUTH_ACCOUNT_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH5001", "소셜 계정 연결에 실패했습니다."),
+    _USER_SOCIAL_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH5002", "소셜 사용자 생성에 실패했습니다."),
+    _SOCIAL_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "OAUTH4003", "소셜 로그인에 이메일이 필요합니다."),
+    _SOCIAL_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "OAUTH4004", "지원하지 않는 소셜 제공자입니다."),
+    _SOCIAL_PROFILE_EXPIRED(HttpStatus.BAD_REQUEST, "OAUTH4005", "임시 프로필이 만료되었습니다."),
+    _SOCIAL_PROFILE_NOT_REQUIRED(HttpStatus.BAD_REQUEST, "OAUTH4006", "임시 프로필이 필요하지 않습니다."),
+    _INVALID_AUTH_CODE(HttpStatus.BAD_REQUEST, "OAUTH4007", "유효하지 않거나 만료된 인증 코드"),
+
     //링큐 관련 코드
     _LINKU_VIDEO_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "LINKU4001", "영상 링크는 저장할 수 없습니다."),
     _LINKU_INVALID_URL(HttpStatus.BAD_REQUEST, "LINKU4002", "유효하지 않은 링크입니다."),
@@ -94,7 +96,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _INVALID_PERMISSION_TYPE(HttpStatus.BAD_REQUEST, "PERMISSION400", "유효하지 않은 권한 타입입니다."),
     INVITATION_CREATOR_CANNOT_ACCEPT(HttpStatus.FORBIDDEN, "FOLDER_CREATOR403", "초대 생성자는 자신의 링크로 참여할 수 없습니다."),
     // 북마크 관련 오류
-    _FOLDER_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_BOOKMARK404", "해당 유저의 북마크 정보가 존재하지 않습니다.");
+    _FOLDER_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_BOOKMARK404", "해당 유저의 북마크 정보가 존재하지 않습니다."), ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/config/WebConfig.java
+++ b/src/main/java/com/umc/linkyou/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.umc.linkyou.config;
+
+import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.validation.annotation.ApiV2;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix("/api/v1",
+                c -> c.isAnnotationPresent(ApiV1.class));
+        configurer.addPathPrefix("/api/v2",
+                c -> c.isAnnotationPresent(ApiV2.class));
+    }
+}
+

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -60,30 +61,27 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .formLogin(form -> form.disable())
                 .sessionManagement(session -> session
-                        .sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS) // ← IF_REQUIRED → STATELESS
                 )
+
                 .oauth2Login(oauth2 -> oauth2
-                        // /oauth2/authorization/{registrationId} 진입 URI
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/oauth2/authorization")
+                                // STATELESS여도 OAuth2 state는 세션에 저장하도록 명시
+                                .authorizationRequestRepository(
+                                        new HttpSessionOAuth2AuthorizationRequestRepository()
+                                )
                         )
-
-                        // /login/oauth2/code/{registrationId} 콜백 URI 패턴 (페이지 매핑 X, 콜백 전용)
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/login/oauth2/code/*")
                         )
-
-                        // Authorization Code → Access Token 교환 시 사용할 클라이언트
                         .tokenEndpoint(token -> token
                                 .accessTokenResponseClient(oAuth2TokenClient)
                         )
-
-                        // Access Token → userInfo 조회 후 Users/AuthAccount 매핑
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)
                         )
                         .successHandler(oAuth2SuccessHandler)
-//                        .defaultSuccessUrl("/login/success", true)
                 )
                 .requiresChannel(channel -> channel
                         .anyRequest().requiresSecure()

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 "/", "/css/**",
-                                "/api/users/**",
+                                "/api/v1/users/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/*.well-known/**",
                                 "/open/**",

--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
 import com.umc.linkyou.oauth.OAuth2SuccessHandler;
 import com.umc.linkyou.oauth.OAuth2TokenClient;
 import com.umc.linkyou.oauth.OAuth2UserServiceImpl;
+import com.umc.linkyou.oauth.RedisAuthorizationRequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,7 +15,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -33,6 +33,8 @@ public class SecurityConfig {
     private final OAuth2TokenClient oAuth2TokenClient;
     @Lazy
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final RedisAuthorizationRequestRepository redisAuthorizationRequestRepository;
+
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -68,9 +70,7 @@ public class SecurityConfig {
                         .authorizationEndpoint(authorization -> authorization
                                 .baseUri("/oauth2/authorization")
                                 // STATELESS여도 OAuth2 state는 세션에 저장하도록 명시
-                                .authorizationRequestRepository(
-                                        new HttpSessionOAuth2AuthorizationRequestRepository()
-                                )
+                                .authorizationRequestRepository(redisAuthorizationRequestRepository)
                         )
                         .redirectionEndpoint(redirection -> redirection
                                 .baseUri("/login/oauth2/code/*")

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -20,6 +21,8 @@ import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -29,6 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
+    private final StringRedisTemplate stringRedisTemplate; // ← 신규 추가
 
     @Value("${app.deeplink.base-url}")
     private String deepLinkBaseUrl;
@@ -39,6 +43,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${jwt.hmac-secret}")
     private String hmacSecret;
 
+    private static final long AUTH_CODE_TTL_SECONDS = 30L; // 1회용 코드 유효시간
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
@@ -46,27 +52,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getEmail();
-        // provider 파라미터 추출 (session 또는 request-uri 기반)
-        String requestUri = request.getRequestURI(); // /login/oauth2/code/kakao
-        String provider = extractProvider(requestUri); // "kakao", "google", ...
+        String requestUri = request.getRequestURI();
+        String provider = extractProvider(requestUri);
 
-
-
-        // User 조회 (방어적 처리)
         Optional<Users> userOpt = userRepository.findByEmail(email);
         if (userOpt.isEmpty()) {
-            // 로그 남기고 FAIL 리다이렉트
             log.warn("OAuth2SuccessHandler: userRepository.findByEmail returned empty for email={}, provider={}",
                     email, provider);
-
-            String failUrl = String.format(
+            response.sendRedirect(String.format(
                     "%s/auth?provider=%s&result=FAIL&errorCode=USER_NOT_FOUND",
-                    deepLinkBaseUrl,
-                    provider
-            );
-
-            response.sendRedirect(failUrl);
-            return;  // 예외 없이 종료
+                    deepLinkBaseUrl, provider));
+            return;
         }
 
         Users user = userOpt.get();
@@ -74,6 +70,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         try {
             if (user.getStatus() == UserStatus.TEMP) {
+                // TEMP: socialToken은 추가정보 입력용 → 보안 민감도 낮아서 기존 유지
                 String socialToken = jwtTokenProvider.createAccessToken(email);
                 redirectUrl = String.format(
                         "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
@@ -85,17 +82,23 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 String accessToken  = jwtTokenProvider.createAccessToken(email);
                 String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
+                // refreshToken 화이트리스트 저장
                 userRefreshTokenRepository.findByUserId(user.getId())
                         .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
-
                 String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
                 userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
 
+                // 1회용 코드 생성 → Redis에 토큰 임시 저장 (30초 TTL)
+                String code = UUID.randomUUID().toString().replace("-", "");
+                String redisKey = "auth:code:" + code;
+                String redisValue = accessToken + "::" + refreshToken;
+                stringRedisTemplate.opsForValue().set(redisKey, redisValue, AUTH_CODE_TTL_SECONDS, TimeUnit.SECONDS);
+
+                // URL엔 code만 노출
                 redirectUrl = String.format(
-                        "%s/auth?provider=%s&result=SUCCESS&status=ACTIVE&accessToken=%s&refreshToken=%s",
+                        "%s/auth?provider=%s&result=SUCCESS&status=ACTIVE&code=%s",
                         deepLinkBaseUrl, provider,
-                        URLEncoder.encode(accessToken,  StandardCharsets.UTF_8),
-                        URLEncoder.encode(refreshToken, StandardCharsets.UTF_8)
+                        URLEncoder.encode(code, StandardCharsets.UTF_8)
                 );
 
             } else {
@@ -106,29 +109,30 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             }
 
         } catch (Exception e) {
-            // 토큰 발급 / Redis 저장 중 예외 → 500 대신 FAIL 딥링크
             log.error("OAuth2SuccessHandler: token generation failed for email={}, provider={}", email, provider, e);
             redirectUrl = String.format(
                     "%s/auth?provider=%s&result=FAIL&errorCode=TOKEN_GENERATION_FAILED",
                     deepLinkBaseUrl, provider
             );
         }
+
+        log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
+                redirectUrl, email, user.getStatus());
         response.sendRedirect(redirectUrl);
     }
 
-    /** /login/oauth2/code/{provider} URI에서 provider 추출 */
     private String extractProvider(String requestUri) {
         if (requestUri == null) return "unknown";
         String[] parts = requestUri.split("/");
-        return parts[parts.length - 1]; // 마지막 세그먼트
+        return parts[parts.length - 1];
     }
 
     private String hmac(String token) {
         try {
             var mac = javax.crypto.Mac.getInstance("HmacSHA256");
             mac.init(new javax.crypto.spec.SecretKeySpec(
-                    hmacSecret.getBytes(StandardCharsets.UTF_8),  "HmacSHA256"));
-            return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes()));
+                    hmacSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return java.util.HexFormat.of().formatHex(mac.doFinal(token.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -32,7 +32,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
-    private final StringRedisTemplate stringRedisTemplate; // ← 신규 추가
+    private final StringRedisTemplate stringRedisTemplate;
 
     @Value("${app.deeplink.base-url}")
     private String deepLinkBaseUrl;
@@ -57,8 +57,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         Optional<Users> userOpt = userRepository.findByEmail(email);
         if (userOpt.isEmpty()) {
-            log.warn("OAuth2SuccessHandler: userRepository.findByEmail returned empty for email={}, provider={}",
-                    email, provider);
             response.sendRedirect(String.format(
                     "%s/auth?provider=%s&result=FAIL&errorCode=USER_NOT_FOUND",
                     deepLinkBaseUrl, provider));
@@ -109,15 +107,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             }
 
         } catch (Exception e) {
-            log.error("OAuth2SuccessHandler: token generation failed for email={}, provider={}", email, provider, e);
             redirectUrl = String.format(
                     "%s/auth?provider=%s&result=FAIL&errorCode=TOKEN_GENERATION_FAILED",
                     deepLinkBaseUrl, provider
             );
         }
 
-        log.info("OAuth2 딥링크 리다이렉트: {} (user={}, status={})",
-                redirectUrl, email, user.getStatus());
         response.sendRedirect(redirectUrl);
     }
 

--- a/src/main/java/com/umc/linkyou/oauth/RedisAuthorizationRequestRepository.java
+++ b/src/main/java/com/umc/linkyou/oauth/RedisAuthorizationRequestRepository.java
@@ -1,0 +1,82 @@
+package com.umc.linkyou.oauth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RedisAuthorizationRequestRepository
+        implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String KEY_PREFIX = "oauth2:state:";
+    private static final Duration TTL = Duration.ofMinutes(10); // state 유효 시간
+
+    private String key(HttpServletRequest request) {
+        // state 파라미터로 키 구성 (저장/로드/삭제 모두 동일 키 사용)
+        String state = request.getParameter("state");
+        return KEY_PREFIX + (state != null ? state : "unknown");
+    }
+
+    @Override
+    public void saveAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
+
+        try {
+            String state = authorizationRequest.getState();
+            String json = objectMapper.writeValueAsString(authorizationRequest);
+            stringRedisTemplate.opsForValue().set(KEY_PREFIX + state, json, TTL);
+            log.debug("OAuth2 AuthorizationRequest saved. state={}", state);
+        } catch (Exception e) {
+            log.error("OAuth2 AuthorizationRequest 저장 실패", e);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        try {
+            String json = stringRedisTemplate.opsForValue().get(key(request));
+            if (json == null) return null;
+            return objectMapper.readValue(json, OAuth2AuthorizationRequest.class);
+        } catch (Exception e) {
+            log.error("OAuth2 AuthorizationRequest 로드 실패", e);
+            return null;
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        try {
+            String redisKey = key(request);
+            String json = stringRedisTemplate.opsForValue().getAndDelete(redisKey);
+            if (json == null) return null;
+            log.debug("OAuth2 AuthorizationRequest 삭제. key={}", redisKey);
+            return objectMapper.readValue(json, OAuth2AuthorizationRequest.class);
+        } catch (Exception e) {
+            log.error("OAuth2 AuthorizationRequest 삭제 실패", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/umc/linkyou/service/users/AuthCodeService.java
+++ b/src/main/java/com/umc/linkyou/service/users/AuthCodeService.java
@@ -17,15 +17,13 @@ public class AuthCodeService {
 
     public UserResponseDTO.TokenPair exchangeCode(String code) {
         String redisKey = AUTH_CODE_KEY + code;
-        String token = stringRedisTemplate.opsForValue().get(redisKey);
+        String token = stringRedisTemplate.opsForValue().getAndDelete(redisKey);
 
-        if (token == null) {
-            log.warn("AuthCodeService: 유효하지 않거나 만료된 code={}", code);
+        String[] tokens = token.split("::");
+        if (tokens.length != 2) {
+            log.error("AuthCodeService: Redis 토큰 형식 오류 code={}, token={}", code, token);
             throw new GeneralException(ErrorStatus._INVALID_AUTH_CODE);
         }
-
-        stringRedisTemplate.delete(redisKey); //1회용 즉시 삭제
-        String[] tokens = token.split("::");
         return new UserResponseDTO.TokenPair(tokens[0], tokens[1]);
 
     }

--- a/src/main/java/com/umc/linkyou/service/users/AuthCodeService.java
+++ b/src/main/java/com/umc/linkyou/service/users/AuthCodeService.java
@@ -1,0 +1,33 @@
+package com.umc.linkyou.service.users;
+
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.web.dto.UserResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthCodeService {
+    private final StringRedisTemplate stringRedisTemplate;
+    private static final String AUTH_CODE_KEY = "auth:code:";
+
+    public UserResponseDTO.TokenPair exchangeCode(String code) {
+        String redisKey = AUTH_CODE_KEY + code;
+        String token = stringRedisTemplate.opsForValue().get(redisKey);
+
+        if (token == null) {
+            log.warn("AuthCodeService: 유효하지 않거나 만료된 code={}", code);
+            throw new GeneralException(ErrorStatus._INVALID_AUTH_CODE);
+        }
+
+        stringRedisTemplate.delete(redisKey); //1회용 즉시 삭제
+        String[] tokens = token.split("::");
+        return new UserResponseDTO.TokenPair(tokens[0], tokens[1]);
+
+    }
+
+}

--- a/src/main/java/com/umc/linkyou/validation/annotation/ApiV1.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/ApiV1.java
@@ -1,0 +1,9 @@
+package com.umc.linkyou.validation.annotation;
+
+import org.springframework.web.bind.annotation.RestController;
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@RestController
+public @interface ApiV1 {}

--- a/src/main/java/com/umc/linkyou/validation/annotation/ApiV2.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/ApiV2.java
@@ -1,0 +1,9 @@
+package com.umc.linkyou.validation.annotation;
+
+import org.springframework.web.bind.annotation.RestController;
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@RestController
+public @interface ApiV2 {}

--- a/src/main/java/com/umc/linkyou/web/controller/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/UserController.java
@@ -10,6 +10,7 @@ import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.service.users.TermsAgreementService;
 import com.umc.linkyou.service.users.UserService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.EmailVerificationResponse;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
@@ -23,9 +24,10 @@ import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "user-controller", description = "사용자 관련 API")
 @Slf4j
+@ApiV1
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/users")
+@RequestMapping("/users")
 public class UserController {
 
     private final UserService userService;

--- a/src/main/java/com/umc/linkyou/web/controller/user/AuthCodeController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/AuthCodeController.java
@@ -1,0 +1,28 @@
+package com.umc.linkyou.web.controller.user;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.service.users.AuthCodeService;
+import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.dto.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name="auth-controller", description = "소셜로그인시 임시코드와 accessToken, refreshToken을 교환하는 api")
+@ApiV1
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthCodeController {
+    private final AuthCodeService authCodeService;
+
+    @Operation(
+            summary = "1회용 code를 request param으로 넣으면 accessToken + refreshToken으로 교환합니다. 30초 이내 1회만 사용 가능합니다."
+    )
+    @PostMapping("/token/exchange")
+    public ApiResponse<UserResponseDTO.TokenPair> exchangeCode(@RequestParam String code){
+        return ApiResponse.onSuccess(authCodeService.exchangeCode(code));
+    }
+}

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -1,4 +1,4 @@
-package com.umc.linkyou.web.controller;
+package com.umc.linkyou.web.controller.user;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;


### PR DESCRIPTION
## 🔗 관련 이슈
#240   #208

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- `@ApiV1` / `@ApiV2` 커스텀 어노테이션 기반 API 버전 관리 체계 도입
- `WebConfig.addPathPrefix()`로 컨트롤러 클래스 단위 버전 prefix 자동 적용
- `validation/annotation/` 패키지에 `ApiV1`, `ApiV2` 어노테이션 추가
- `web/controller/user/` 하위 패키지로 컨트롤러 구조 정리
- `ErrorStatus` 소셜 로그인 관련 에러 코드 prefix `USERS` → `OAUTH` 로 정리

### 2️⃣ Functional Requirement
- **딥링크 URL 토큰 직접 노출 문제 해결** — 단기 인증 코드 교환 방식 도입
  - 기존: `?accessToken=eyJ...&refreshToken=eyJ...` URL에 직접 노출
  - 변경: `?code=a1b2c3d4...` 30초 TTL 1회용 코드만 URL에 노출
  - `POST /api/v1/auth/token/exchange?code=` API로 실제 토큰 교환
- `OAuth2SuccessHandler` — Redis에 `auth:code:{uuid}` 키로 토큰 임시 저장 (TTL 30초)
- `AuthCodeService` 신규 추가 — 코드 검증, 1회용 삭제, 토큰 반환 로직
- `AuthCodeController` 신규 추가 — `POST /api/v1/auth/token/exchange`
- `hmac()` UTF-8 charset 고정 — `token.getBytes()` → `token.getBytes(StandardCharsets.UTF_8)`
- `SecurityConfig` permitAll 경로 `/api/users/**` → `/api/v1/users/**`, `/api/v1/auth/**` 추가
- `UserController` `@RequestMapping("api/users")` → `@RequestMapping("/users")` + `@ApiV1` 적용

---

## 🧪 테스트 결과
- [ ] `POST /api/v1/auth/token/exchange?code={code}` — 정상 코드 → `accessToken` + `refreshToken` 반환 확인
- [ ] 만료된 코드(30초 경과) → `OAUTH4007` 에러 반환 확인
- [ ] 동일 코드 2회 사용 → 1회 이후 `OAUTH4007` 에러 반환 확인
- [ ] 카카오 소셜 로그인 → 딥링크 URL에 `code`만 포함되는지 확인
- [ ] `POST /api/v1/users/login`, `GET /api/v1/users/me` 등 기존 API 정상 동작 확인

---

## 📸 스크린샷 (선택)
> Swagger UI에서 `/api/v1/auth/token/exchange` 엔드포인트 확인 후 첨부

---

## 📎 참고 사항
- `AUTH_CODE_TTL_SECONDS = 30L` 현재 하드코딩 → 추후 `application.properties`의 `auth.code.ttl-seconds`로 이전해야 할까요?
- 딥링크 보안 강화를 위해 Android 측 `App Links` (`android:autoVerify="true"`) 설정 별도 협의 필요
- validation\\annotation\\ApiV1.java 가져다가 version업데이트해야 해요 현재 user, oauth만 되어 있음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * API 버전(ApiV1/ApiV2) 적용으로 버전별 엔드포인트 지원
  * 일회용 인증 코드 교환용 엔드포인트(/auth/token/exchange) 추가 및 Redis 기반 코드 발급/교환 도입

* **개선 사항**
  * 소셜 로그인 오류 코드 체계 재정비(OAUTH 접두사, 신규 INVALID_AUTH_CODE)
  * OAuth2 로그인 흐름 및 세션 정책을 무상태(Stateless)로 조정하고 인증요청 영구화 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->