### PR TITLE
feat: #208 social login security err

### DIFF
--- a/src/main/java/com/umc/linkyou/config/security/jwt/CustomUserDetails.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/CustomUserDetails.java
@@ -11,11 +11,17 @@ import java.util.Collection;
 public class CustomUserDetails implements UserDetails {
 
     private Users users;
+    private String provider;
 
     public CustomUserDetails(Users users){
         this.users = users;
     }
 
+    public CustomUserDetails(Users users, String provider) {
+        this.users = users;
+        this.provider = provider;
+    }
+    public String getProvider() { return provider; }
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         Collection<GrantedAuthority> collection = new ArrayList<>();

--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
@@ -150,9 +150,10 @@ public class JwtTokenProvider {
     }
 
     // 액세스 토큰 생성 (subject 기반)
-    public String createAccessToken(String subject) {
+    public String createAccessToken(String subject, String provider) {
         return Jwts.builder()
                 .setSubject(subject)
+                .claim("provider", provider)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/config/security/jwt/JwtTokenProvider.java
@@ -77,11 +77,12 @@ public class JwtTokenProvider {
         Claims claims = validateAndParseAccess(token).getBody();
         String email = claims.getSubject();
         // String role = claims.get("role", String.class);
+        String provider = claims.get("provider", String.class);
 
         // Users users = ... // 이메일로 Users 엔티티 조회
         Users users = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("해당 이메일을 가진 유저가 존재하지 않습니다: " + email));
-        CustomUserDetails principal = new CustomUserDetails(users);
+        CustomUserDetails principal = new CustomUserDetails(users,provider);
 
         return new UsernamePasswordAuthenticationToken(principal, token, principal.getAuthorities());
     }

--- a/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
+++ b/src/main/java/com/umc/linkyou/domain/UserRefreshToken.java
@@ -19,12 +19,15 @@ public class UserRefreshToken {
     @Indexed
     private Long userId;
 
+    private String provider;
+
     @TimeToLive(unit = TimeUnit.MILLISECONDS)
     private Long ttl;
 
-    public UserRefreshToken(String refreshToken, Long userId, Long ttl) {
+    public UserRefreshToken(String refreshToken, Long userId, String provider, Long ttl) {
         this.refreshToken = refreshToken;
         this.userId = userId;
+        this.provider = provider;
         this.ttl = ttl;
     }
 }

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -1,11 +1,14 @@
 package com.umc.linkyou.oauth;
 
 import com.umc.linkyou.config.security.jwt.JwtTokenProvider;
+import com.umc.linkyou.domain.AuthAccount;
 import com.umc.linkyou.domain.UserRefreshToken;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.Provider;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.oauth.utils.CustomOAuth2User;
 import com.umc.linkyou.repository.UserRefreshTokenRepository;
+import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -33,6 +36,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private final UserRepository userRepository;
     private final UserRefreshTokenRepository userRefreshTokenRepository;
     private final StringRedisTemplate stringRedisTemplate;
+    private final AuthAccountRepository authAccountRepository;
 
     @Value("${app.deeplink.base-url}")
     private String deepLinkBaseUrl;
@@ -52,24 +56,27 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
         String email = oAuth2User.getEmail();
-        String requestUri = request.getRequestURI();
-        String provider = extractProvider(requestUri);
+        String externalId = oAuth2User.getExternalId();
+        String provider   = oAuth2User.getProvider();
 
-        Optional<Users> userOpt = userRepository.findByEmail(email);
-        if (userOpt.isEmpty()) {
+        Optional<AuthAccount> authAccountOpt = authAccountRepository
+                .findByProviderAndExternalId(Provider.valueOf(provider), externalId);
+
+        if (authAccountOpt.isEmpty()) {
+            log.warn("AuthAccount not found: provider={}, externalId={}", provider, externalId);
             response.sendRedirect(String.format(
                     "%s/auth?provider=%s&result=FAIL&errorCode=USER_NOT_FOUND",
                     deepLinkBaseUrl, provider));
             return;
         }
 
-        Users user = userOpt.get();
+        Users user = authAccountOpt.get().getUser();
         String redirectUrl;
 
         try {
             if (user.getStatus() == UserStatus.TEMP) {
                 // TEMP: socialToken은 추가정보 입력용 → 보안 민감도 낮아서 기존 유지
-                String socialToken = jwtTokenProvider.createAccessToken(email);
+                String socialToken = jwtTokenProvider.createAccessToken(email, provider);
                 redirectUrl = String.format(
                         "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
                         deepLinkBaseUrl, provider,
@@ -77,7 +84,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 );
 
             } else if (user.getStatus() == UserStatus.ACTIVE) {
-                String accessToken  = jwtTokenProvider.createAccessToken(email);
+                String accessToken  = jwtTokenProvider.createAccessToken(email, provider);
                 String refreshToken = jwtTokenProvider.createRefreshToken(email);
 
                 // refreshToken 화이트리스트 저장

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -91,8 +91,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 userRefreshTokenRepository.findByUserId(user.getId())
                         .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
                 String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
-                userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
-
+                userRefreshTokenRepository.save(
+                        new UserRefreshToken(id, user.getId(), provider, refreshTtlMs) // provider = "KAKAO", "GOOGLE"
+                );
                 // 1회용 코드 생성 → Redis에 토큰 임시 저장 (30초 TTL)
                 String code = UUID.randomUUID().toString().replace("-", "");
                 String redisKey = "auth:code:" + code;

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -27,6 +27,22 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * OAuth2 인증 성공 후 처리 플로우
+ *
+ * ① CustomOAuth2User에서 email, externalId, provider 추출 (소셜 프로필 기반)
+ * ② provider null/blank 체크 → 실패 시 FAIL/INVALID_PROVIDER 리다이렉트
+ * ③ Provider.valueOf()로 enum 변환 → 알 수 없는 provider면 FAIL/INVALID_PROVIDER 리다이렉트
+ * ④ externalId null/blank 체크 → 실패 시 FAIL/INVALID_EXTERNAL_ID 리다이렉트
+ * ⑤ (provider + externalId)로 AuthAccount 조회 → 없으면 FAIL/USER_NOT_FOUND 리다이렉트
+ * ⑥ DB에서 확정된 Users 레코드 추출 → confirmedEmail 사용 (소셜 프로필 email 대신)
+ * ⑦ UserStatus 분기
+ *    - TEMP   : socialToken 발급 → 추가 프로필 입력 페이지로 리다이렉트
+ *    - ACTIVE : accessToken + refreshToken 발급 → 1회용 code(30초 TTL)로 간접 전달
+ *    - 그 외  : FAIL/INACTIVE_USER 리다이렉트
+ * ⑧ 예외 발생 시 FAIL/TOKEN_GENERATION_FAILED 리다이렉트
+ */
+
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -75,6 +91,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     deepLinkBaseUrl, provider));
             return;
         }
+        if (externalId == null || externalId.isBlank()) {
+            log.warn("OAuth2SuccessHandler: externalId is null or blank, provider={}, email={}", provider, email);
+            response.sendRedirect(String.format(
+                    "%s/auth?provider=%s&result=FAIL&errorCode=INVALID_EXTERNAL_ID",
+                    deepLinkBaseUrl, provider));
+            return;
+        }
 
         Optional<AuthAccount> authAccountOpt = authAccountRepository
                 .findByProviderAndExternalId(providerEnum, externalId);
@@ -88,12 +111,13 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         }
 
         Users user = authAccountOpt.get().getUser();
+        String confirmedEmail = user.getEmail();
         String redirectUrl;
 
         try {
             if (user.getStatus() == UserStatus.TEMP) {
                 // TEMP: socialToken은 추가정보 입력용 → 보안 민감도 낮아서 기존 유지
-                String socialToken = jwtTokenProvider.createAccessToken(email, provider);
+                String socialToken = jwtTokenProvider.createAccessToken(confirmedEmail, provider);
                 redirectUrl = String.format(
                         "%s/auth?provider=%s&result=SUCCESS&status=TEMP&socialToken=%s",
                         deepLinkBaseUrl, provider,
@@ -101,8 +125,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 );
 
             } else if (user.getStatus() == UserStatus.ACTIVE) {
-                String accessToken  = jwtTokenProvider.createAccessToken(email, provider);
-                String refreshToken = jwtTokenProvider.createRefreshToken(email);
+                String accessToken  = jwtTokenProvider.createAccessToken(confirmedEmail, provider);
+                String refreshToken = jwtTokenProvider.createRefreshToken(confirmedEmail);
 
                 // refreshToken 화이트리스트 저장
                 userRefreshTokenRepository.findByUserId(user.getId())

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2SuccessHandler.java
@@ -58,9 +58,26 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         String email = oAuth2User.getEmail();
         String externalId = oAuth2User.getExternalId();
         String provider   = oAuth2User.getProvider();
+        if (provider == null || provider.isBlank()) {
+            log.warn("OAuth2SuccessHandler: provider is null or blank, email={}", email);
+            response.sendRedirect(String.format(
+                    "%s/auth?provider=unknown&result=FAIL&errorCode=INVALID_PROVIDER",
+                    deepLinkBaseUrl));
+            return;
+        }
+        Provider providerEnum;
+        try {
+            providerEnum = Provider.valueOf(provider);
+        } catch (IllegalArgumentException e) {
+            log.warn("OAuth2SuccessHandler: unknown provider={}, email={}", provider, email);
+            response.sendRedirect(String.format(
+                    "%s/auth?provider=%s&result=FAIL&errorCode=INVALID_PROVIDER",
+                    deepLinkBaseUrl, provider));
+            return;
+        }
 
         Optional<AuthAccount> authAccountOpt = authAccountRepository
-                .findByProviderAndExternalId(Provider.valueOf(provider), externalId);
+                .findByProviderAndExternalId(providerEnum, externalId);
 
         if (authAccountOpt.isEmpty()) {
             log.warn("AuthAccount not found: provider={}, externalId={}", provider, externalId);

--- a/src/main/java/com/umc/linkyou/oauth/OAuth2UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/oauth/OAuth2UserServiceImpl.java
@@ -79,7 +79,7 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
         boolean isNewUser = user.getStatus() == UserStatus.TEMP;
 
         //OAuth 객체 반환
-        return createCustomOAuth2User(user, oAuth2User, isNewUser);
+        return createCustomOAuth2User(user, oAuth2User, isNewUser, externalId, provider);
     }
 
 
@@ -201,14 +201,15 @@ public class OAuth2UserServiceImpl implements OAuth2UserService<OAuth2UserReques
     }
 
     /**Spring Security에 저잫할 Oauth 객체 생성*/
-    private CustomOAuth2User createCustomOAuth2User(Users user, OAuth2User oAuth2User, boolean isNewUser) {
+    private CustomOAuth2User createCustomOAuth2User(Users user, OAuth2User oAuth2User, boolean isNewUser
+            ,String externalId, Provider provider) {
         Map<String, Object> attributes = new HashMap<>(oAuth2User.getAttributes());
         if (isNewUser) {
             attributes.put("needsTermsAgreement", true);
         }
         return new CustomOAuth2User(
                 Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name())),
-                attributes, "email", user.getEmail()
+                attributes, "email", user.getEmail(), externalId, provider.name()
         );
     }
 

--- a/src/main/java/com/umc/linkyou/oauth/utils/CustomOAuth2User.java
+++ b/src/main/java/com/umc/linkyou/oauth/utils/CustomOAuth2User.java
@@ -12,17 +12,23 @@ public class CustomOAuth2User implements OAuth2User {
     private final Map<String, Object> attributes;
     private final String nameAttributeKey;
     private final String email;
+    private final String externalId;
+    private final String provider;
 
     public CustomOAuth2User(
             Collection<? extends GrantedAuthority> authorities,
             Map<String, Object> attributes,
             String nameAttributeKey,
-            String email
+            String email,
+            String externalId,
+            String provider
     ) {
         this.authorities = authorities;
         this.attributes = attributes;
         this.nameAttributeKey = nameAttributeKey;
         this.email = email;
+        this.externalId = externalId;
+        this.provider = provider;
     }
 
     @Override
@@ -43,4 +49,6 @@ public class CustomOAuth2User implements OAuth2User {
     public String getEmail() {
         return email;
     }
+    public String getExternalId() { return externalId; }
+    public String getProvider() { return provider; }
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -18,7 +18,7 @@ public interface UserService {
     void validateNickNameNotDuplicate(String nickname);
 
     // 마이페이지 조회
-    UserResponseDTO.UserProfileSummaryDto userInfo(Long id);
+    UserResponseDTO.UserProfileSummaryDto userInfo(Long userId, String loginProvider);
 
     // 마이페이지 수정
     void updateUserProfile(Long userId, UserRequestDTO.UpdateProfileDTO updateDTO);

--- a/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
@@ -195,15 +195,16 @@ public class UserServiceImpl implements UserService {
                 Collections.singleton(() -> user.getRole().name())
         );
 
-        String accessToken = jwtTokenProvider.generateToken(authentication);
+        String accessToken = jwtTokenProvider.createAccessToken(user.getEmail(), Provider.GENERAL.name());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getEmail());
 
         // 리프레시 토큰이 이미 있으면 토큰을 갱신하고 없으면 토큰을 추가
         userRefreshTokenRepository.findByUserId(user.getId())
                 .ifPresent(t -> userRefreshTokenRepository.deleteById(t.getRefreshToken()));
         String id = hmac(jwtTokenProvider.normalizeStrict(refreshToken));
-        userRefreshTokenRepository.save(new UserRefreshToken(id, user.getId(), refreshTtlMs));
-
+        userRefreshTokenRepository.save(
+                new UserRefreshToken(id, user.getId(), Provider.GENERAL.name(), refreshTtlMs)
+        );
         return UserConverter.toLoginResultDTO(user, accessToken, refreshToken);
     }
 
@@ -306,14 +307,20 @@ public class UserServiceImpl implements UserService {
         var saved = userRefreshTokenRepository.findById(oldId)
                 .orElseThrow(() -> new UserHandler(ErrorStatus._UNAUTHORIZED));
 
-        // 4) (권장) 로테이션: 이전 토큰 삭제 → 새 토큰 저장(※ DB 접근 없음)
+        // 저장된 provider 꺼내기
+        String provider = saved.getProvider() != null
+                ? saved.getProvider()
+                : Provider.GENERAL.name(); // null 방어 (기존 레코드 호환)
+
         String newRefresh = jwtTokenProvider.createRefreshToken(email);
         String newId = hmac(jwtTokenProvider.normalizeStrict(newRefresh));
         userRefreshTokenRepository.deleteById(oldId);
-        userRefreshTokenRepository.save(new UserRefreshToken(newId, saved.getUserId(), refreshTtlMs));
+        userRefreshTokenRepository.save(
+                new UserRefreshToken(newId, saved.getUserId(), provider, refreshTtlMs) // provider 유지
+        );
 
-        // 5) 새 Access 발급
-        String newAccess = jwtTokenProvider.createAccessToken(email, Provider.GENERAL.name());
+        // 원래 provider로 재발급
+        String newAccess = jwtTokenProvider.createAccessToken(email, provider);
         return new UserResponseDTO.TokenPair(newAccess, newRefresh);
     }
 
@@ -407,13 +414,16 @@ public class UserServiceImpl implements UserService {
 
     // 마이페이지 조회
     @Override
-    public UserResponseDTO.UserProfileSummaryDto userInfo(Long userId){
+    public UserResponseDTO.UserProfileSummaryDto userInfo(Long userId, String loginProvider) {
         UserResponseDTO.UserProfileSummaryDto s = userQueryRepository.findUserProfileSummary(userId);
         List<String> purposes  = purposeRepository.findAllPurposeNamesByUserId(userId);
         List<String> interests = interestRepository.findAllInterestNamesByUserId(userId);
 
-        return UserConverter.toUserInfoDTO(s, purposes, interests);
+        UserResponseDTO.UserProfileSummaryDto result = UserConverter.toUserInfoDTO(s, purposes, interests);
+        result.setLoginProvider(loginProvider);
+        return result;
     }
+
 
     // 마이페이지 수정
     @Override

--- a/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.EmailVerification;
 import com.umc.linkyou.domain.UserRefreshToken;
 import com.umc.linkyou.domain.enums.Gender;
+import com.umc.linkyou.domain.enums.Provider;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.domain.folder.Fcolor;
 import com.umc.linkyou.domain.folder.Folder;
@@ -312,7 +313,7 @@ public class UserServiceImpl implements UserService {
         userRefreshTokenRepository.save(new UserRefreshToken(newId, saved.getUserId(), refreshTtlMs));
 
         // 5) 새 Access 발급
-        String newAccess = jwtTokenProvider.createAccessToken(email);
+        String newAccess = jwtTokenProvider.createAccessToken(email, Provider.GENERAL.name());
         return new UserResponseDTO.TokenPair(newAccess, newRefresh);
     }
 

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -99,8 +99,9 @@ public class UserController {
     )
     @GetMapping("/me")
     public ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long newUserId = userDetails.getUsers().getId();  //보안 문제 때문에 추가함
-        return ApiResponse.onSuccess(userService.userInfo(newUserId));
+        Long userId = userDetails.getUsers().getId();
+        String loginProvider = userDetails.getProvider();
+        return ApiResponse.onSuccess(userService.userInfo(userId,loginProvider));
     }
 
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -99,7 +99,7 @@ public class UserController {
     )
     @GetMapping("/me")
     public ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        Long userId = userDetails.getUsers().getId();
+        Long userId = usersUtils.getAuthenticatedUserId(userDetails);
         String loginProvider = userDetails.getProvider();
         return ApiResponse.onSuccess(userService.userInfo(userId,loginProvider));
     }

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -82,7 +82,9 @@ public class UserResponseDTO {
         private final Job job;
         private final Long myLinku;
         private final Long myFolder;
-        private final Long myAiLinku;   // Boolean → Long
+        private final Long myAiLinku;
+        @Setter
+        private String loginProvider;
         private List<String> purposes;
         private List<String> interests;
 
@@ -104,6 +106,7 @@ public class UserResponseDTO {
             this.myAiLinku  = aiLinkCount;   // 여기서 Long 그대로 대입
             this.purposes   = java.util.Collections.emptyList();
             this.interests  = java.util.Collections.emptyList();
+            this.loginProvider = null;
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
#208

---

## 📌 작업 내용
> OAuth2 소셜 로그인의 이메일 기반 계정 조회 보안 취약점 수정 및 로그인 방식 식별 기능 추가

### 1️⃣ Non-Functional Requirement
- `CustomOAuth2User`에 `externalId`, `provider` 필드 추가하여 소셜 계정 식별 구조 개선
- `OAuth2SuccessHandler` 이메일 기반 조회 → `externalId` 기반 조회로 교체 (보안 강화)
- `SessionCreationPolicy.IF_REQUIRED` → `STATELESS`로 변경 (JWT 서버에 맞는 세션 정책 적용)
- `HttpSessionOAuth2AuthorizationRequestRepository` 명시하여 STATELESS 환경에서 OAuth2 state 검증 유지

### 2️⃣ Functional Requirement
- `Provider` enum에 `GENERAL` 추가 (일반 로그인 식별)
- `JwtTokenProvider.createAccessToken(email, provider)` — `provider` 클레임 포함한 액세스 토큰 발급
- 일반 로그인(`loginUser`) 및 토큰 재발급(`reissueRefreshToken`)에 `Provider.GENERAL` 적용

---

## 🧪 테스트 결과

- [ ] JWT `provider` 클레임 포함 여부 확인-> 회원정보 반환에서
- [ ] STATELESS 전환 후 소셜 로그인 정상 동작 확인

---


## 📎 참고 사항

- **보안 이슈**: 기존 코드는 소셜 로그인 시 `email`로만 계정을 조회하여, 동일 이메일로 일반 가입한 계정으로 로그인이 가능한 취약점 존재 → `externalId` 기반 조회로 수정
- **계정 연동 정책**: 동일 이메일 + 다른 소셜 계정 시 기존 `Users`에 `AuthAccount` 추가 연동 (자동 병합)되며, 향후 연동 해제 기능 확장 가능
- **STATELESS + OAuth2 공존**: `STATELESS` 세션 정책이더라도 `HttpSessionOAuth2AuthorizationRequestRepository`를 명시하면 OAuth2 state 파라미터 검증이 정상 동작함


참고자료
> https://turtle0204.tistory.com/entry/OAuth2-%EC%86%8C%EC%85%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EC%9D%B4%EB%A9%94%EC%9D%BC-%EA%B8%B0%EC%A4%80-%EC%A1%B0%ED%9A%8C-%ED%9B%84-%EB%B3%91%ED%95%A9-%EB%B3%B4%EC%95%88-%EC%B7%A8%EC%95%BD%EC%A0%90-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 소셜 로그인 시 공급자(provider) 정보가 액세스 토큰과 사용자 프로필에 포함됩니다.
  * 외부 계정(externalId) 기반 연동과 1회 코드 방식의 리다이렉트가 추가되었습니다.

* **개선사항**
  * 리프레시 토큰 및 로그인·재발급 흐름이 공급자 단위로 관리되어 다중 OAuth 공급자 사용 시 일관성 향상.
  * 사용자 요약에 로그인 공급자 정보(loginProvider)가 노출되어 공급자 맥락을 확인 가능.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->