### PR TITLE
feat: Response에서 result 부분 빈 객체 허용 & CommonErrorStatus 정리

### DIFF
--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -1,0 +1,257 @@
+# LinkU API Response Format
+
+## 1. 공통 응답 포맷
+
+LinkU API는 아래 공통 응답 포맷을 사용한다.
+
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON200",
+  "message": "성공입니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {}
+}
+```
+
+현재 서버 기준 응답 필드는 아래와 같다.
+
+| 필드명 | 타입 | 설명 |
+| --- | --- | --- |
+| `isSuccess` | `Boolean` | 요청 성공 여부 |
+| `code` | `String` | 서버 내부 응답 코드 |
+| `message` | `String` | 응답 메시지 |
+| `timestamp` | `LocalDateTime` | 응답 시각 |
+| `result` | `Object` | 실제 응답 데이터 |
+
+## 2. `result` 정책
+
+- `result`는 항상 응답에 포함한다.
+- 조회/생성/수정 등 실제 데이터가 있으면 해당 DTO, 배열, 단순 값을 그대로 담는다.
+- 반환할 payload가 없는 성공 응답은 `result: {}` 형태로 내려간다.
+- 실패 응답도 현재 공통 포맷을 따르며, 필요 시 `result`에 추가 데이터가 들어갈 수 있다.
+
+예시:
+
+성공 + 데이터 있음
+
+```json
+{
+  "isSuccess": true,
+  "code": "USERS2001",
+  "message": "사용자 정보 조회에 성공했습니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {
+    "id": 1,
+    "nickname": "linku"
+  }
+}
+```
+
+성공 + payload 없음
+
+```json
+{
+  "isSuccess": true,
+  "code": "AUTH2003",
+  "message": "인증 코드가 전송되었습니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {}
+}
+```
+
+실패
+
+```json
+{
+  "isSuccess": false,
+  "code": "COMMON400",
+  "message": "잘못된 요청입니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {}
+}
+```
+
+## 3. 성공 응답 기본 포맷
+
+### 3.1 기본 성공 코드
+
+| 코드 | 이름 | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `COMMON200` | `_OK` | `200 (OK)` | 성공입니다. |
+| `COMMON201` | `_CREATED` | `201 (CREATED)` | 성공적으로 생성(저장)되었습니다. |
+
+### 3.2 성공 응답 예시
+
+기본 성공 응답
+
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON200",
+  "message": "성공입니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {
+    "data": "example"
+  }
+}
+```
+
+생성 성공 응답
+
+```json
+{
+  "isSuccess": true,
+  "code": "COMMON201",
+  "message": "성공적으로 생성(저장)되었습니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {}
+}
+```
+
+## 4. 에러 응답 기본 포맷
+
+```json
+{
+  "isSuccess": false,
+  "code": "COMMON500",
+  "message": "서버 에러, 관리자에게 문의 바랍니다.",
+  "timestamp": "2026-05-15T02:30:00",
+  "result": {}
+}
+```
+
+## 5. 공통 에러 코드
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `COMMON400` | `_BAD_REQUEST` | `400 (BAD_REQUEST)` | 잘못된 요청입니다. |
+| `COMMON401` | `_UNAUTHORIZED` | `401 (UNAUTHORIZED)` | 인증이 필요합니다. |
+| `COMMON403` | `_FORBIDDEN` | `403 (FORBIDDEN)` | 금지된 요청입니다. |
+| `COMMON429` | `_TOO_MANY_REQUESTS` | `429 (TOO_MANY_REQUESTS)` | 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. |
+| `COMMON500` | `_INTERNAL_SERVER_ERROR` | `500 (INTERNAL_SERVER_ERROR)` | 서버 에러, 관리자에게 문의 바랍니다. |
+
+## 6. S3 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `S34001` | `_S3_INVALID_FILE` | `400 (BAD_REQUEST)` | 유효하지 않은 파일입니다. |
+| `S34002` | `_S3_INVALID_IMAGE` | `400 (BAD_REQUEST)` | 이미지 파일만 업로드할 수 있습니다. |
+| `S34003` | `_S3_INVALID_URL` | `400 (BAD_REQUEST)` | 유효하지 않은 S3 URL입니다. |
+| `S34004` | `_S3_FILE_EMPTY` | `400 (BAD_REQUEST)` | 업로드할 파일이 없습니다. |
+| `S34005` | `_S3_EXTRACT_URL_FAILED` | `400 (BAD_REQUEST)` | URL에서 파일명을 추출할 수 없습니다. |
+| `S3404` | `_S3_FILE_NOT_FOUND` | `404 (NOT_FOUND)` | S3 파일을 찾을 수 없습니다. |
+| `S35001` | `_S3_UPLOAD_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | S3 파일 업로드에 실패했습니다. |
+| `S35002` | `_S3_DELETE_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | S3 파일 삭제에 실패했습니다. |
+
+## 7. OAuth/회원 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `AUTH4001` | `UNAUTHORIZED` | `401 (UNAUTHORIZED)` | 인증이 필요합니다. |
+| `AUTH4011` | `INVALID_TOKEN` | `401 (UNAUTHORIZED)` | 잘못된 토큰입니다. |
+| `AUTH4002` | `EXPIRED_TOKEN` | `400 (BAD_REQUEST)` | 만료된 토큰입니다. |
+| `AUTH4003` | `PERMISSION_DENIED` | `403 (FORBIDDEN)` | 권한이 없습니다. |
+| `OAUTH4003` | `_SOCIAL_EMAIL_REQUIRED` | `400 (BAD_REQUEST)` | 소셜 로그인에 이메일이 필요합니다. |
+| `OAUTH4004` | `_SOCIAL_UNSUPPORTED_PROVIDER` | `400 (BAD_REQUEST)` | 지원하지 않는 소셜 제공자입니다. |
+| `OAUTH4008` | `_INVALID_ID_TOKEN` | `400 (BAD_REQUEST)` | 유효하지 않거나 만료된 ID 토큰 |
+| `OAUTH4009` | `_SOCIAL_EXTERNAL_ID_REQUIRED` | `400 (BAD_REQUEST)` | 소셜 계정 ID가 필요합니다. |
+| `OAUTH4010` | `_INVALID_EMAIL_FORMAT` | `400 (BAD_REQUEST)` | 올바른 이메일 형식이 아닙니다. |
+| `OAUTH5001` | `_AUTH_ACCOUNT_SAVE_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 소셜 계정 연결에 실패했습니다. |
+| `USERS4001` | `_ALREADY_ACTIVE_USER` | `400 (BAD_REQUEST)` | 이미 해당 이메일로 user가 존재합니다. 새로운 회원정보를 만들고 싶다면 탈퇴해주세요. |
+| `USERS4002` | `_INVALID_GENDER` | `400 (BAD_REQUEST)` | 성별을 올바르게 선택해야합니다.(MALE: 1, FEMALE: 2) |
+| `USERS4004` | `_EXPIRED_VERIFICATION_CODE` | `400 (BAD_REQUEST)` | 인증 코드가 만료되었습니다. |
+| `USERS4005` | `_INVALID_PASSWORD` | `400 (BAD_REQUEST)` | 잘못된 비밀번호입니다. |
+| `USERS4006` | `_PASSWORD_MISMATCH` | `400 (BAD_REQUEST)` | 비밀번호와 비밀번호 확인이 일치하지 않습니다. |
+| `USERS4011` | `_VERIFICATION_FAILED` | `401 (UNAUTHORIZED)` | 인증 코드 검증 실패 |
+| `USERS4012` | `_LOGIN_FAILED` | `401 (UNAUTHORIZED)` | 이메일 주소 또는 비밀번호를 다시 확인하세요. |
+| `USERS4014` | `_SOCIAL_ACCOUNT_ONLY` | `401 (UNAUTHORIZED)` | 소셜 전용 계정입니다. 소셜 로그인을 이용하세요. |
+| `USERS4041` | `_USER_NOT_FOUND` | `404 (NOT_FOUND)` | 사용자를 찾을 수 없습니다. |
+| `USERS4042` | `_USER_INACTIVE` | `404 (NOT_FOUND)` | 사용자가 INACTIVE 임시 회원탈퇴 상태입니다. |
+| `USERS4091` | `_DUPLICATE_NICKNAME` | `409 (CONFLICT)` | 중복된 닉네임입니다. |
+| `USERS4092` | `_DUPLICATE_JOIN_REQUEST` | `409 (CONFLICT)` | 중복된 이메일입니다. |
+| `USERS5001` | `_SEND_MAIL_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 인증 코드 전송 실패 |
+| `TERMS4001` | `INVALID_TERMS_TYPE` | `400 (BAD_REQUEST)` | 유효하지 않은 약관 타입입니다. |
+
+## 8. LinkU 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `LINKU4001` | `_LINKU_VIDEO_NOT_ALLOWED` | `400 (BAD_REQUEST)` | 영상 링크는 저장할 수 없습니다. |
+| `LINKU4002` | `_LINKU_INVALID_URL` | `400 (BAD_REQUEST)` | 유효하지 않은 링크입니다. |
+| `LINKU4003` | `_RECOMMEND_LINKU_NOT_ENOUGH_LINKS` | `400 (BAD_REQUEST)` | 추천을 위해 저장된 링크가 3개 이상이어야 합니다. |
+| `LINKU4004` | `_RECOMMEND_LINKU_NO_RECOMMENDATION` | `400 (BAD_REQUEST)` | 추천할 만한 링크가 없습니다. |
+| `LINKU4005` | `_RECOMMEND_LINKU_NEW_USER` | `400 (BAD_REQUEST)` | 신규 사용자는 추천 기능을 이용할 수 없습니다. |
+| `LINKU404` | `_USER_LINKU_NOT_FOUND` | `404 (NOT_FOUND)` | user_linku 테이블을 찾기 못했습니다. |
+| `LINKU4041` | `_LINKU_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 링크 정보를 찾을 수 없습니다. |
+
+## 9. 카테고리/도메인/감정/상황
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `CATEGORY4041` | `_CATEGORY_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 카테고리를 찾을 수 없습니다. |
+| `DOMAIN4041` | `_DOMAIN_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 도메인을 찾을 수 없습니다. |
+| `EMOTION4041` | `_EMOTION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 감정을 찾을 수 없습니다. |
+| `FOLDER4041` | `_FOLDER_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 폴더를 찾을 수 없습니다. |
+| `SITUATION4041` | `_SITUATION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 상황을 찾을 수 없습니다. |
+
+## 10. 폴더 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `FOLDER404` | `_FOLDER_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 폴더를 찾을 수 없습니다. |
+| `FOLDER_PARENT404` | `_FOLDER_PARENT_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 부모 폴더가 없습니다. |
+| `FOLDER_CATEGORY404` | `_FOLDER_CATEGORY_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 카테고리가 없습니다. |
+| `FOLDER_CREATE403` | `_FOLDER_CREATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더를 생성할 권한이 없습니다. |
+| `FOLDER_UPDATE403` | `_FOLDER_UPDATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 수정 권한이 없습니다. |
+| `FOLDER_DELETE403` | `_FOLDER_DELETE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 삭제 권한이 없습니다. |
+| `FOLDER_ACCESS403` | `_FOLDER_ACCESS_FORBIDDEN` | `403 (FORBIDDEN)` | 해당 폴더에 접근 권한이 없습니다. |
+| `FOLDER_NAME409` | `_FOLDER_NAME_CONFLICT` | `409 (CONFLICT)` | 카테고리명과 동일한 폴더명은 사용할 수 없습니다. |
+| `FOLDER_CURSOR400` | `_FOLDER_INVALID_CURSOR` | `400 (BAD_REQUEST)` | 유효하지 않은 커서 값입니다. |
+| `FOLDER_OWNER500` | `_FOLDER_OWNER_NOT_FOUND` | `500 (INTERNAL_SERVER_ERROR)` | 폴더의 소유자 정보를 찾을 수 없습니다. |
+| `FOLDER_PERMISSION404` | `_FOLDER_PERMISSION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 폴더 권한 정보를 찾을 수 없습니다. |
+| `FOLDER_TOKEN404` | `INVITATION_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 토큰을 찾을 수 없습니다. |
+| `FOLDER_TOKEN_INVALID404` | `INVITATION_EXPIRED` | `404 (NOT_FOUND)` | 공유 폴더 토큰이 유효하지 않습니다. |
+| `FOLDER_LINK_INVALID404` | `INVITATION_LINK_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 링크가 유효하지 않습니다. |
+| `FOLDER_OWNER_403` | `_FOLDER_PERMISSION_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 수정 권한을 가지고 있지 않습니다. |
+| `FOLDER_OWNER_403` | `_FOLDER_OWNER_UPDATE_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 주인의 권한은 수정할 수 없습니다. |
+| `FOLDER_CREATOR403` | `INVITATION_CREATOR_CANNOT_ACCEPT` | `403 (FORBIDDEN)` | 초대 생성자는 자신의 링크로 참여할 수 없습니다. |
+| `PERMISSION400` | `_INVALID_PERMISSION_TYPE` | `400 (BAD_REQUEST)` | 유효하지 않은 권한 타입입니다. |
+| `FOLDER_BOOKMARK404` | `_FOLDER_BOOKMARK_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 북마크 정보가 존재하지 않습니다. |
+
+## 11. AI Article / Gemini 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `AIARTICLE4041` | `_AI_ARTICLE_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 AI Article을 찾을 수 없습니다. |
+| `AIARTICLE4091` | `_DUPLICATE_AI_ARTICLE` | `409 (CONFLICT)` | 이미 해당 링크로 생성된 AI Article이 존재합니다. |
+| `AIARTICLE500` | `_INTERNAL_SERVER_ERROR` | `500 (INTERNAL_SERVER_ERROR)` | AI 요약 처리 중 오류가 발생했습니다. |
+| `OPENAI5001` | `_AI_PARSE_ERROR` | `400 (BAD_REQUEST)` | AI 응답 파싱에 실패했습니다. |
+| `OPENAI5002` | `_AI_INVALID_RESPONSE` | `500 (INTERNAL_SERVER_ERROR)` | AI 응답이 예상한 형식이 아닙니다. |
+| `CRAWLER5001` | `_CONTENT_EXTRACTION_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 웹페이지 본문 추출에 실패했습니다. |
+| `CRAWLER5002` | `_CONTENT_EXTRACTION_PROHIBITED` | `500 (INTERNAL_SERVER_ERROR)` | 크롤링이 금지된 웹사이트입니다. |
+| `GEMINI4291` | `GEMINI_TOO_MANY_REQUESTS` | `429 (TOO_MANY_REQUESTS)` | AI 요청이 너무 많습니다. 잠시 후 다시 시도해주세요. |
+| `GEMINI5001` | `GEMINI_UNKNOWN_ERROR` | `500 (INTERNAL_SERVER_ERROR)` | AI 처리 중 알 수 없는 오류가 발생했습니다. |
+| `GEMINI5002` | `GEMINI_RESPONSE_FORMAT_ERROR` | `500 (INTERNAL_SERVER_ERROR)` | AI 응답 형식이 올바르지 않습니다. |
+| `GEMINI5021` | `GEMINI_BAD_REQUEST` | `400 (BAD_REQUEST)` | 잘못된 AI 요청입니다. |
+| `GEMINI5021` | `GEMINI_API_ERROR` | `502 (BAD_GATEWAY)` | Gemini API 호출 중 오류가 발생했습니다. |
+| `GEMINI5022` | `GEMINI_PARSE_ERROR` | `502 (BAD_GATEWAY)` | AI 응답 JSON 파싱에 실패했습니다. |
+| `GEMINI5041` | `GEMINI_TIMEOUT` | `504 (GATEWAY_TIMEOUT)` | Gemini 응답 시간이 초과되었습니다. |
+
+## 12. 알림 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `ALARM_NOT_FOUND` | `ALARM_NOT_FOUND` | `404 (NOT_FOUND)` | 알람을 찾을 수 없습니다. |
+| `ALARM_PERMISSION_DENIED` | `ALARM_PERMISSION_DENIED` | `401 (UNAUTHORIZED)` | 알람에 대한 권한이 없습니다. |
+| `ALARM5001` | `ALARM_TOPIC_SUBSCRIPTION_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 알림 주제 구독 상태 변경에 실패했습니다. |
+| `ALARM5002` | `ALARM_SEND_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 알림 전송에 실패했습니다. |
+
+## 13. 구현 기준 메모
+
+- 성공 응답 생성: `ApiResponse.onSuccess(...)`
+- 실패 응답 생성: `ApiResponse.onFailure(...)`
+- payload 없는 성공 응답: `ApiResponse.onSuccess(code)` 사용
+- 현재 payload 없는 성공 응답은 `result: {}` 형태로 내려가도록 맞춘 상태
+- 기본 성공 코드 사용 시 `SuccessStatus._OK`
+- 도메인별 성공 코드는 `AuthSuccessStatus`, `UserSuccessStatus`, `FolderSuccessStatus`, `LinkuSuccessStatus`, `AiArticleSuccessStatus`, `AlarmSuccessStatus`, `CategorySuccessStatus` 등에서 관리

--- a/src/main/java/com/umc/linkyou/apiPayload/ApiResponse.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/ApiResponse.java
@@ -31,6 +31,7 @@ public class ApiResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final LocalDateTime timestamp;
 
+    @Schema(type = "object")
     private final T result;
 
     // Code, result 모두 커스텀

--- a/src/main/java/com/umc/linkyou/apiPayload/ApiResponse.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/ApiResponse.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 @Getter
 @AllArgsConstructor
@@ -30,30 +31,36 @@ public class ApiResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final LocalDateTime timestamp;
 
-    private T result;
+    private final T result;
 
+    // Code, result 모두 커스텀
     public static <T> ApiResponse<T> onSuccess(BaseSuccessCode code, T result) {
-        return new ApiResponse<>(true, code.getReason().getCode(), code.getReason().getMessage(), LocalDateTime.now(), result);
+        return success(code.getReason().getCode(), code.getReason().getMessage(), result);
     }
 
+    // result가 비어 있을 경우
+    public static ApiResponse<Object> onSuccess(BaseSuccessCode code) {
+        return success(code.getReason().getCode(), code.getReason().getMessage(), Collections.emptyMap());
+    }
+
+    // 기본 SUCCESS, result 포함
     public static <T> ApiResponse<T> onSuccess(T result) {
-        return new ApiResponse<>(
-                true,
-                SuccessStatus._OK.getReason().getCode(),
-                SuccessStatus._OK.getReason().getMessage(),
-                LocalDateTime.now(),
-                result
-        );
+        return success(SuccessStatus._OK.getReason().getCode(), SuccessStatus._OK.getReason().getMessage(), result);
     }
 
-
-    // 실패한 경우 응답 생성 - 해당 메서드 사용 권장
-    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T data){
-        return new ApiResponse<>(false, code.getReason().getCode(), code.getReason().getMessage(), LocalDateTime.now(), data);
+    private static <T> ApiResponse<T> success(String code, String message, T result) {
+        return new ApiResponse<>(true, code, message, LocalDateTime.now(), result);
     }
 
-    // 실패한 경우 응답 생성
-    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+    private static <T> ApiResponse<T> failure(String code, String message, T data) {
         return new ApiResponse<>(false, code, message, LocalDateTime.now(), data);
+    }
+
+    public static <T> ApiResponse<T> onFailure(BaseErrorCode code, T data) {
+        return failure(code.getReason().getCode(), code.getReason().getMessage(), data);
+    }
+
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data) {
+        return failure(code, message, data);
     }
 }

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/CommonErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/CommonErrorStatus.java
@@ -16,8 +16,6 @@ public enum CommonErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON401", "인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
-    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "COMMON4011", "잘못된 토큰입니다."),
-    _INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "COMMON4012", "잘못된 비밀번호입니다."),
 
     // S3 관련 에러
     _S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3404", "S3 파일을 찾을 수 없습니다."),

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -13,13 +13,9 @@ public enum ErrorStatus implements BaseErrorCode {
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
-    _EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST,"COMMON400","인증 코드가 만료되었습니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
-    _INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "COMMON4011", "잘못된 토큰입니다."),
-    _INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "COMMON4012", "잘못된 비밀번호입니다."),
-    _PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "COMMON4013", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
     // S3 관련 오류
     _S3_FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "S3404", "S3 파일을 찾을 수 없습니다."),

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/auth/AuthErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/auth/AuthErrorStatus.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum AuthErrorStatus implements BaseErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH4001", "인증이 필요합니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "잘못된 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4002", "만료된 토큰입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH4003", "권한이 없습니다."),
     _REFRESH_TOKEN_SESSION_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "세션 저장 중 오류가 발생했습니다.");

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -151,7 +151,7 @@ public class SwaggerConfig {
         ReasonDTO reason = status.getReasonHttpStatus();
 
         com.umc.linkyou.apiPayload.ApiResponse<Object> exampleResponse =
-                com.umc.linkyou.apiPayload.ApiResponse.onSuccess((Object) null);
+                com.umc.linkyou.apiPayload.ApiResponse.onSuccess(status);
 
         addExample(responses, reason.getHttpStatus().value(), status.name(), reason.getMessage(), exampleResponse);
     }

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -151,7 +151,7 @@ public class SwaggerConfig {
         ReasonDTO reason = status.getReasonHttpStatus();
 
         com.umc.linkyou.apiPayload.ApiResponse<Object> exampleResponse =
-                com.umc.linkyou.apiPayload.ApiResponse.onSuccess(null);
+                com.umc.linkyou.apiPayload.ApiResponse.onSuccess((Object) null);
 
         addExample(responses, reason.getHttpStatus().value(), status.name(), reason.getMessage(), exampleResponse);
     }

--- a/src/main/java/com/umc/linkyou/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/jwt/JwtTokenProvider.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.config.properties.Constants;
 import com.umc.linkyou.config.properties.JwtProperties;
 
@@ -130,7 +129,7 @@ public class JwtTokenProvider {
         String providerStr = claims.get("provider", String.class);  // String 그대로!
 
         if (providerStr == null || providerStr.isBlank()) {
-            throw new UserHandler(ErrorStatus._INVALID_TOKEN);
+            throw new UserHandler(AuthErrorStatus.INVALID_TOKEN);
         }
 
         // 3) 토큰 소유자 userId 조회
@@ -142,7 +141,7 @@ public class JwtTokenProvider {
 
         // 5) Redis Hash 화이트리스트에 키가 존재하는지 확인
         if (!refreshTokenManager.validateToken(expectedUserId, providerStr, deviceId, id)) {
-            throw new UserHandler(ErrorStatus._INVALID_TOKEN);
+            throw new UserHandler(AuthErrorStatus.INVALID_TOKEN);
         }
     }
 

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -2,9 +2,7 @@ package com.umc.linkyou.service.users;
 
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
-import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
-import jakarta.servlet.http.HttpServletRequest;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
@@ -347,14 +345,9 @@ public class UserService {
     }
 
     // 로그아웃
-    public void logoutUser(Long userId, HttpServletRequest request, String deviceId) {
+    public void logoutUser(Long userId, String accessToken, String deviceId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(UserErrorStatus._USER_NOT_FOUND));
-
-        String accessToken = JwtTokenProvider.resolveToken(request);
-        if (accessToken == null) {
-            throw new GeneralException(AuthErrorStatus.UNAUTHORIZED);
-        }
 
         refreshTokenManager.deleteTokenForDevice(userId, deviceId);
 

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -2,7 +2,9 @@ package com.umc.linkyou.service.users;
 
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
@@ -345,9 +347,14 @@ public class UserService {
     }
 
     // 로그아웃
-    public void logoutUser(Long userId, String accessToken, String deviceId) {
+    public void logoutUser(Long userId, HttpServletRequest request, String deviceId) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new UserHandler(UserErrorStatus._USER_NOT_FOUND));
+
+        String accessToken = JwtTokenProvider.resolveToken(request);
+        if (accessToken == null) {
+            throw new GeneralException(AuthErrorStatus.UNAUTHORIZED);
+        }
 
         refreshTokenManager.deleteTokenForDevice(userId, deviceId);
 

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -38,7 +38,7 @@ public interface AlarmApi {
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @PostMapping("/fcmtoken")
-    ApiResponse<Void> registerFcmToken(
+    ApiResponse<Object> registerFcmToken(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmFcmTokenDTO alarmFcmTokenDTO
     );
@@ -49,7 +49,7 @@ public interface AlarmApi {
             """)
     @ApiSuccessCode(SuccessStatus._OK)
     @DeleteMapping("/fcmtoken")
-    ApiResponse<Void> deleteFcmToken(
+    ApiResponse<Object> deleteFcmToken(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmFcmTokenDTO alarmFcmTokenDTO
     );
@@ -63,7 +63,7 @@ public interface AlarmApi {
     @ApiErrorCode(errorStatus = {ErrorStatus._FORBIDDEN})
     @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_SEND_FAILED})
     @PostMapping("/test/send")
-    ApiResponse<Void> sendTestAlarm(
+    ApiResponse<Object> sendTestAlarm(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.TestAlarmSendDTO request
     );
@@ -128,7 +128,7 @@ public interface AlarmApi {
     @ApiErrorCode(errorStatus = {ErrorStatus._FORBIDDEN})
     @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_TOPIC_SUBSCRIPTION_FAILED})
     @PostMapping("/admin/broadcast")
-    ApiResponse<Void> registerAdminAlarm(
+    ApiResponse<Object> registerAdminAlarm(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AdminAlarmSendRequestDTO request
     );
@@ -140,7 +140,7 @@ public interface AlarmApi {
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_NOT_FOUND})
     @PatchMapping("/{alarmId}/read")
-    ApiResponse<Void> markAlarmAsRead(
+    ApiResponse<Object> markAlarmAsRead(
             @CurrentUser CustomUserDetails userDetails,
             @Parameter(description = "읽음 처리할 알림 ID")
             @PathVariable Long alarmId

--- a/src/main/java/com/umc/linkyou/web/api/AuthApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AuthApi.java
@@ -91,7 +91,7 @@ public interface AuthApi {
     @ApiErrorCode(commonErrorStatus = {CommonErrorStatus._TOO_MANY_REQUESTS})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._SEND_MAIL_FAILED})
     @PostMapping("/email/code")
-    ApiResponse<Void> sendCode(@RequestBody @Valid EmailRequestDTO.CodeSendDTO request);
+    ApiResponse<Object> sendCode(@RequestBody @Valid EmailRequestDTO.CodeSendDTO request);
 
     @Operation(
             summary = "이메일 인증 코드 검증",
@@ -106,7 +106,7 @@ public interface AuthApi {
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._EXPIRED_VERIFICATION_CODE})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._VERIFICATION_FAILED})
     @PostMapping("/email/verify")
-    ApiResponse<Void> verifyCode(@RequestBody @Valid EmailRequestDTO.CodeVerifyDTO request);
+    ApiResponse<Object> verifyCode(@RequestBody @Valid EmailRequestDTO.CodeVerifyDTO request);
 
     @Operation(
             summary = "닉네임 중복 확인",
@@ -119,7 +119,7 @@ public interface AuthApi {
     @ApiAuthSuccessCode(AuthSuccessStatus.NICKNAME_AVAILABLE)
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._DUPLICATE_NICKNAME})
     @GetMapping("/check-nickname")
-    ApiResponse<Void> checkNickname(@RequestParam String nickname);
+    ApiResponse<Object> checkNickname(@RequestParam String nickname);
 
     @Operation(
             summary = "비밀번호 재설정 링크 전송",
@@ -134,7 +134,7 @@ public interface AuthApi {
     @ApiErrorCode(commonErrorStatus = {CommonErrorStatus._TOO_MANY_REQUESTS})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._SEND_MAIL_FAILED})
     @PostMapping("/password/reset/send")
-    ApiResponse<Void> sendPasswordResetLink(@RequestBody @Valid EmailRequestDTO.ResetLinkDTO request);
+    ApiResponse<Object> sendPasswordResetLink(@RequestBody @Valid EmailRequestDTO.ResetLinkDTO request);
 
     @Operation(
             summary = "비밀번호 재설정",
@@ -152,7 +152,7 @@ public interface AuthApi {
             UserErrorStatus._USER_NOT_FOUND
     })
     @PutMapping("/password/reset")
-    ApiResponse<Void> resetPassword(@RequestBody @Valid PasswordResetRequestDTO request);
+    ApiResponse<Object> resetPassword(@RequestBody @Valid PasswordResetRequestDTO request);
 
     @Operation(
             summary = "로그아웃",
@@ -166,5 +166,5 @@ public interface AuthApi {
     @ApiAuthSuccessCode(AuthSuccessStatus.LOGOUT_SUCCESS)
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @PostMapping("/logout")
-    ApiResponse<Void> logout(@CurrentUser CustomUserDetails userDetails, @RequestParam String deviceId, HttpServletRequest request);
+    ApiResponse<Object> logout(@CurrentUser CustomUserDetails userDetails, @RequestParam String deviceId, HttpServletRequest request);
 }

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -3,6 +3,7 @@ package com.umc.linkyou.web.api;
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
+import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -28,7 +29,8 @@ public interface UserApi {
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
-    @ApiErrorCode(errorStatus = {ErrorStatus._UNAUTHORIZED, ErrorStatus._INTERNAL_SERVER_ERROR})
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(errorStatus = {ErrorStatus._INTERNAL_SERVER_ERROR})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @GetMapping("/me")
     ApiResponse<UserResponseDTO.UserProfileSummaryDto> getUserInfo(

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -47,7 +47,7 @@ public interface UserApi {
     @ApiErrorCode(errorStatus = {ErrorStatus._BAD_REQUEST}) // 잘못된 Job ID 등
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND, UserErrorStatus._DUPLICATE_NICKNAME})
     @PatchMapping("/profile")
-    ApiResponse<Void> updateUserProfile(
+    ApiResponse<Object> updateUserProfile(
             @CurrentUser CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.UpdateProfileDTO updateDTO);
 

--- a/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
@@ -35,25 +35,25 @@ public class AlarmController implements AlarmApi {
     private final FcmPushSender fcmPushSender;
 
     @Override
-    public ApiResponse<Void> registerFcmToken(
+    public ApiResponse<Object> registerFcmToken(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmFcmTokenDTO alarmFcmTokenDTO
     ) {
         alarmService.registerFcmToken(userDetails.getUserId(), alarmFcmTokenDTO);
-        return ApiResponse.onSuccess(AlarmSuccessStatus.FCM_TOKEN_REGISTERED, null);
+        return ApiResponse.onSuccess(AlarmSuccessStatus.FCM_TOKEN_REGISTERED);
     }
 
     @Override
-    public ApiResponse<Void> deleteFcmToken(
+    public ApiResponse<Object> deleteFcmToken(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmFcmTokenDTO alarmFcmTokenDTO
     ) {
         alarmService.deleteFcmToken(userDetails.getUserId(), alarmFcmTokenDTO.fcmToken());
-        return ApiResponse.onSuccess(AlarmSuccessStatus.FCM_TOKEN_DELETED, null);
+        return ApiResponse.onSuccess(AlarmSuccessStatus.FCM_TOKEN_DELETED);
     }
 
     @Override
-    public ApiResponse<Void> sendTestAlarm(
+    public ApiResponse<Object> sendTestAlarm(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.TestAlarmSendDTO request
     ) {
@@ -62,7 +62,7 @@ public class AlarmController implements AlarmApi {
                 request.fcmToken(),
                 FcmSendRequestDTO.of(AlarmType.ANNOUNCEMENT_UPDATE, userDetails.getUserId())
         );
-        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_TEST_SENT, null);
+        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_TEST_SENT);
     }
 
     @Override
@@ -100,22 +100,22 @@ public class AlarmController implements AlarmApi {
     }
 
     @Override
-    public ApiResponse<Void> registerAdminAlarm(
+    public ApiResponse<Object> registerAdminAlarm(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AdminAlarmSendRequestDTO request
     ) {
         validateAdmin(userDetails);
         alarmService.registerAdminAlarm(request);
-        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_BROADCAST_REGISTERED, null);
+        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_BROADCAST_REGISTERED);
     }
 
     @Override
-    public ApiResponse<Void> markAlarmAsRead(
+    public ApiResponse<Object> markAlarmAsRead(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long alarmId
     ) {
         alarmService.markAlarmAsRead(userDetails.getUserId(), alarmId);
-        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_READ, null);
+        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_READ);
     }
 
     private void validateAdmin(CustomUserDetails userDetails) {

--- a/src/main/java/com/umc/linkyou/web/controller/CurationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CurationController.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.service.curation.CurationLikeService;
 import com.umc.linkyou.service.curation.CurationService;
 import com.umc.linkyou.service.curation.CurationTopLogService;
@@ -40,9 +41,9 @@ public class CurationController {
             description = "모든 사용자에 대해 월간 큐레이션을 즉시 생성합니다. 운영/개발 전용 엔드포인트입니다."
     )
     @GetMapping("/batch/manual")
-    public ResponseEntity<ApiResponse<Void>> triggerBatch() {
+    public ResponseEntity<ApiResponse<Object>> triggerBatch() {
         curationService.generateMonthlyCurationForAllUsers();
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK));
     }
 
     @Operation(
@@ -50,11 +51,11 @@ public class CurationController {
             description = "기존 운영 코드 변경 없이, 테스트 데이터만 일괄 생성합니다. 이미 존재하는 (user, month)는 스킵합니다."
     )
     @PostMapping("/seed-feb-to-jul-2025")
-    public ResponseEntity<ApiResponse<Void>> seedFebToJul2025(
+    public ResponseEntity<ApiResponse<Object>> seedFebToJul2025(
             @RequestParam(defaultValue = "false") boolean materializeExternal
     ) {
         curationService.seedFebToJul2025(materializeExternal);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK));
     }
 
     /**
@@ -112,9 +113,9 @@ public class CurationController {
             description = "해당 큐레이션에 좋아요를 등록합니다."
     )
     @PostMapping("/{curationId}/like")
-    public ResponseEntity<ApiResponse<Void>> likeCuration(@PathVariable Long curationId, @RequestParam Long userId) {
+    public ResponseEntity<ApiResponse<Object>> likeCuration(@PathVariable Long curationId, @RequestParam Long userId) {
         curationLikeService.likeCuration(userId, curationId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK));
     }
     /**
      * 큐레이션 좋아요 취소
@@ -124,9 +125,9 @@ public class CurationController {
             description = "해당 큐레이션의 좋아요를 취소합니다."
     )
     @DeleteMapping("/{curationId}/like")
-    public ResponseEntity<ApiResponse<Void>> unlikeCuration(@PathVariable Long curationId, @RequestParam Long userId) {
+    public ResponseEntity<ApiResponse<Object>> unlikeCuration(@PathVariable Long curationId, @RequestParam Long userId) {
         curationLikeService.unlikeCuration(userId, curationId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.ok(ApiResponse.onSuccess(SuccessStatus._OK));
     }
 
     /**

--- a/src/main/java/com/umc/linkyou/web/controller/FolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/FolderController.java
@@ -59,12 +59,12 @@ public class FolderController {
             description = "소분류 폴더를 삭제합니다."
     )
     @DeleteMapping("/subfolders/{folderId}")
-    public ApiResponse<Void> deleteFolder(
+    public ApiResponse<Object> deleteFolder(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         folderService.deleteFolder(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_DELETED, null);
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_DELETED);
     }
 
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
@@ -160,13 +160,13 @@ public class LinkuController {
             description = "사용자가 저장한 링크를 삭제합니다."
     )
     @DeleteMapping("/{userLinkuId}")
-    public ApiResponse<Void> deleteUsersLinku(
+    public ApiResponse<Object> deleteUsersLinku(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long userLinkuId
     ) {
         Long userId = userDetails.getUserId();
         linkuService.deleteUsersLinku(userId, userLinkuId);
-        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_DELETED, null);
+        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_DELETED);
 
     }
 

--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -41,12 +41,12 @@ public class ShareFolderController {
 
     @Operation(summary = "초대 링크 삭제", description = "초대 링크를 비활성화합니다.")
     @DeleteMapping("/{folderId}/invitation")
-    public ApiResponse<Void> deactivateInviteLink(
+    public ApiResponse<Object> deactivateInviteLink(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         shareFolderService.deactivateInviteLink(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_DEACTIVATED, null);
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_DEACTIVATED);
     }
 
     @Operation(summary = "폴더 멤버 조회", description = "공유된 폴더의 멤버 목록을 조회합니다.")

--- a/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
@@ -33,11 +33,11 @@ public class SharedFolderController {
 
     @Operation(summary = "공유 받은 폴더 삭제", description = "공유 받은 폴더를 자신의 목록에서 제거합니다. (폴더 자체는 삭제되지 않습니다)")
     @DeleteMapping("/{folderId}")
-    public ApiResponse<Void> deleteSharedFolder(
+    public ApiResponse<Object> deleteSharedFolder(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long folderId
     ) {
         sharedFolderService.deleteSharedFolder(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_LEAVE_OK, null);
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_LEAVE_OK);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
@@ -1,14 +1,11 @@
 package com.umc.linkyou.web.controller.user;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
-import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
-import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.service.email.EmailVerificationService;
 import com.umc.linkyou.service.email.PasswordResetService;
 import com.umc.linkyou.service.users.UserService;
@@ -31,7 +28,6 @@ public class AuthController implements AuthApi {
     private final UserService userService;
     private final EmailVerificationService emailVerificationService;
     private final PasswordResetService passwordResetService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public ApiResponse<UserResponseDTO.JoinResultDTO> join(@RequestBody @Valid UserRequestDTO.JoinDTO request) {
@@ -50,47 +46,44 @@ public class AuthController implements AuthApi {
     }
 
     @Override
-    public ApiResponse<Void> sendCode(@RequestBody @Valid EmailRequestDTO.CodeSendDTO request) {
+    public ApiResponse<Object> sendCode(@RequestBody @Valid EmailRequestDTO.CodeSendDTO request) {
         emailVerificationService.sendCode(request.email());
-        return ApiResponse.onSuccess(AuthSuccessStatus.SEND_VERIFICATION_CODE, null);
+        return ApiResponse.onSuccess(
+                AuthSuccessStatus.SEND_VERIFICATION_CODE);
     }
 
     @Override
-    public ApiResponse<Void> verifyCode(@RequestBody @Valid EmailRequestDTO.CodeVerifyDTO request) {
+    public ApiResponse<Object> verifyCode(@RequestBody @Valid EmailRequestDTO.CodeVerifyDTO request) {
         emailVerificationService.verifyCode(request.email(), request.code());
-        return ApiResponse.onSuccess(AuthSuccessStatus.EMAIL_VERIFICATION_SUCCESS, null);
+        return ApiResponse.onSuccess(
+                AuthSuccessStatus.EMAIL_VERIFICATION_SUCCESS);
     }
 
     @Override
-    public ApiResponse<Void> checkNickname(@RequestParam String nickname) {
+    public ApiResponse<Object> checkNickname(@RequestParam String nickname) {
         userService.checkNicknameAvailable(nickname);
-        return ApiResponse.onSuccess(AuthSuccessStatus.NICKNAME_AVAILABLE, null);
+        return ApiResponse.onSuccess(AuthSuccessStatus.NICKNAME_AVAILABLE);
     }
 
     @Override
-    public ApiResponse<Void> sendPasswordResetLink(@RequestBody @Valid EmailRequestDTO.ResetLinkDTO request) {
+    public ApiResponse<Object> sendPasswordResetLink(@RequestBody @Valid EmailRequestDTO.ResetLinkDTO request) {
         passwordResetService.sendResetLink(request.email());
-        return ApiResponse.onSuccess(AuthSuccessStatus.PASSWORD_RESET_LINK_SENT, null);
+        return ApiResponse.onSuccess(AuthSuccessStatus.PASSWORD_RESET_LINK_SENT);
     }
 
     @Override
-    public ApiResponse<Void> resetPassword(@RequestBody @Valid PasswordResetRequestDTO request) {
+    public ApiResponse<Object> resetPassword(@RequestBody @Valid PasswordResetRequestDTO request) {
         passwordResetService.resetPassword(request.getToken(), request.getNewPassword(), request.getConfirmPassword());
-        return ApiResponse.onSuccess(AuthSuccessStatus.PASSWORD_RESET_SUCCESS, null);
+        return ApiResponse.onSuccess(AuthSuccessStatus.PASSWORD_RESET_SUCCESS);
     }
 
     @Override
-    public ApiResponse<Void> logout(
+    public ApiResponse<Object> logout(
             @CurrentUser CustomUserDetails userDetails,
             @RequestParam String deviceId,
             HttpServletRequest request
     ) {
-        String accessToken = JwtTokenProvider.resolveToken(request);
-        if (accessToken == null) {
-            throw new GeneralException(AuthErrorStatus.UNAUTHORIZED);
-        }
-
-        userService.logoutUser(userDetails.getUserId(), accessToken, deviceId);
-        return ApiResponse.onSuccess(AuthSuccessStatus.LOGOUT_SUCCESS, null);
+        userService.logoutUser(userDetails.getUserId(), request, deviceId);
+        return ApiResponse.onSuccess(AuthSuccessStatus.LOGOUT_SUCCESS);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
@@ -1,11 +1,14 @@
 package com.umc.linkyou.web.controller.user;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.service.email.EmailVerificationService;
 import com.umc.linkyou.service.email.PasswordResetService;
 import com.umc.linkyou.service.users.UserService;
@@ -83,7 +86,11 @@ public class AuthController implements AuthApi {
             @RequestParam String deviceId,
             HttpServletRequest request
     ) {
-        userService.logoutUser(userDetails.getUserId(), request, deviceId);
+        String accessToken = JwtTokenProvider.resolveToken(request);
+        if (accessToken == null) {
+            throw new GeneralException(AuthErrorStatus.UNAUTHORIZED);
+        }
+        userService.logoutUser(userDetails.getUserId(), accessToken, deviceId);
         return ApiResponse.onSuccess(AuthSuccessStatus.LOGOUT_SUCCESS);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -36,9 +36,9 @@ public class UserController implements UserApi {
     }
 
     @Override
-    public ApiResponse<Void> updateUserProfile(@CurrentUser CustomUserDetails userDetails, UserRequestDTO.UpdateProfileDTO updateDTO) {
+    public ApiResponse<Object> updateUserProfile(@CurrentUser CustomUserDetails userDetails, UserRequestDTO.UpdateProfileDTO updateDTO) {
         userService.updateUserProfile(userDetails.getUserId(), updateDTO);
-        return ApiResponse.onSuccess(UserSuccessStatus.USER_PROFILE_UPDATED, null);
+        return ApiResponse.onSuccess(UserSuccessStatus.USER_PROFILE_UPDATED);
     }
 
     @Override

--- a/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.service.users;
 
 import com.umc.linkyou.config.properties.JwtProperties;
+import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
 import com.umc.linkyou.jwt.TokenIssueService;
@@ -63,6 +64,7 @@ class UserServiceImplTest {
     @Mock private UsersCategoryColorRepository usersCategoryColorRepository;
     @Mock private RefreshTokenManager refreshTokenManager;
     @Mock private TokenIssueService tokenIssueService;
+    @Mock private AccessTokenBlackListManager accessTokenBlackListManager;
     @Mock private UserStatusValidator userStatusValidator;
     @Mock private AuthAccountRepository authAccountRepository;
     @Mock private JwtProperties jwtProperties;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
- result에서 값이 필요없는 경우 빈 객체를 반환하도록 설정
- 모든 컨트롤러에 적용
- swaggerConfig에 적용 

ApiResponse를 다음과 같이 설정합니다. 
- 빈 응답일 경우 -> Obejct 타입
- result가 필요한 경우 -> 해당 result 타입 

result가 없는 경우, 응답을 다음과 같이 최종 반환합니다 

```json
{
  "isSuccess": true,
  "code": "AUTH2003",
  "message": "인증 코드가 전송되었습니다.",
  "timestamp": "2026-05-15T01:51:20.815723",
  "result": {}
}
```

- commonErrorStatus에서 도메인으로 분리할 수 있는 에러코드 제거 -> 상태코드가 중복되면 표시되지 않도록 수정

### 2️⃣ Functional Requirement


---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.
<img width="1130" height="599" alt="image" src="https://github.com/user-attachments/assets/dfe9af39-e85b-45b5-b86f-4c773e69e30e" />

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Refactor**
  * API 응답 구조 개선으로 모든 엔드포인트의 성공 응답 형식이 통일됨
  * 알림, 인증, 사용자, 큐레이션, 폴더, 공유 기능의 API 응답 처리 최적화
  * 응답 페이로드 생성 로직 단순화 및 안정성 강화

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LinkYou-2025/LinkU_backend/pull/300)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->