### PR TITLE
Refactor/#240 api versioning

### DIFF
--- a/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
+++ b/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
@@ -7,7 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@@ApiV1
+@ApiV1
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/s3")

--- a/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
+++ b/src/main/java/com/umc/linkyou/awsS3/controller/AwsS3Controller.java
@@ -1,11 +1,13 @@
 package com.umc.linkyou.awsS3.controller;
 
 import com.umc.linkyou.awsS3.AwsS3Service;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+@@ApiV1
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/s3")

--- a/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
@@ -7,6 +7,7 @@ import com.umc.linkyou.domain.AiArticle;
 import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.service.AiArticleService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.AiArticleResponsetDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,8 +16,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "ai-article-controller", description = "AI 기사 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/aiarticle")
+@RequestMapping("/aiarticle")
 @RequiredArgsConstructor
 public class AiArticleController {
 

--- a/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,9 +15,10 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "alarm-controller", description = "알림 관련 API")
+@ApiV1
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/alarm")
+@RequestMapping("/alarm")
 public class AlarmController {
 
     private final AlarmService alarmService;

--- a/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.category.CategoryService;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.category.CategoryListResponseDTO;
 import com.umc.linkyou.web.dto.category.UpdateCategoryColorRequestDTO;
 import com.umc.linkyou.web.dto.category.UserCategoryColorResponseDTO;
@@ -18,8 +19,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "category-controller", description = "카테고리 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/categories")
+@RequestMapping("/categories")
 @RequiredArgsConstructor
 public class CategoryController {
     private final CategoryService categoryService;

--- a/src/main/java/com/umc/linkyou/web/controller/CurationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CurationController.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.service.curation.CurationLikeService;
@@ -23,9 +24,10 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Tag(name = "curation-controller", description = "큐레이션 관련 API")
+@ApiV1
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/curations")
+@RequestMapping("/curations")
 public class CurationController {
 
     private final CurationTopLogService curationTopLogService;

--- a/src/main/java/com/umc/linkyou/web/controller/DeepLinkController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/DeepLinkController.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.validation.annotation.ApiV1;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/com/umc/linkyou/web/controller/DomainController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/DomainController.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.DomainConverter;
 import com.umc.linkyou.service.domain.DomainService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.DomainDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,8 +16,9 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "domain-controller", description = "도메인 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/domain")
+@RequestMapping("/domain")
 @RequiredArgsConstructor
 public class DomainController {
 

--- a/src/main/java/com/umc/linkyou/web/controller/FolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/FolderController.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.FolderService;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.folder.*;
 import com.umc.linkyou.web.dto.folder.linku.FolderLinkusResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,8 +17,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "folder-controller", description = "폴더 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/folders")
+@RequestMapping("/folders")
 @RequiredArgsConstructor
 public class FolderController {
     private final FolderService folderService;

--- a/src/main/java/com/umc/linkyou/web/controller/InvitationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/InvitationController.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.share.InvitationService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.folder.share.InvitationInfoResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -13,8 +14,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "invitation-controller", description = "초대 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/invitations")
+@RequestMapping("/invitations")
 @RequiredArgsConstructor
 public class InvitationController {
 

--- a/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
@@ -11,6 +11,7 @@ import com.umc.linkyou.service.Linku.LinkuRecommendService;
 import com.umc.linkyou.service.Linku.LinkuSearchService;
 import com.umc.linkyou.service.Linku.LinkuService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.linku.LinkuRequestDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import com.umc.linkyou.web.dto.linku.LinkuSearchSuggestionResponse;
@@ -27,8 +28,9 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Tag(name = "linku-controller", description = "링크(Linku) 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/linku")
+@RequestMapping("/linku")
 @RequiredArgsConstructor
 public class LinkuController {
 

--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.share.ShareFolderService;
 import com.umc.linkyou.utils.UsersUtils;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.folder.share.FolderPermissionRequestDTO;
 import com.umc.linkyou.web.dto.folder.share.ShareFolderRequestDTO;
 import com.umc.linkyou.web.dto.folder.share.ShareFolderResponseDTO;
@@ -21,8 +22,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "share-folder-controller", description = "폴더 공유 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/folders/share")
+@RequestMapping("/folders/share")
 @RequiredArgsConstructor
 public class ShareFolderController {
     private final ShareFolderService shareFolderService;

--- a/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.shared.SharedFolderService;
+import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.dto.folder.FolderListResponseDTO;
 import com.umc.linkyou.web.dto.folder.FolderResponseDTO;
 import com.umc.linkyou.web.dto.folder.FolderTreeResponseDTO;
@@ -19,8 +20,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "shared-folder-controller", description = "공유 받은 폴더 관련 API")
+@ApiV1
 @RestController
-@RequestMapping("/api/folders/shared")
+@RequestMapping("/folders/shared")
 @RequiredArgsConstructor
 public class SharedFolderController {
     private final SharedFolderService sharedFolderService;


### PR DESCRIPTION
## 🔗 관련 이슈
> #240

---

## 📌 작업 내용
>  API 버전 관리 체계 도입 — @ApiV1 / @ApiV2 어노테이션 기반 /api/v1, /api/v2 prefix 적용

--- 

## 📎 참고 사항 (선택)
> 딥링크 리디렉션 페이지는 경로 유지를 위해 versioning에서 제외했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 12개 컨트롤러의 공개 API 경로에서 `/api` 접두사를 제거하고 일관된 API 버전 어노테이션을 적용했습니다. 일부 컨트롤러는 경로 변경 없이 버전 어노테이션(또는 관련 import)만 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->