### PR TITLE
feat: #271 text-crawling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
+	//runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
 
-	//implementation 'com.mysql:mysql-connector-j'
+	implementation 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	//runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client:3.3.3'
 
-	implementation 'com.mysql:mysql-connector-j'
+	//implementation 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/umc/linkyou/service/BlogTextService.java
+++ b/src/main/java/com/umc/linkyou/service/BlogTextService.java
@@ -1,0 +1,85 @@
+package com.umc.linkyou.service;
+
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.infra.parser.TitleDomainParser;
+import com.umc.linkyou.infra.parser.WebContentExtractor;
+import com.umc.linkyou.web.dto.BlogTextResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.PrintWriter;
+import java.time.LocalDateTime;
+import java.util.List;
+
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BlogTextService {
+
+    private final WebContentExtractor webContentExtractor;
+    private final TitleDomainParser titleDomainParser;
+
+    public BlogTextResponseDTO getBlogText(String url) {
+        // 1. 도메인 및 제목 파싱 (robots.txt의 영향을 덜 받음)
+        TitleDomainParser.ParsedPageInfo pageInfo = titleDomainParser.parseUrl(url);
+
+        String cleanText;
+        try {
+            // 2. 본문 추출 시도
+            String rawText = webContentExtractor.extractTextFromUrl(url);
+            cleanText = rawText.replaceAll("[\r\n\t]", " ").replaceAll(" +", " ").trim();
+        } catch (GeneralException e) {
+            // robots.txt 차단(PROHIBITED)이나 추출 실패(FAILED) 시 처리
+            log.warn("[데이터셋 수집 보완] 본문 추출 불가로 제목/도메인 대체 → URL: {}, 사유: {}", url, e.getMessage());
+
+            // 제목이 있으면 제목을, 없으면 도메인을 본문 데이터로 대체 (학습용 최소 정보)
+            cleanText = (pageInfo.title() != null && !pageInfo.title().isBlank())
+                    ? "[본문추출불가] " + pageInfo.title()
+                    : "[본문추출불가] " + pageInfo.domain();
+        } catch (Exception e) {
+            cleanText = "[알수없는에러] " + url;
+        }
+
+        return BlogTextResponseDTO.builder()
+                .url(url)
+                .title(pageInfo.title() != null ? pageInfo.title() : "제목없음")
+                .domain(pageInfo.domain())
+                .cleanText(cleanText)
+                .textLength(cleanText.length())
+                .crawledAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void writeCsvDirectly(List<String> urls, PrintWriter writer) {
+        writer.println("URL,Title,Domain,CleanText,Length,CrawledAt");
+
+        for (String url : urls) {
+            try {
+                BlogTextResponseDTO data = getBlogText(url);
+
+                writer.printf("\"%s\",\"%s\",\"%s\",\"%s\",%d,\"%s\"\n",
+                        data.getUrl(),
+                        data.getTitle().replace("\"", "'"),
+                        data.getDomain(),
+                        data.getCleanText().replace("\"", "'"),
+                        data.getTextLength(),
+                        data.getCrawledAt());
+            } catch (Exception e) {
+                log.error("[CSV 작성 실패] URL: {}", url);
+                // e.getMessage()가 null일 경우를 대비해 "Unknown Error" 등으로 처리
+                String errorMessage = (e.getMessage() != null) ? e.getMessage().replace("\"", "'") : "Internal Server Error";
+                writer.printf("\"%s\",\"FAILED\",\"ERROR\",\"%s\",0,\"%s\"\n",
+                        url, errorMessage, LocalDateTime.now());
+            }
+        }
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        // 쌍따옴표를 홑따옴표로 바꾸거나 쌍따옴표 두 개("")로 만드는 방식 중 선택
+        // 여기서는 가장 안전한 홑따옴표 치환 방식을 사용합니다.
+        return value.replace("\"", "'");
+    }
+}

--- a/src/main/java/com/umc/linkyou/web/controller/BlogTextController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/BlogTextController.java
@@ -1,0 +1,56 @@
+package com.umc.linkyou.web.controller;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.service.BlogTextService;
+import com.umc.linkyou.web.dto.BlogTextRequestDTO;
+import com.umc.linkyou.web.dto.BlogTextResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/blogs/text")
+@Tag(name = "Dataset API", description = "KoBART 데이터셋 수집 전용 API (DB 저장 미사용)")
+public class BlogTextController {
+
+    private final BlogTextService blogTextService;
+
+    @PostMapping("/preview")
+    @Operation(summary = "단일 블로그 크롤링 미리보기", description = "저장 없이 본문 추출 결과만 JSON으로 확인합니다.")
+    public ApiResponse<BlogTextResponseDTO> previewBlogText(@RequestParam String url) {
+        return ApiResponse.onSuccess(blogTextService.getBlogText(url));
+    }
+
+    @Operation(
+            summary = "URL 리스트로 즉시 CSV 다운로드",
+            description = "입력된 URL 리스트를 크롤링하여 DB 저장 없이 즉시 CSV로 내뱉습니다."
+    )
+    @PostMapping(value = "/export") // produces = "text/csv"는 브라우저가 인식하도록 유지
+    public void exportDirectCsv(@RequestBody BlogTextRequestDTO request, HttpServletResponse response) throws IOException {
+
+        // 1. 파일 설정
+        String fileName = "blog_dataset_" + LocalDate.now() + ".csv";
+        response.setContentType("text/csv; charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        response.setHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
+
+        // 2. BOM 처리 (엑셀 한글 깨짐 방지 핵심)
+        response.getWriter().write('\ufeff');
+
+        // 3. 실시간 크롤링 및 CSV 작성
+        if (request.getUrls() != null && !request.getUrls().isEmpty()) {
+            blogTextService.writeCsvDirectly(request.getUrls(), response.getWriter());
+        }
+
+        response.getWriter().flush();
+        response.getWriter().close();
+        // void이므로 return ApiResponse... 를 하지 않습니다.
+    }
+}

--- a/src/main/java/com/umc/linkyou/web/dto/BlogTextRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/BlogTextRequestDTO.java
@@ -1,0 +1,25 @@
+package com.umc.linkyou.web.dto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "블로그 텍스트 수집 요청 객체")
+public class BlogTextRequestDTO {
+
+    @Schema(description = "수집할 블로그 URL", example = "https://blog.naver.com/example/123")
+    private String url;
+
+    @Schema(
+            description = "배치 수집용 URL 리스트 (최대 100개 권장)",
+            example = "[\"https://blog.naver.com/moki_allrecords/223527506604\", \"https://kimdee.tistory.com/entry/오픽-후기\", \"https://brunch.co.kr/@chlngers/512\"]"
+    )
+    private List<String> urls;
+}

--- a/src/main/java/com/umc/linkyou/web/dto/BlogTextResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/BlogTextResponseDTO.java
@@ -1,0 +1,33 @@
+package com.umc.linkyou.web.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "블로그 텍스트 수집 응답 객체")
+public class BlogTextResponseDTO {
+
+    @Schema(description = "원본 URL", example = "https://blog.naver.com/...")
+    private String url;
+
+    @Schema(description = "블로그 제목", example = "FastAPI와 KoBART 연동하기")
+    private String title;
+
+    @Schema(description = "출처 도메인", example = "blog.naver.com")
+    private String domain;
+
+    @Schema(description = "정제된 본문 텍스트 (학습용 데이터)", example = "오늘은 FastAPI를 활용해...")
+    private String cleanText;
+
+    @Schema(description = "본문 글자 수", example = "1250")
+    private int textLength;
+
+    @Schema(description = "수집 일시")
+    private LocalDateTime crawledAt;
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> closes # [이슈번호를 입력하세요]

---

## 📌 작업 내용
> KoBART 모델 파인튜닝을 위한 고품질 블로그 데이터셋 수집 API를 구축하였습니다. 
> 기획자 데이터 수집 편의성을 위해 DB 저장 없이 즉시 CSV로 추출하는 기능을 포함합니다.

### 1️⃣ Non-Functional Requirement
- **인프라 컴포넌트 재사용**: 기존 `WebContentExtractor`, `TitleDomainParser`를 활용하여 일관된 크롤링 로직 적용
- **데이터 무결성 및 정제**: CSV 저장 시 행 밀림 방지를 위해 줄바꿈(`\n`), 탭(`\t`), 쌍따옴표(`"`)를 공백 및 홑따옴표로 자동 치환
- **인코딩 최적화**: UTF-8 BOM(`\ufeff`) 설정을 통해 엑셀(Excel)에서 별도 설정 없이 한글이 바로 노출되도록 개선

### 2️⃣ Functional Requirement
- **실시간 데이터셋 추출 API**: URL 리스트 입력 시 즉시 크롤링 후 CSV 파일 반환 (`POST /api/blogs/text/export`)
- **수집 미리보기 API**: 단일 URL에 대해 본문 추출 결과를 JSON으로 즉시 확인 (`POST /api/blogs/text/preview`)
- **강력한 예외 처리**: `robots.txt` 차단 또는 크롤링 실패 시 프로세스를 중단하지 않고 해당 행에 에러 메시지를 기록하며 완주하도록 설계
- **Swagger 편의성 개선**: `BlogTextRequestDTO` 내 실무 데이터 기반의 Example Value를 적용하여 기획자 테스트 편의성 증대

---

## 🧪 테스트 결과
- **Swagger 배치 테스트**: 20개 이상의 다양한 도메인(Naver, Tistory, Brunch 등) URL 리스트 전송 시 정상 동작 확인
- **엑셀 인코딩 검증**: 다운로드된 CSV 파일을 Windows Excel 2021 및 메모장에서 열었을 때 한글 깨짐 없음 확인
- **에러 핸들링**: 본문 추출이 불가능한 URL의 경우 제목/도메인 정보를 Fallback 데이터로 삽입하여 데이터 손실 최소화

---

## 📸 스크린샷 (선택)
---

## 📎 참고 사항 (선택)
- **성능 관련**: 현재 순차 크롤링 방식이므로, 대량의 URL(100개 이상) 요청 시 응답 시간이 길어질 수 있습니다. (추후 병렬 처리 도입 검토 예정)
- **기획자 가이드**: `cleanText` 열의 데이터를 모델 학습에 직접 사용하므로, 광고성 문구가 포함된 데이터는 기획 단계에서 필터링 후 사용 권장합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 블로그 URL의 본문 텍스트를 추출하고 미리보기할 수 있습니다.
  * 여러 블로그의 정보(제목, 도메인, 정제된 본문)를 CSV 파일로 일괄 내보낼 수 있습니다.
  * 추출 실패 시 도메인 또는 제목으로 대체 정보를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->