### PR TITLE
Feature/#295 withdraw rollback

### DIFF
--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -146,9 +146,6 @@ public class UserService {
                 .orElseThrow(() -> new UserHandler(UserErrorStatus._LOGIN_FAILED));
 
         Long userId = user.getId();
-        if (user.getStatus() == UserStatus.INACTIVE) {
-            throw new GeneralException(UserErrorStatus._USER_INACTIVE); // INACTIVE 유저는 로그인 불가
-        }
         // 소셜 전용 계정 차단 (GENERAL AuthAccount 없음)
         boolean hasGeneralAccount = authAccountRepository.existsByUserIdAndProvider(
                 user.getId(), Provider.GENERAL);

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -18,7 +18,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-
+import java.time.temporal.ChronoUnit;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,6 +30,9 @@ public class UserWithdrawService{
     private final UserRepository userRepository;
     private final RefreshTokenManager refreshTokenManager;
     private final AuthAccountRepository authAccountRepository;
+
+    // 탈퇴 유예 기간
+    private static final int GRACE_PERIOD_DAYS = 14;
 
     @Transactional
     public Users withdrawUser(Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO) {
@@ -56,6 +59,11 @@ public class UserWithdrawService{
         if (user.getStatus() != UserStatus.INACTIVE) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST); // 이미 활성 상태인 경우
         }
+        // 2. inactiveDate가 null이거나 14일이 경과했는지 확인
+        LocalDateTime inactiveDate = user.getInactiveDate();
+        if (inactiveDate == null || ChronoUnit.DAYS.between(inactiveDate, LocalDateTime.now()) > GRACE_PERIOD_DAYS) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
+        }
         // 상태 및 탈퇴 관련 필드 초기화
         user.setStatus(UserStatus.ACTIVE);
         user.setInactiveDate(null);
@@ -68,8 +76,8 @@ public class UserWithdrawService{
     @Scheduled(cron = "0 0 3 * * ?")
     @Transactional
     public void deleteCompletelyInactiveUsers() {
-        LocalDateTime DaysAgo = LocalDateTime.now().minusDays(14);
-        List<Long> inactiveUserIds = userRepository.findInactiveUserIds(DaysAgo);
+        LocalDateTime daysAgo = LocalDateTime.now().minusDays(GRACE_PERIOD_DAYS);
+        List<Long> inactiveUserIds = userRepository.findInactiveUserIds(daysAgo);
 
         if (inactiveUserIds.isEmpty()) {
             log.debug("삭제할 비활성 사용자 없음");

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -43,12 +43,33 @@ public class UserWithdrawService{
         userRepository.save(user);
         return user;
     }
-    //30 일 이후 삭제
+
+    /**
+     * 회원 탈퇴 복구 API
+     * INACTIVE 상태의 사용자를 다시 ACTIVE로 전환합니다.
+     */
+    @Transactional
+    public Users recoverUser(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+
+        if (user.getStatus() != UserStatus.INACTIVE) {
+            throw new GeneralException(ErrorStatus._BAD_REQUEST); // 이미 활성 상태인 경우
+        }
+        // 상태 및 탈퇴 관련 필드 초기화
+        user.setStatus(UserStatus.ACTIVE);
+        user.setInactiveDate(null);
+        user.setDeleted_reason(null);
+
+        return userRepository.save(user);
+    }
+
+    //14 일 이후 삭제
     @Scheduled(cron = "0 0 3 * * ?")
     @Transactional
     public void deleteCompletelyInactiveUsers() {
-        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
-        List<Long> inactiveUserIds = userRepository.findInactiveUserIds(thirtyDaysAgo);
+        LocalDateTime DaysAgo = LocalDateTime.now().minusDays(14);
+        List<Long> inactiveUserIds = userRepository.findInactiveUserIds(DaysAgo);
 
         if (inactiveUserIds.isEmpty()) {
             log.debug("삭제할 비활성 사용자 없음");

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "user-controller", description = "사용자 마이페이지 및 설정 관련 API")
 @RequestMapping("/users")
 public interface UserApi {
-
+    // 회원정보 조회
     @Operation(
             summary = "마이페이지 조회",
             description = """
@@ -29,11 +29,13 @@ public interface UserApi {
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(errorStatus = {ErrorStatus._UNAUTHORIZED, ErrorStatus._INTERNAL_SERVER_ERROR})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @GetMapping("/me")
     ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails);
 
+    // 회원정보 수정
     @Operation(
             summary = "마이페이지 수정",
             description = """
@@ -50,21 +52,8 @@ public interface UserApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.UpdateProfileDTO updateDTO);
 
-    @Operation(
-            summary = "회원 탈퇴 (비활성화)",
-            description = """
-                    사용자 계정을 비활성화(INACTIVE) 처리합니다.
-                    - 탈퇴 사유를 입력받아 저장합니다.
-                    - 실제 데이터 삭제는 정책에 따라 유예 기간(예: 30일) 후에 진행됩니다.
-                    """
-    )
-    @ApiSuccessCode(SuccessStatus._OK)
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
-    @PostMapping("/inactive")
-    ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid UserRequestDTO.DeleteReasonDTO deleteReasonDTO);
 
+    // 소셜 프로필 완성 temp -> active
     @Operation(
             summary = "소셜 프로필 완성",
             description = """
@@ -81,6 +70,7 @@ public interface UserApi {
             @RequestBody @Valid UserRequestDTO.SocialCompleteDTO request,
             @AuthenticationPrincipal CustomUserDetails userDetails);
 
+    // 약관동의 일괄
     @Operation(
             summary = "약관 동의 (일괄)",
             description = """
@@ -95,6 +85,7 @@ public interface UserApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.TermsAgreeDTO request);
 
+    // 약관 개별 변경
     @Operation(
             summary = "약관 개별 변경",
             description = "특정 약관(예: 마케팅 수신 동의)에 대한 동의 여부를 개별적으로 수정합니다."
@@ -106,6 +97,7 @@ public interface UserApi {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.SingleTermUpdateDTO request);
 
+    // 약관 상태 조회
     @Operation(
             summary = "약관 상태 조회",
             description = "사용자가 현재 어떤 약관에 동의했는지 전체 목록과 상태를 조회합니다."
@@ -116,6 +108,23 @@ public interface UserApi {
     ApiResponse<UserResponseDTO.TermsStatusDTO> getTermsStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails);
 
+    // 회원탈퇴
+    @Operation(
+            summary = "회원 탈퇴 (비활성화)",
+            description = """
+                    사용자 계정을 비활성화(INACTIVE) 처리합니다.
+                    - 탈퇴 사유를 입력받아 저장합니다.
+                    - 실제 데이터 삭제는 정책에 따라 유예 기간(예: 30일) 후에 진행됩니다.
+                    """
+    )
+    @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @PostMapping("/inactive")
+    ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDTO.DeleteReasonDTO deleteReasonDTO);
+
+    // 회원 탈퇴 복구 - 14일 이내
     @Operation(
             summary = "회원탈퇴 복구 (계정 활성화)",
             description = """
@@ -124,6 +133,11 @@ public interface UserApi {
                 - 탈퇴 유예 기간 내 사용자의 계정을 다시 ACTIVE 상태로 복구합니다."""
     )
     @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(errorStatus = {
+            ErrorStatus._BAD_REQUEST, // 14일 경과 시
+            ErrorStatus._UNAUTHORIZED,
+            ErrorStatus._ALREADY_ACTIVE_USER // 이미 복구된 상태일 때
+    })
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @PostMapping("/recover")
     ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -115,4 +115,17 @@ public interface UserApi {
     @GetMapping("/terms/status")
     ApiResponse<UserResponseDTO.TermsStatusDTO> getTermsStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(
+            summary = "회원탈퇴 복구 (계정 활성화)",
+            description = """
+                탈퇴 유예 기간(14일) 내에 있는 사용자의 계정을 다시 활성화합니다.
+                - 상태를 ACTIVE로 변경하고 탈퇴 사유 및 날짜를 초기화합니다.
+                - 탈퇴 유예 기간 내 사용자의 계정을 다시 ACTIVE 상태로 복구합니다."""
+    )
+    @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @PostMapping("/recover")
+    ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(
+            @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -1,6 +1,8 @@
 package com.umc.linkyou.web.controller.user;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.config.security.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.Users;
@@ -9,9 +11,12 @@ import com.umc.linkyou.service.users.UserService;
 import com.umc.linkyou.service.users.UserWithdrawService;
 import com.umc.linkyou.utils.UsersUtils;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.validation.annotation.swagger.ApiSuccessCode;
 import com.umc.linkyou.web.api.UserApi;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -79,4 +84,12 @@ public class UserController implements UserApi {
         return ApiResponse.onSuccess(termsAgreementService.getTermsStatus(userDetails));
     }
 
+    //회원탈퇴 복구 api
+    // 회원탈퇴 복구 api
+    @Override
+    public ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(CustomUserDetails userDetails) {
+        Long userId = usersUtils.getAuthenticatedUserId(userDetails);
+        Users user = userWithdrawService.recoverUser(userId);
+        return ApiResponse.onSuccess(UserConverter.toWithDrawalResultDTO(user));
+    }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -85,7 +85,6 @@ public class UserController implements UserApi {
     }
 
     //회원탈퇴 복구 api
-    // 회원탈퇴 복구 api
     @Override
     public ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(CustomUserDetails userDetails) {
         Long userId = usersUtils.getAuthenticatedUserId(userDetails);

--- a/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
@@ -1,0 +1,152 @@
+package com.umc.linkyou.service;
+
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.config.security.jwt.RefreshTokenManager;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.UserStatus;
+import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.users.UserWithdrawService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserWithdrawService - recoverUser 테스트")
+public class UserWithdrawServiceTest {
+
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock private RefreshTokenManager refreshTokenManager;
+    @Mock private AuthAccountRepository authAccountRepository;
+
+    @InjectMocks
+    private UserWithdrawService userWithdrawService;
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class Success {
+
+        @Test
+        @DisplayName("INACTIVE 상태이고 14일 이내라면 ACTIVE로 복구된다")
+        void 정상복구_성공() {
+            // given
+            Long userId = 1L;
+            Users user = Users.builder()
+                    .id(userId)
+                    .status(UserStatus.INACTIVE)
+                    .build();
+            user.setInactiveDate(LocalDateTime.now().minusDays(7)); // 7일 전 탈퇴
+            user.setDeleted_reason("테스트 탈퇴");
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+
+            // when
+            Users result = userWithdrawService.recoverUser(userId);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(result.getInactiveDate()).isNull();
+            assertThat(result.getDeleted_reason()).isNull();
+        }
+
+        @Test
+        @DisplayName("탈퇴 직후(1분 이내)에도 복구된다")
+        void 탈퇴직후_즉시복구_성공() {
+            // given
+            Long userId = 2L;
+            Users user = Users.builder()
+                    .id(userId)
+                    .status(UserStatus.INACTIVE)
+                    .build();
+            user.setInactiveDate(LocalDateTime.now().minusMinutes(1));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+
+            // when
+            Users result = userWithdrawService.recoverUser(userId);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        }
+
+        @Test
+        @DisplayName("탈퇴 후 정확히 13일 23시간에도 복구된다 (경계값)")
+        void 유예기간_경계값_복구_성공() {
+            // given
+            Long userId = 3L;
+            Users user = Users.builder()
+                    .id(userId)
+                    .status(UserStatus.INACTIVE)
+                    .build();
+            user.setInactiveDate(LocalDateTime.now().minusDays(13).minusHours(23));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+
+            // when
+            Users result = userWithdrawService.recoverUser(userId);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+        }
+    }
+    @Nested
+    @DisplayName("실패 케이스")
+    class Failure {
+
+        @Test
+        @DisplayName("존재하지 않는 유저 ID면 USER_NOT_FOUND 예외가 발생한다")
+        void 존재하지않는_유저_예외() {
+            // given
+            Long userId = 999L;
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(e -> {
+                        GeneralException ex = (GeneralException) e;
+                        assertThat(ex.getCode()).isEqualTo(UserErrorStatus._USER_NOT_FOUND);
+                    });
+        }
+
+        @Test
+        @DisplayName("이미 ACTIVE 상태인 유저는 BAD_REQUEST 예외가 발생한다")
+        void 이미활성상태_예외() {
+            // given
+            Long userId = 1L;
+            Users user = Users.builder()
+                    .id(userId)
+                    .status(UserStatus.ACTIVE)
+                    .build();
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(e -> {
+                        GeneralException ex = (GeneralException) e;
+                        assertThat(ex.getCode()).isEqualTo(ErrorStatus._BAD_REQUEST);
+                    });
+        }
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/gemini/GeminiLinkuServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/gemini/GeminiLinkuServiceTest.java
@@ -87,4 +87,6 @@ class GeminiLinkuServiceTest {
             }
         }
     }
+
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#295

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- Spring REST Docs + MockMvc 기반 API 문서 자동화 환경 구성
- `@WebMvcTest` + `@AutoConfigureRestDocs` + `@ExtendWith(RestDocumentationExtension.class)` 표준 테스트 구조 적용
- 테스트 코드 작성 컨벤션 정립 (`@Nested` 성공/실패 케이스 분리)

### 2️⃣ Functional Requirement
- `UserController` REST Docs 테스트 작성
  - `POST /api/v1/users/join` - 일반 회원 가입
  - `POST /api/v1/users/inactive` - 회원 탈퇴
  - `POST /api/v1/users/recover` - 회원 탈퇴 복구
  - `PATCH /api/v1/users/social/complete` - 소셜 프로필 완성 (성공 / 이미 활성 유저 실패)
- `UserWithdrawService` 단위 테스트 작성 (`recoverUser`)
  - 성공: 정상 복구, 탈퇴 직후 복구, 경계값(13일 23시간)
  - 실패: 유저 없음, 이미 ACTIVE, 유예 기간 만료, inactiveDate null, 경계값 만료

---

## 🧪 테스트 결과

- `UserControllerTest` - 4개 테스트 전체 통과
- `UserWithdrawServiceTest` - 5개 테스트 전체 통과 (`@ExtendWith(MockitoExtension.class)` 누락 수정 후)
- REST Docs 스니펫 생성 확인
  - `user/join`, `user/withdraw`, `user/recover`, `user/social-complete`, `user/social-complete-fail`

---

## 📸 스크린샷 (선택)
<img width="1257" height="1146" alt="image" src="https://github.com/user-attachments/assets/e9794059-e84c-425d-81a1-4a872b75963d" />

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 복구: 탈퇴된 계정을 14일 유예 기간 내에 복구하여 재활성화할 수 있는 복구 기능(복구 API) 추가

* **변경사항**
  * 비활성 계정도 로그인 흐름을 진행하도록 로그인 검증 로직 변경
  * 비활성 계정의 완전 삭제 유예 기간을 30일에서 14일로 단축

* **테스트**
  * 계정 복구 동작(성공/실패 경로)에 대한 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->