### PR TITLE
Refactor/#233 security apiusers permitall

### DIFF
--- a/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
+++ b/src/main/java/com/umc/linkyou/config/security/SecurityConfig.java
@@ -24,12 +24,6 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-//    private final OAuth2UserServiceImpl oAuth2UserService;
-//    private final OAuth2TokenClient oAuth2TokenClient;
-//    @Lazy
-//    private final OAuth2SuccessHandler oAuth2SuccessHandler;
-//    private final RedisAuthorizationRequestRepository redisAuthorizationRequestRepository;
-
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,8 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 "/", "/css/**",
-                                "/api/v1/users/**",
-                                "/api/v1/auth/token/exchange",
+                                "/api/v1/auth/**",
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/*.well-known/**",
                                 "/open/**",

--- a/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
     private final UsersUtils usersUtils;
 
     @Operation(summary = "회원 가입 (이메일)", description = "이메일을 통해 회원가입을 진행합니다.")
-    @PostMapping("/signup/email")
+    @PostMapping("/signup")
     public ApiResponse<UserResponseDTO.JoinResultDTO> join(@RequestBody @Valid UserRequestDTO.JoinDTO request){
         Users user = userService.joinUser(request);
         return ApiResponse.onSuccess(UserConverter.toJoinResultDTO(user));
@@ -47,15 +47,6 @@ public class AuthController {
         return ApiResponse.onSuccess(userService.reissueRefreshToken(refreshToken));
     }
 
-    @Operation(summary = "소셜 프로필 완성", description = "소셜 로그인 후 TEMP 상태 사용자의 추가 정보를 입력합니다.")
-    @PatchMapping("/signup/social/profile")
-    public ApiResponse<UserResponseDTO.JoinResultDTO> completeSocialProfile(
-            @RequestBody @Valid UserRequestDTO.SocialCompleteDTO request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        Users user = usersUtils.validateTempUser(userDetails);
-        Users updatedUser = userService.socialCompleteProfile(user, request);
-        return ApiResponse.onSuccess(UserConverter.toJoinResultDTO(updatedUser));
-    }
 
     @Operation(summary = "이메일 인증 코드 전송")
     @PostMapping("/email/code")

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -37,65 +37,6 @@ public class UserController {
     private final TermsAgreementService termsAgreementService;
 
     @Operation(
-            summary = "회원 가입",
-            description = "새로운 사용자를 등록합니다. 이메일, 비밀번호, 닉네임, 성별(남자1,여자2), 직업, 목적, 관심사 등을 입력받습니다."
-    )
-    @PostMapping("/join")
-    public ApiResponse<UserResponseDTO.JoinResultDTO> join(@RequestBody @Valid UserRequestDTO.JoinDTO request){
-        Users user = userService.joinUser(request);
-        return ApiResponse.onSuccess(UserConverter.toJoinResultDTO(user));
-    }
-
-    @Operation(
-            summary = "유저 로그인",
-            description = "이메일과 비밀번호로 로그인합니다. 성공 시 Access Token과 Refresh Token을 반환합니다."
-    )
-    @PostMapping("/login")
-    public ApiResponse<UserResponseDTO.LoginResultDTO> login(@RequestBody @Valid UserRequestDTO.LoginRequestDTO request) {
-        return ApiResponse.onSuccess(userService.loginUser(request));
-    }
-
-    @Operation(
-            summary = "토큰 재발급",
-            description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다."
-    )
-    @PostMapping("/reissue")
-    public ApiResponse<UserResponseDTO.TokenPair> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        return ApiResponse.onSuccess(userService.reissueRefreshToken(refreshToken));
-    }
-
-    @Operation(
-            summary = "닉네임 중복 확인",
-            description = "입력한 닉네임이 이미 사용 중인지 확인합니다."
-    )
-    @GetMapping("/check-nickname")
-    public ApiResponse<String> checkNickname(@RequestParam String nickname) {
-        userService.validateNickNameNotDuplicate(nickname);
-        return ApiResponse.of(SuccessStatus._NICKNAME_AVAILABLE, "사용 가능한 닉네임 입니다.");
-    }
-
-    @Operation(
-            summary = "이메일 인증 코드 전송",
-            description = "입력한 이메일 주소로 인증 코드를 전송합니다."
-    )
-    @PostMapping("/emails/code")
-    public ApiResponse<String> sendCode(@RequestParam("email") @Valid String email) {
-        userService.sendCode(email);
-        return ApiResponse.of(SuccessStatus._VERIFICATION_CODE_SENT, "이메일로 인증 코드가 전송되었습니다.");
-    }
-
-    @Operation(
-            summary = "이메일 인증 코드 검증",
-            description = "전송받은 인증 코드를 검증합니다."
-    )
-    @GetMapping("/emails/verify")
-    public ApiResponse<EmailVerificationResponse> verifyCode(@RequestParam("email") @Valid String email,
-                                                             @RequestParam("code") String authCode) {
-        EmailVerificationResponse response = userService.verifyCode(email, authCode);
-        return ApiResponse.of(SuccessStatus._EMAIL_VERIFICATION_SUCCESS, response);
-    }
-
-    @Operation(
             summary = "마이페이지 조회",
             description = "사용자의 프로필 정보를 조회합니다."
     )


### PR DESCRIPTION
## 🔗 관련 이슈
- closes [#233]

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- Spring Security 설정에서 `/api/v1/users/**` 경로에 일괄적으로 적용되어 있던 `permitAll` 정책을 제거하고, 최소 권한 원칙에 맞게 설정 구조를 정리했습니다.  
- 인증이 불필요한 엔드포인트(회원가입, 로그인 등)만 명시적으로 `permitAll`로 허용하도록 설정을 분리하여, 보안 설정 가독성과 유지보수성을 개선했습니다.  

### 2️⃣ Functional Requirement
- `/api/v1/users/**` 하위 API가 더 이상 무분별하게 공개되지 않도록 수정하여, 회원 정보 조회/수정 등 민감한 API는 JWT 인증이 필수로 동작하도록 변경했습니다.  
- 인증이 필요 없는 공개 API(`/api/v1/auth/join`, `/api/v1/auth/login`, `/api/v1/auth/email/verify` 등)는 기존 동작을 유지하면서 명시적으로 `permitAll`을 적용해 클라이언트 영향 없이 보안을 강화했습니다.  
- 향후 추가될 사용자 관련 API도 기본적으로 인증이 요구되도록 기본 정책을 `anyRequest().authenticated()` 중심으로 정리했습니다.  

---

## 🧪 테스트 결과
안함
---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **API 변경사항**
  * 인증 관련 API 엔드포인트가 재구성되었습니다.
  * 이메일 가입 엔드포인트의 경로가 변경되었습니다.
  * 소셜 프로필 완성 기능이 제거되었습니다.
  * 인증 요청의 허용 범위가 확대되어 더 많은 인증 관련 요청이 추가 검증 없이 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->