### PR TITLE
FEAT: 이메일 도메인 검증 & 스웨거 에러코드 문서화 자동화

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserErrorStatus.java
@@ -16,6 +16,7 @@ public enum UserErrorStatus implements BaseErrorCode {
     _EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "USERS4004", "인증 코드가 만료되었습니다."),
     _INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USERS4005", "잘못된 비밀번호입니다."),
     _PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USERS4006", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
+    _INVALID_EMAIL_ADDRESS(HttpStatus.BAD_REQUEST, "USERS4008", "유효하지 않은 이메일 주소입니다."),
     // 401 Unauthorized
     _VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "USERS4011", "인증 코드 검증 실패"),
     _LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "USERS4012", "이메일 주소 또는 비밀번호를 다시 확인하세요."),

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -6,10 +6,16 @@ import com.umc.linkyou.apiPayload.code.ReasonDTO;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
 import com.umc.linkyou.apiPayload.code.SuccessReasonDTO;
+import com.umc.linkyou.apiPayload.code.status.CommonErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
+import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.gemini.GeminiErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.validation.annotation.swagger.ApiAuthSuccessCode;
+import com.umc.linkyou.validation.annotation.swagger.ApiDomainErrorCodes;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCodes;
 import com.umc.linkyou.validation.annotation.swagger.ApiSuccessCode;
@@ -41,7 +47,7 @@ public class SwaggerConfig {
     public OpenAPI linkyouAPI() {
         Info info = new Info()
                 .title("linkyou API")
-                .description("linkyou API 명세서")
+                .description("linkyou API 명세서\n\n" + buildErrorCodeReference())
                 .version("1.0.0");
 
         String jwtSchemeName = "JWT TOKEN";
@@ -101,6 +107,23 @@ public class SwaggerConfig {
 
             if (!errorCodes.isEmpty()) {
                 generateErrorCodeResponseExample(operation, errorCodes.toArray(new ApiErrorCode[0]));
+            }
+
+            // 3. 클래스/인터페이스 단위 도메인 에러 전체 주입
+            ApiDomainErrorCodes domainCodes = handlerMethod.getBeanType().getAnnotation(ApiDomainErrorCodes.class);
+            if (domainCodes == null) {
+                for (Class<?> iface : handlerMethod.getBeanType().getInterfaces()) {
+                    domainCodes = iface.getAnnotation(ApiDomainErrorCodes.class);
+                    if (domainCodes != null) break;
+                }
+            }
+            if (domainCodes != null) {
+                ApiResponses responses = operation.getResponses();
+                for (Class<? extends BaseErrorCode> enumClass : domainCodes.value()) {
+                    for (BaseErrorCode code : enumClass.getEnumConstants()) {
+                        addErrorCodeExample(responses, code);
+                    }
+                }
             }
 
             return operation;
@@ -180,6 +203,9 @@ public class SwaggerConfig {
             for (AuthErrorStatus status : annotation.authErrorStatus()) {
                 addErrorCodeExample(responses, status);
             }
+            for (CurationErrorStatus status : annotation.curationErrorStatus()) {
+                addErrorCodeExample(responses, status);
+            }
         }
     }
 
@@ -189,6 +215,38 @@ public class SwaggerConfig {
                 com.umc.linkyou.apiPayload.ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
 
         addExample(responses, reason.getHttpStatus().value(), ((Enum<?>)status).name(), reason.getMessage(), exampleResponse);
+    }
+
+    private String buildErrorCodeReference() {
+        List<Class<? extends BaseErrorCode>> errorEnums = List.of(
+                AuthErrorStatus.class,
+                UserErrorStatus.class,
+                ErrorStatus.class,
+                AlarmErrorStatus.class,
+                AiArticleErrorStatus.class,
+                CurationErrorStatus.class,
+                GeminiErrorStatus.class,
+                CommonErrorStatus.class
+        );
+
+        StringBuilder sb = new StringBuilder("---\n## 에러 코드 레퍼런스\n\n");
+
+        for (Class<? extends BaseErrorCode> errorEnum : errorEnums) {
+            sb.append("<details>\n");
+            sb.append("<summary><b>").append(errorEnum.getSimpleName()).append("</b></summary>\n\n");
+            sb.append("| Code | HTTP | Message |\n");
+            sb.append("|------|:----:|---------|\n");
+
+            for (BaseErrorCode code : errorEnum.getEnumConstants()) {
+                ErrorReasonDTO reason = code.getReasonHttpStatus();
+                sb.append("| `").append(reason.getCode()).append("` | ")
+                        .append(reason.getHttpStatus().value()).append(" | ")
+                        .append(reason.getMessage()).append(" |\n");
+            }
+            sb.append("\n</details>\n\n");
+        }
+
+        return sb.toString();
     }
 
 }

--- a/src/main/java/com/umc/linkyou/domain/CurationSectionInfo.java
+++ b/src/main/java/com/umc/linkyou/domain/CurationSectionInfo.java
@@ -9,7 +9,7 @@ import lombok.*;
         name = "curation_section_info",
         uniqueConstraints = @UniqueConstraint(
                 name = "uq_curation_section",
-                columnNames = {"month", "section_number"}
+                columnNames = {"base_month", "section_number"}
         )
 )
 @Getter
@@ -22,7 +22,7 @@ public class CurationSectionInfo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 7, nullable = false)
+    @Column(name = "base_month", length = 7, nullable = false)
     private String month; // "YYYY-MM"
 
     @Column(name = "section_number", nullable = false)

--- a/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
@@ -4,12 +4,12 @@ import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.xbill.DNS.Lookup;
-import org.xbill.DNS.MXRecord;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Type;
 
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.InitialDirContext;
+import java.util.Hashtable;
 import java.util.Locale;
 
 /**
@@ -19,45 +19,49 @@ import java.util.Locale;
 @Component
 public class EmailDomainValidator {
 
-    public boolean isDeliverableAddress(String email) {
-        if (email == null || email.isBlank()) return false;
+    private static final String DNS_TIMEOUT_MS = "3000";
+    private static final String DNS_RETRIES = "1";
 
+    // 전체 email 도메인 검증 로직, 서비스에서 따로 예외를 던지도록 설정
+    public boolean isDeliverableAddress(String email) throws AddressException {
+        if (email == null || email.isBlank()) return false;
         String domain = extractDomain(email);
-        return domain != null && hasDnsRecord(domain);
+        return hasDnsRecord(domain);
     }
 
-    private String extractDomain(String email) {
-        try {
-            InternetAddress address = new InternetAddress(email, true);
-            address.validate();
-            String addr = address.getAddress();
-            return addr.substring(addr.indexOf('@') + 1).toLowerCase(Locale.ROOT);
-        } catch (AddressException e) {
-            return null;
-        }
+    private String extractDomain(String email) throws AddressException {
+        InternetAddress address = new InternetAddress(email, true);
+        address.validate();
+        String addr = address.getAddress();
+        return addr.substring(addr.indexOf('@') + 1).toLowerCase(Locale.ROOT);
     }
 
     private boolean hasDnsRecord(String domain) {
+        Hashtable<String, String> env = new Hashtable<>();
+        env.put("java.naming.factory.initial", "com.sun.jndi.dns.DnsContextFactory");
+        env.put("java.naming.provider.url", "dns:");
+        env.put("com.sun.jndi.dns.timeout.initial", DNS_TIMEOUT_MS);
+        env.put("com.sun.jndi.dns.timeout.retries", DNS_RETRIES);
+
+        InitialDirContext ctx = null;
         try {
-            Record[] mx = new Lookup(domain, Type.MX).run();
-            if (mx != null && mx.length > 0) return hasUsableMx(mx);
+            ctx = new InitialDirContext(env);
+            Attributes mxAttrs = ctx.getAttributes(domain, new String[]{"MX"});
+            if (mxAttrs.get("MX") != null) return true;
 
-            Record[] a = new Lookup(domain, Type.A).run();
-            if (a != null && a.length > 0) return true;
-
-            Record[] aaaa = new Lookup(domain, Type.AAAA).run();
-            return aaaa != null && aaaa.length > 0;
-        } catch (TextParseException e) {
-            log.warn("이메일 도메인 DNS 조회 실패 domain={}", domain);
+            Attributes aAttrs = ctx.getAttributes(domain, new String[]{"A", "AAAA"});
+            return aAttrs.get("A") != null || aAttrs.get("AAAA") != null;
+        } catch (NameNotFoundException e) {
+            // 도메인이 존재하지 않음 (NXDOMAIN)
             return false;
+        } catch (NamingException e) {
+            // timeout 등 일시적 인프라 오류 — 검증 불가이므로 통과 처리
+            log.warn("이메일 도메인 DNS 조회 실패, fail-open 처리 domain={}", domain);
+            return true;
+        } finally {
+            if (ctx != null) {
+                try { ctx.close(); } catch (NamingException ignored) {}
+            }
         }
-    }
-
-    private boolean hasUsableMx(Record[] records) {
-        for (Record r : records) {
-            MXRecord mx = (MXRecord) r;
-            if (!mx.getTarget().toString().equals(".")) return true;
-        }
-        return false;
     }
 }

--- a/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
@@ -4,17 +4,13 @@ import jakarta.mail.internet.AddressException;
 import jakarta.mail.internet.InternetAddress;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.xbill.DNS.Lookup;
-import org.xbill.DNS.MXRecord;
-import org.xbill.DNS.Record;
-import org.xbill.DNS.TextParseException;
-import org.xbill.DNS.Type;
 
+import javax.naming.NamingException;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.InitialDirContext;
+import java.util.Hashtable;
 import java.util.Locale;
 
-/**
- * 이메일 도메인 유효성 검사
- */
 @Slf4j
 @Component
 public class EmailDomainValidator {
@@ -39,25 +35,19 @@ public class EmailDomainValidator {
 
     private boolean hasDnsRecord(String domain) {
         try {
-            Record[] mx = new Lookup(domain, Type.MX).run();
-            if (mx != null && mx.length > 0) return hasUsableMx(mx);
+            Hashtable<String, String> env = new Hashtable<>();
+            env.put("java.naming.factory.initial", "com.sun.jndi.dns.DnsContextFactory");
+            env.put("java.naming.provider.url", "dns:");
+            InitialDirContext ctx = new InitialDirContext(env);
 
-            Record[] a = new Lookup(domain, Type.A).run();
-            if (a != null && a.length > 0) return true;
+            Attributes mxAttrs = ctx.getAttributes(domain, new String[]{"MX"});
+            if (mxAttrs.get("MX") != null) return true;
 
-            Record[] aaaa = new Lookup(domain, Type.AAAA).run();
-            return aaaa != null && aaaa.length > 0;
-        } catch (TextParseException e) {
+            Attributes aAttrs = ctx.getAttributes(domain, new String[]{"A", "AAAA"});
+            return aAttrs.get("A") != null || aAttrs.get("AAAA") != null;
+        } catch (NamingException e) {
             log.warn("이메일 도메인 DNS 조회 실패 domain={}", domain);
             return false;
         }
-    }
-
-    private boolean hasUsableMx(Record[] records) {
-        for (Record r : records) {
-            MXRecord mx = (MXRecord) r;
-            if (!mx.getTarget().toString().equals(".")) return true;
-        }
-        return false;
     }
 }

--- a/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailDomainValidator.java
@@ -1,0 +1,63 @@
+package com.umc.linkyou.service.email;
+
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.InternetAddress;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.MXRecord;
+import org.xbill.DNS.Record;
+import org.xbill.DNS.TextParseException;
+import org.xbill.DNS.Type;
+
+import java.util.Locale;
+
+/**
+ * 이메일 도메인 유효성 검사
+ */
+@Slf4j
+@Component
+public class EmailDomainValidator {
+
+    public boolean isDeliverableAddress(String email) {
+        if (email == null || email.isBlank()) return false;
+
+        String domain = extractDomain(email);
+        return domain != null && hasDnsRecord(domain);
+    }
+
+    private String extractDomain(String email) {
+        try {
+            InternetAddress address = new InternetAddress(email, true);
+            address.validate();
+            String addr = address.getAddress();
+            return addr.substring(addr.indexOf('@') + 1).toLowerCase(Locale.ROOT);
+        } catch (AddressException e) {
+            return null;
+        }
+    }
+
+    private boolean hasDnsRecord(String domain) {
+        try {
+            Record[] mx = new Lookup(domain, Type.MX).run();
+            if (mx != null && mx.length > 0) return hasUsableMx(mx);
+
+            Record[] a = new Lookup(domain, Type.A).run();
+            if (a != null && a.length > 0) return true;
+
+            Record[] aaaa = new Lookup(domain, Type.AAAA).run();
+            return aaaa != null && aaaa.length > 0;
+        } catch (TextParseException e) {
+            log.warn("이메일 도메인 DNS 조회 실패 domain={}", domain);
+            return false;
+        }
+    }
+
+    private boolean hasUsableMx(Record[] records) {
+        for (Record r : records) {
+            MXRecord mx = (MXRecord) r;
+            if (!mx.getTarget().toString().equals(".")) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/umc/linkyou/service/email/EmailService.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailService.java
@@ -1,6 +1,5 @@
 package com.umc.linkyou.service.email;
 
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.config.properties.SesProperties;
@@ -50,7 +49,7 @@ public class EmailService {
         }
     }
 
-    // 이메일 재설정 메일 전송
+    // 비밀번호 재설정 메일 전송
     public void sendPasswordResetEmail(String toEmail,
                                        String nickname,
                                        String resetUrl,

--- a/src/main/java/com/umc/linkyou/service/email/EmailVerificationService.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailVerificationService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.Duration;
@@ -18,6 +19,7 @@ import java.util.Objects;
 /*
     * 이메일 인증 기능을 담당하는 서비스
     * 회원가입 시 이메일로 인증 코드를 발송하고, 사용자가 입력한 코드와 Redis에 저장된 코드를 비교하여 검증하는 로직을 포함
+    * 도메인 검증 로직 포함
  */
 @Slf4j
 @Service
@@ -29,6 +31,7 @@ public class EmailVerificationService {
     private final StringRedisTemplate stringRedisTemplate;
     private final EmailService emailService;
     private final EmailRateLimiter rateLimiter;
+    private final EmailDomainValidator emailDomainValidator;
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final int EXPIRY_MINUTES = 10;
@@ -43,7 +46,10 @@ public class EmailVerificationService {
 
     // 회원가입 이메일 인증 코드 전송
     // 이미 가입된 이메일이면 중복 에러
+    @Transactional(readOnly = true)
     public void sendCode(String email) {
+        validateDeliverableEmail(email);
+
         if (authAccountRepository.existsByEmail(email)) {
             throw new UserHandler(UserErrorStatus._DUPLICATE_JOIN_REQUEST);
         }
@@ -55,14 +61,8 @@ public class EmailVerificationService {
         String code = generateCode();
         emailVerificationRedisRepository.save(EmailVerificationCache.of(hashedEmail, code));
 
-        try {
-            emailService.sendVerificationEmailTemplate(email, "링큐 회원", code, EXPIRY_MINUTES);
-            resetVerifyFailureCount(hashedEmail);
-        } catch (Exception e) {
-            log.error("이메일 인증 코드 전송 실패", e);
-            emailVerificationRedisRepository.deleteById(hashedEmail);
-            throw new UserHandler(UserErrorStatus._SEND_MAIL_FAILED);
-        }
+        emailService.sendVerificationEmailTemplate(email, "링큐 회원", code, EXPIRY_MINUTES);
+        resetVerifyFailureCount(hashedEmail);
         log.info("이메일 인증 코드 전송 완료");
     }
 
@@ -116,5 +116,12 @@ public class EmailVerificationService {
             builder.append(SECURE_RANDOM.nextInt(10));
         }
         return builder.toString();
+    }
+
+    // 도메인 검증
+    private void validateDeliverableEmail(String email) {
+        if (!emailDomainValidator.isDeliverableAddress(email)) {
+            throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
+        }
     }
 }

--- a/src/main/java/com/umc/linkyou/service/email/EmailVerificationService.java
+++ b/src/main/java/com/umc/linkyou/service/email/EmailVerificationService.java
@@ -12,6 +12,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.mail.internet.AddressException;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Objects;
@@ -118,9 +119,13 @@ public class EmailVerificationService {
         return builder.toString();
     }
 
-    // 도메인 검증
+    // 이메일 포맷 및 도메인 검증
     private void validateDeliverableEmail(String email) {
-        if (!emailDomainValidator.isDeliverableAddress(email)) {
+        try {
+            if (!emailDomainValidator.isDeliverableAddress(email)) {
+                throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
+            }
+        } catch (AddressException e) {
             throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
         }
     }

--- a/src/main/java/com/umc/linkyou/service/email/PasswordResetService.java
+++ b/src/main/java/com/umc/linkyou/service/email/PasswordResetService.java
@@ -11,6 +11,7 @@ import com.umc.linkyou.repository.userRepository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import jakarta.mail.internet.AddressException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -109,8 +110,13 @@ public class PasswordResetService {
         }
     }
 
+    // 이메일 포맷 및 도메인 검증
     private void validateDeliverableEmail(String email) {
-        if (!emailDomainValidator.isDeliverableAddress(email)) {
+        try {
+            if (!emailDomainValidator.isDeliverableAddress(email)) {
+                throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
+            }
+        } catch (AddressException e) {
             throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
         }
     }

--- a/src/main/java/com/umc/linkyou/service/email/PasswordResetService.java
+++ b/src/main/java/com/umc/linkyou/service/email/PasswordResetService.java
@@ -40,6 +40,7 @@ public class PasswordResetService {
     private final PasswordResetRedisRepository passwordResetRedisRepository;
     private final EmailService emailService;
     private final EmailRateLimiter rateLimiter;
+    private final EmailDomainValidator emailDomainValidator;
 
     @Value("${app.server.base-url}")
     private String serverBaseUrl;
@@ -54,6 +55,8 @@ public class PasswordResetService {
     // 비밀번호 재설정 링크 전송
     @Transactional(readOnly = true)
     public void sendResetLink(String email) {
+        validateDeliverableEmail(email);
+
         rateLimiter.enforce(email, SEND_COOLDOWN_KEY, DAILY_SEND_COUNT_KEY,
                 SEND_COOLDOWN, DAILY_LIMIT_TTL, MAX_DAILY_SEND_COUNT);
         authAccountRepository.findUserByEmailAndProvider(email, Provider.GENERAL)
@@ -67,19 +70,7 @@ public class PasswordResetService {
 
         String nickname = (user.getNickName() == null || user.getNickName().isBlank()) ? "링큐 회원" : user.getNickName();
         String resetUrl = serverBaseUrl + "/password/reset?token=" + token;
-        try {
-            // 이메일 발송 실패 시 Redis에 저장된 토큰 삭제해서 재설정 시도 불가하도록 함
-            emailService.sendPasswordResetEmail(email, nickname, resetUrl, EXPIRY_MINUTES);
-        } catch (Exception e) {
-            try {
-                // 이메일 발송 실패 시 토큰 정리 시도, 실패해도 TTL로 자동 만료되므로 재시도 방지 가능
-                passwordResetRedisRepository.deleteById(token);
-            } catch (Exception redisEx) {
-                // 토큰 TTL로 자동 만료되므로 정리 실패는 로그만 남김
-                log.error("발송 실패 후 토큰 정리 실패", redisEx);
-            }
-            throw e;
-        }
+        emailService.sendPasswordResetEmail(email, nickname, resetUrl, EXPIRY_MINUTES);
         log.info("비밀번호 재설정 링크 전송: {}", user.getId());
     }
 
@@ -115,6 +106,12 @@ public class PasswordResetService {
         }
         if (!PASSWORD_POLICY_PATTERN.matcher(newPassword).matches()) {
             throw new UserHandler(UserErrorStatus._INVALID_PASSWORD);
+        }
+    }
+
+    private void validateDeliverableEmail(String email) {
+        if (!emailDomainValidator.isDeliverableAddress(email)) {
+            throw new UserHandler(UserErrorStatus._INVALID_EMAIL_ADDRESS);
         }
     }
 }

--- a/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiDomainErrorCodes.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiDomainErrorCodes.java
@@ -1,0 +1,11 @@
+package com.umc.linkyou.validation.annotation.swagger;
+
+import com.umc.linkyou.apiPayload.code.BaseErrorCode;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiDomainErrorCodes {
+    Class<? extends BaseErrorCode>[] value();
+}

--- a/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import java.lang.annotation.*;
 
@@ -18,4 +19,5 @@ public @interface ApiErrorCode {
     AiArticleErrorStatus[] aiArticleErrorStatus() default {};
     AuthErrorStatus[] authErrorStatus() default {};
     CommonErrorStatus[] commonErrorStatus() default {};
+    CurationErrorStatus[] curationErrorStatus() default {};
 }

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -48,6 +48,7 @@ public interface AlarmApi {
             - 요청 body의 `fcmToken`은 필수값입니다.
             """)
     @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @DeleteMapping("/fcmtoken")
     ApiResponse<Object> deleteFcmToken(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -16,6 +16,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -107,7 +109,7 @@ public interface AlarmApi {
             @Parameter(description = "커서(userAlarmId). null일 경우 최신부터 조회")
             @RequestParam(required = false) Long cursor,
             @Parameter(description = "조회 개수")
-            @RequestParam(defaultValue = "20") int size
+            @RequestParam(defaultValue = "20") @Min(1) @Max(20) int size
     );
 
     @Operation(summary = "알림 상세 조회", description = """

--- a/src/main/java/com/umc/linkyou/web/api/AuthApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AuthApi.java
@@ -14,6 +14,7 @@ import com.umc.linkyou.web.dto.EmailRequestDTO;
 import com.umc.linkyou.web.dto.PasswordResetRequestDTO;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -121,37 +122,12 @@ public interface AuthApi {
     @GetMapping("/check-nickname")
     ApiResponse<Object> checkNickname(@RequestParam String nickname);
 
-    @Operation(
-            summary = "비밀번호 재설정 링크 전송",
-            description = """
-                    등록된 이메일로 비밀번호 재설정 페이지 링크를 전송합니다.
-                    - 일반 로그인 계정이면 비밀번호 재설정 링크를 전송합니다.
-                    - 가입되지 않은 이메일이거나 소셜 전용 계정이어도 동일한 성공 응답을 반환합니다.
-                    - 재설정 링크는 Redis에 저장된 토큰 기준으로 10분 동안 유효합니다.
-                    """
-    )
-    @ApiAuthSuccessCode(AuthSuccessStatus.PASSWORD_RESET_LINK_SENT)
-    @ApiErrorCode(commonErrorStatus = {CommonErrorStatus._TOO_MANY_REQUESTS})
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._SEND_MAIL_FAILED})
+    @Operation(hidden = true)
     @PostMapping("/password/reset/send")
     ApiResponse<Object> sendPasswordResetLink(@RequestBody @Valid EmailRequestDTO.ResetLinkDTO request);
 
-    @Operation(
-            summary = "비밀번호 재설정",
-            description = """
-                    토큰, 새 비밀번호, 비밀번호 확인을 입력해 비밀번호를 변경합니다.
-                    - `token`은 메일의 비밀번호 재설정 링크에서 전달받은 값입니다.
-                    - 새 비밀번호와 비밀번호 확인이 일치하면 비밀번호를 변경합니다.
-                    - 토큰이 없거나 만료되면 비밀번호 재설정이 불가능합니다.
-                    """
-    )
-    @ApiAuthSuccessCode(AuthSuccessStatus.PASSWORD_RESET_SUCCESS)
-    @ApiErrorCode(userErrorStatus = {
-            UserErrorStatus._INVALID_PASSWORD,
-            UserErrorStatus._PASSWORD_MISMATCH,
-            UserErrorStatus._USER_NOT_FOUND
-    })
-    @PutMapping("/password/reset")
+    @Operation(hidden = true)
+    @PostMapping("/password/reset")
     ApiResponse<Object> resetPassword(@RequestBody @Valid PasswordResetRequestDTO request);
 
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/api/CategoryApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/CategoryApi.java
@@ -1,0 +1,35 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.category.CategoryListResponseDTO;
+import com.umc.linkyou.web.dto.category.UpdateCategoryColorRequestDTO;
+import com.umc.linkyou.web.dto.category.UserCategoryColorResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "category-controller", description = "카테고리 관련 API")
+@RequestMapping("/categories")
+public interface CategoryApi {
+
+    @Operation(summary = "카테고리 목록 조회", description = "사용자가 사용할 수 있는 모든 카테고리 목록을 조회합니다.")
+    @GetMapping
+    ApiResponse<List<CategoryListResponseDTO>> getCategoryList(
+            @CurrentUser CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "유저 카테고리(중분류 폴더) 색상 수정", description = "사용자의 카테고리(중분류 폴더) 색상을 수정합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._CATEGORY_NOT_FOUND})
+    @PutMapping("/{categoryId}/color")
+    ApiResponse<UserCategoryColorResponseDTO> updateUserCategoryColor(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long categoryId,
+            @RequestBody UpdateCategoryColorRequestDTO request
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/CurationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/CurationApi.java
@@ -1,0 +1,54 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.curation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "curation-controller", description = "큐레이션 관련 API")
+@RequestMapping("/curations")
+public interface CurationApi {
+
+    @Operation(summary = "큐레이션 섹션 정보 조회", description = "지정한 월(YYYY-MM)의 섹션별 제목, 설명, 대표 이미지를 반환합니다. 미입력 시 이번 달 기준. 모든 유저 동일.")
+    @GetMapping("/sections")
+    ResponseEntity<ApiResponse<List<CurationSectionResponse>>> getSectionInfo(
+            @RequestParam(required = false) String month
+    );
+
+    @Operation(summary = "연도별 큐레이션 히스토리 조회", description = "지정한 연도의 1~12월 큐레이션 목록을 반환합니다. 미입력 시 올해 기준. 생성되지 않은 달은 curationId, thumbnailUrl이 null입니다.")
+    @GetMapping("/history")
+    ResponseEntity<ApiResponse<List<CurationListResponse>>> getMyCurationList(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam(required = false) Integer year
+    );
+
+    @Operation(summary = "가장 최근 큐레이션 조회", description = "내 최신 큐레이션을 조회합니다.")
+    @GetMapping("/latest")
+    ResponseEntity<ApiResponse<CurationLatestResponse>> getLatestCuration(
+            @CurrentUser CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "큐레이션 상세 조회", description = "큐레이션 ID로 상세 정보를 조회합니다.")
+    @ApiErrorCode(curationErrorStatus = {CurationErrorStatus._CURATION_NOT_FOUND, CurationErrorStatus._CURATION_FORBIDDEN})
+    @GetMapping("/detail/{curationId}")
+    ResponseEntity<ApiResponse<CurationDetailResponse>> getCurationDetail(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long curationId
+    );
+
+    @Operation(summary = "큐레이션 기반 링크 추천", description = "내부/외부 링크를 추천합니다.")
+    @ApiErrorCode(curationErrorStatus = {CurationErrorStatus._CURATION_NOT_FOUND})
+    @GetMapping("/recommend-links")
+    ResponseEntity<ApiResponse<List<RecommendedLinkResponse>>> getRecommendedLinks(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam Long curationId
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/DomainApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/DomainApi.java
@@ -1,0 +1,38 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.DomainDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "domain-controller", description = "도메인 관련 API")
+@RequestMapping("/domain")
+public interface DomainApi {
+
+    @Operation(summary = "도메인 생성", description = "새로운 도메인을 생성합니다. 도메인 이름, 도메인 꼬리, 이미지를 포함할 수 있습니다.")
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ApiResponse<DomainDTO.DomainReponseDTO> createDomain(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String domainTail,
+            @RequestParam(required = false) MultipartFile image
+    );
+
+    @Operation(summary = "도메인 수정", description = "기존 도메인의 정보를 수정합니다. 도메인 이름, 도메인 꼬리, 이미지를 수정할 수 있습니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._DOMAIN_NOT_FOUND})
+    @PatchMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ApiResponse<DomainDTO.DomainReponseDTO> updateDomain(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam Long id,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String domainTail,
+            @RequestParam(required = false) MultipartFile image
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -1,0 +1,87 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.folder.*;
+import com.umc.linkyou.web.dto.folder.linku.FolderLinkusResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "folder-controller", description = "폴더 관련 API")
+@RequestMapping("/folders")
+public interface FolderApi {
+
+    @Operation(summary = "소분류 폴더 생성", description = "중분류 폴더 하위에 소분류 폴더를 생성합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_CREATE_FORBIDDEN, ErrorStatus._FOLDER_CREATE_DUPLICATE})
+    @PostMapping("/{parentFolderId}/subfolders")
+    ApiResponse<FolderResponseDTO> createFolder(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long parentFolderId,
+            @RequestBody FolderCreateRequestDTO request
+    );
+
+    @Operation(summary = "소분류 폴더 수정", description = "기존 소분류 폴더의 정보를 수정합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @PutMapping("/subfolders/{folderId}")
+    ApiResponse<FolderResponseDTO> updateFolder(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @RequestBody FolderUpdateRequestDTO request
+    );
+
+    @Operation(summary = "소분류 폴더 삭제", description = "소분류 폴더를 삭제합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_DELETE_FORBIDDEN})
+    @DeleteMapping("/subfolders/{folderId}")
+    ApiResponse<Object> deleteFolder(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+
+    @Operation(summary = "내 폴더 목록(트리) 조회", description = "사용자의 모든 폴더를 트리 구조로 조회합니다.")
+    @GetMapping("/my")
+    ApiResponse<List<FolderTreeResponseDTO>> getMyFolderTree(
+            @CurrentUser CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "중분류 폴더 조회", description = "사용자의 모든 중분류 폴더 목록을 조회합니다. sort: name(가나다순, 기본값), updatedAt(최근 수정순)")
+    @GetMapping("/parentFolders")
+    ApiResponse<List<FolderListResponseDTO>> getParentFolderList(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "name") String sort
+    );
+
+    @Operation(summary = "중분류 내부의 하위 폴더 조회", description = "특정 중분류 폴더의 하위 소분류 폴더 목록을 조회합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN})
+    @GetMapping("/{parentFolderId}/subfolders")
+    ApiResponse<List<FolderListResponseDTO>> getSubFolderList(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long parentFolderId
+    );
+
+    @Operation(summary = "북마크 설정/해제", description = "폴더의 북마크 상태를 설정하거나 해제합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_BOOKMARK_NOT_FOUND})
+    @PatchMapping("/{folderId}/bookmark")
+    ApiResponse<BookmarkUpdateResponseDTO> updateBookmark(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @RequestBody BookmarkUpdateRequestDTO request
+    );
+
+    @Operation(summary = "폴더 내부 링크, 폴더 목록 조회", description = "특정 폴더 내부의 링크와 하위 폴더 목록을 조회합니다. 커서 기반 페이지네이션을 지원합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN, ErrorStatus._FOLDER_INVALID_CURSOR})
+    @GetMapping("/{folderId}/linkus")
+    ApiResponse<FolderLinkusResponseDTO> getFolderLinkus(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @RequestParam(defaultValue = "20") @Min(1) int limit,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "name") String sort
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
@@ -1,0 +1,31 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.folder.share.InvitationInfoResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "invitation-controller", description = "초대 관련 API")
+@RequestMapping("/invitations")
+public interface InvitationApi {
+
+    @Operation(summary = "초대장 미리보기", description = "토큰을 통해 초대된 폴더명과 초대자 닉네임을 확인합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus.INVITATION_NOT_FOUND, ErrorStatus.INVITATION_EXPIRED, ErrorStatus.INVITATION_LINK_NOT_FOUND})
+    @GetMapping("/{token}")
+    ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(
+            @PathVariable String token
+    );
+
+    @Operation(summary = "초대 수락하기", description = "초대를 수락합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus.INVITATION_NOT_FOUND, ErrorStatus.INVITATION_EXPIRED, ErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT})
+    @PostMapping("/{token}")
+    ApiResponse<Long> acceptInvitation(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable String token
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
@@ -1,0 +1,38 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "keyword-controller", description = "키워드 통계 관련 API")
+@RequestMapping("/keywords")
+public interface KeywordApi {
+
+    @Operation(summary = "내 월별 상위 키워드 조회")
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @GetMapping("/my")
+    ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getMyTopKeywords(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit
+    );
+
+    @Operation(summary = "같은 직업 유저들의 상위 키워드 조회")
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND, UserErrorStatus._JOB_NOT_SET})
+    @GetMapping("/job")
+    ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getJobTopKeywords(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "15") @Min(1) @Max(50) int limit
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
@@ -1,0 +1,98 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.linku.LinkuRequestDTO;
+import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
+import com.umc.linkyou.web.dto.linku.LinkuSearchSuggestionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "linku-controller", description = "링크(Linku) 관련 API")
+@RequestMapping("/linku")
+public interface LinkuApi {
+
+    @Operation(summary = "링크 생성", description = "새로운 링크를 생성합니다. URL, 메모, 감정 ID, 이미지를 포함할 수 있습니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._LINKU_INVALID_URL, ErrorStatus._LINKU_VIDEO_NOT_ALLOWED})
+    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ApiResponse<LinkuResponseDTO.LinkuResultDTO> createLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String linku,
+            @RequestParam(required = false) String memo,
+            @RequestParam(required = false) Long emotionId,
+            @RequestParam(required = false) MultipartFile image
+    );
+
+    @Operation(summary = "링크 존재 여부 확인", description = "해당 URL의 링크가 이미 존재하는지 확인합니다.")
+    @GetMapping("/exist")
+    ApiResponse<LinkuResponseDTO.LinkuIsExistDTO> existLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String url
+    );
+
+    @Operation(summary = "링크 상세 조회 (인증된 사용자)", description = "인증된 사용자의 링크 상세 정보를 조회합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._LINKU_NOT_FOUND, ErrorStatus._USER_LINKU_NOT_FOUND})
+    @GetMapping("/{linkuid}")
+    ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable("linkuid") Long linkuid
+    );
+
+    @Operation(summary = "링크 상세 조회 (사용자 ID 지정)", description = "특정 사용자 ID와 링크 ID로 링크 상세 정보를 조회합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._LINKU_NOT_FOUND, ErrorStatus._USER_LINKU_NOT_FOUND})
+    @GetMapping("/{userId}/{linkuId}")
+    ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(
+            @PathVariable Long userId,
+            @PathVariable Long linkuId
+    );
+
+    @Operation(summary = "최근 열람한 링크 조회", description = "사용자가 최근에 열람한 링크 목록을 조회합니다. limit 파라미터로 조회 개수를 지정할 수 있습니다.")
+    @GetMapping("/recent")
+    ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getRecentViewedLinkus(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "10") int limit
+    );
+
+    @Operation(summary = "링크 수정", description = "기존 링크의 정보(URL, 메모, 감정, 도메인, 제목 등)를 수정합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._LINKU_NOT_FOUND, ErrorStatus._USER_LINKU_NOT_FOUND})
+    @PatchMapping(value = "/{linkuId}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    ApiResponse<LinkuResponseDTO.LinkuResultDTO> updateLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long linkuId,
+            @RequestBody LinkuRequestDTO.LinkuUpdateDTO updateDTO
+    );
+
+    @Operation(summary = "링크 추천", description = "상황(situation)과 감정(emotion)을 기반으로 링크를 추천합니다. 페이지네이션을 지원합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._SITUATION_NOT_FOUND, ErrorStatus._EMOTION_NOT_FOUND, ErrorStatus._RECOMMEND_LINKU_NOT_ENOUGH_LINKS, ErrorStatus._RECOMMEND_LINKU_NO_RECOMMENDATION, ErrorStatus._RECOMMEND_LINKU_NEW_USER})
+    @GetMapping("/recommend")
+    ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> recommendLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam Long situationId,
+            @RequestParam Long emotionId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "5") int size
+    );
+
+    @Operation(summary = "빠른 검색 (사용자 저장 링크 전체 대상)", description = "사용자가 저장한 링크 전체를 대상으로 키워드가 포함된 추천 검색어 목록을 조회합니다.")
+    @GetMapping("/search/quick")
+    ApiResponse<List<LinkuSearchSuggestionResponse>> quickSearch(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String keyword
+    );
+
+    @Operation(summary = "링크 삭제", description = "사용자가 저장한 링크를 삭제합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._USER_LINKU_NOT_FOUND})
+    @DeleteMapping("/{userLinkuId}")
+    ApiResponse<Object> deleteUsersLinku(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long userLinkuId
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -1,0 +1,63 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.folder.share.FolderPermissionRequestDTO;
+import com.umc.linkyou.web.dto.folder.share.ShareFolderResponseDTO;
+import com.umc.linkyou.web.dto.folder.share.ViewerResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "share-folder-controller", description = "폴더 공유 관련 API")
+@RequestMapping("/folders/share")
+public interface ShareFolderApi {
+
+    @Operation(summary = "초대 링크 생성", description = "해당 폴더의 초대용 토큰을 생성합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_CREATE_FORBIDDEN})
+    @PostMapping("/{folderId}/invitation")
+    ApiResponse<String> createInviteLink(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+
+    @Operation(summary = "초대 링크 삭제", description = "초대 링크를 비활성화합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus.INVITATION_NOT_FOUND})
+    @DeleteMapping("/{folderId}/invitation")
+    ApiResponse<Object> deactivateInviteLink(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+
+    @Operation(summary = "폴더 멤버 조회", description = "공유된 폴더의 멤버 목록을 조회합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN})
+    @GetMapping("/{folderId}/members")
+    ApiResponse<List<ViewerResponseDTO>> getFolderViewers(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+
+    @Operation(summary = "폴더 권한 수정", description = "폴더 공유 멤버의 권한(뷰어/라이터)을 수정합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED, ErrorStatus._FOLDER_OWNER_UPDATE_NOT_ALLOWED, ErrorStatus._INVALID_PERMISSION_TYPE})
+    @PutMapping("/{folderId}/members/{userFolderId}")
+    ApiResponse<ShareFolderResponseDTO> updateViewerPermission(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @PathVariable Long userFolderId,
+            @Valid @RequestBody FolderPermissionRequestDTO request
+    );
+
+    @Operation(summary = "폴더 비공개 전환", description = "공유된 폴더를 비공개로 전환하고 모든 공유 권한을 제거합니다.")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @PostMapping("/{folderId}/unshare")
+    ApiResponse<ShareFolderResponseDTO> unshareFolder(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
@@ -1,0 +1,32 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.folder.share.SharedFolderGroupResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "shared-folder-controller", description = "공유 받은 폴더 관련 API")
+@RequestMapping("/folders/shared")
+public interface SharedFolderApi {
+
+    @Operation(summary = "공유 받은 폴더 목록 조회", description = "사용자가 공유 받은 폴더를 소유자별로 그룹핑하여 조회합니다.")
+    @GetMapping
+    ApiResponse<List<SharedFolderGroupResponseDTO>> getSharedFolders(
+            @CurrentUser CustomUserDetails userDetails
+    );
+
+    @Operation(summary = "공유 받은 폴더 삭제", description = "공유 받은 폴더를 자신의 목록에서 제거합니다. (폴더 자체는 삭제되지 않습니다)")
+    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_FOUND})
+    @DeleteMapping("/{folderId}")
+    ApiResponse<Object> deleteSharedFolder(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable Long folderId
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
@@ -40,6 +40,7 @@ public class AiArticleController {
         return ApiResponse.onSuccess(AiArticleSuccessStatus.AI_ARTICLE_OK, result);
     }
 
+    @GetMapping("/category/{categoryId}")
     public ApiResponse<LinkuResponseDTO.LinkuSliceResultDTO> getMyAiArticlesByCategory(
             @PathVariable("categoryId") Long categoryId,
             @RequestParam(name = "cursor", required = false) Long cursor,

--- a/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
@@ -86,7 +86,7 @@ public class AlarmController implements AlarmApi {
             @CurrentUser CustomUserDetails userDetails,
             @RequestParam("alarmType") AlarmSettingType alarmType,
             @RequestParam(required = false) Long cursor,
-            @RequestParam(defaultValue = "20") @Min(1) @Max(20) int size
+            @RequestParam(defaultValue = "20") int size
     ) {
         return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_LIST_OK, alarmService.viewAlarmList(userDetails.getUserId(), alarmType, cursor, size));
     }

--- a/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CategoryController.java
@@ -2,52 +2,32 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.category.CategorySuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.category.CategoryService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.CategoryApi;
 import com.umc.linkyou.web.dto.category.CategoryListResponseDTO;
 import com.umc.linkyou.web.dto.category.UpdateCategoryColorRequestDTO;
 import com.umc.linkyou.web.dto.category.UserCategoryColorResponseDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "category-controller", description = "카테고리 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/categories")
 @RequiredArgsConstructor
-public class CategoryController {
+public class CategoryController implements CategoryApi {
+
     private final CategoryService categoryService;
 
-    @Operation(
-            summary = "카테고리 목록 조회",
-            description = "사용자가 사용할 수 있는 모든 카테고리 목록을 조회합니다."
-    )
-    @GetMapping
-    public ApiResponse<List<CategoryListResponseDTO>> getCategoryList(
-            @CurrentUser CustomUserDetails userDetails
-    ) {
-        List<CategoryListResponseDTO> categoryList = categoryService.getCategories(userDetails.getUserId());
-        return ApiResponse.onSuccess(CategorySuccessStatus.CATEGORY_OK, categoryList);
+    @Override
+    public ApiResponse<List<CategoryListResponseDTO>> getCategoryList(@CurrentUser CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(CategorySuccessStatus.CATEGORY_OK, categoryService.getCategories(userDetails.getUserId()));
     }
 
-    @Operation(
-            summary = "유저 카테고리(중분류 폴더) 색상 수정",
-            description = "사용자의 카테고리(중분류 폴더) 색상을 수정합니다."
-    )
-    @PutMapping("/{categoryId}/color")
-    public ApiResponse<UserCategoryColorResponseDTO> updateUserCategoryColor(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long categoryId,
-            @RequestBody UpdateCategoryColorRequestDTO request
-    ) {
-        UserCategoryColorResponseDTO userCategoryColor =
-                categoryService.updateUserCategoryColor(userDetails.getUserId(), categoryId, request);
-        return ApiResponse.onSuccess(CategorySuccessStatus.CATEGORY_COLOR_OK, userCategoryColor);
+    @Override
+    public ApiResponse<UserCategoryColorResponseDTO> updateUserCategoryColor(@CurrentUser CustomUserDetails userDetails, @PathVariable Long categoryId, @RequestBody UpdateCategoryColorRequestDTO request) {
+        return ApiResponse.onSuccess(CategorySuccessStatus.CATEGORY_COLOR_OK, categoryService.updateUserCategoryColor(userDetails.getUserId(), categoryId, request));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/CurationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/CurationController.java
@@ -1,14 +1,13 @@
 package com.umc.linkyou.web.controller;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
-import com.umc.linkyou.validation.annotation.ApiV1;
-import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.service.curation.CurationService;
 import com.umc.linkyou.service.curation.recommend.CurationRecommendBuilderService;
+import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.CurationApi;
 import com.umc.linkyou.web.dto.curation.*;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,78 +15,40 @@ import org.springframework.web.bind.annotation.*;
 import java.time.YearMonth;
 import java.util.List;
 
-@Tag(name = "curation-controller", description = "큐레이션 관련 API")
 @ApiV1
 @RequiredArgsConstructor
-@RequestMapping("/curations")
-public class CurationController {
+public class CurationController implements CurationApi {
 
     private final CurationService curationService;
     private final CurationRecommendBuilderService curationRecommendBuilderService;
 
-    // 월별 섹션 정보 조회 (제목, 설명, 대표 이미지)
-    @Operation(
-            summary = "큐레이션 섹션 정보 조회",
-            description = "지정한 월(YYYY-MM)의 섹션별 제목, 설명, 대표 이미지를 반환합니다. 미입력 시 이번 달 기준. 모든 유저 동일.")
-    @GetMapping("/sections")
-    public ResponseEntity<ApiResponse<List<CurationSectionResponse>>> getSectionInfo(
-            @RequestParam(required = false) String month
-    ) {
+    @Override
+    public ResponseEntity<ApiResponse<List<CurationSectionResponse>>> getSectionInfo(@RequestParam(required = false) String month) {
         String resolvedMonth = (month != null) ? month : YearMonth.now().toString();
         return ResponseEntity.ok(ApiResponse.onSuccess(curationService.getCurationSections(resolvedMonth)));
     }
 
-    // 올해 12개 큐레이션 히스토리 (없는 달은 빈 상태)
-    @Operation(
-            summary = "연도별 큐레이션 히스토리 조회",
-            description = "지정한 연도의 1~12월 큐레이션 목록을 반환합니다. 미입력 시 올해 기준. 생성되지 않은 달은 curationId, thumbnailUrl이 null입니다.")
-    @GetMapping("/history")
-    public ResponseEntity<ApiResponse<List<CurationListResponse>>> getMyCurationList(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam(required = false) Integer year
-    ) {
-        Long userId = userDetails.getUserId();
+    @Override
+    public ResponseEntity<ApiResponse<List<CurationListResponse>>> getMyCurationList(@CurrentUser CustomUserDetails userDetails, @RequestParam(required = false) Integer year) {
         int resolvedYear = (year != null) ? year : YearMonth.now().getYear();
-        return ResponseEntity.ok(ApiResponse.onSuccess(curationService.getCurationList(userId, resolvedYear)));
+        return ResponseEntity.ok(ApiResponse.onSuccess(curationService.getCurationList(userDetails.getUserId(), resolvedYear)));
     }
 
-    // 가장 최근 큐레이션 조회
-    @Operation(
-            summary = "가장 최근 큐레이션 조회",
-            description = "내 최신 큐레이션을 조회합니다.")
-    @GetMapping("/latest")
-    public ResponseEntity<ApiResponse<CurationLatestResponse>> getLatestCuration(
-            @CurrentUser CustomUserDetails userDetails) {
-        Long userId = userDetails.getUserId();
-        return curationService.getLatestCuration(userId)
+    @Override
+    public ResponseEntity<ApiResponse<CurationLatestResponse>> getLatestCuration(@CurrentUser CustomUserDetails userDetails) {
+        return curationService.getLatestCuration(userDetails.getUserId())
                 .map(body -> ResponseEntity.ok(ApiResponse.onSuccess(body)))
                 .orElse(ResponseEntity.noContent().build());
     }
 
-    // 큐레이션 상세 조회
-    @Operation(
-            summary = "큐레이션 상세 조회",
-            description = "큐레이션 ID로 상세 정보를 조회합니다.")
-    @GetMapping("/detail/{curationId}")
-    public ResponseEntity<ApiResponse<CurationDetailResponse>> getCurationDetail(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long curationId) {
-        Long userId = userDetails.getUserId();
-        return ResponseEntity.ok(ApiResponse.onSuccess(curationService.getCurationDetail(userId, curationId)));
+    @Override
+    public ResponseEntity<ApiResponse<CurationDetailResponse>> getCurationDetail(@CurrentUser CustomUserDetails userDetails, @PathVariable Long curationId) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(curationService.getCurationDetail(userDetails.getUserId(), curationId)));
     }
 
-    // 큐레이션 링크 추천
-    @Operation(
-            summary = "큐레이션 기반 링크 추천",
-            description = "내부/외부 링크를 추천합니다."
-    )
-    @GetMapping("/recommend-links")
-    public ResponseEntity<ApiResponse<List<RecommendedLinkResponse>>> getRecommendedLinks(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam Long curationId
-    ) {
-        Long userId = userDetails.getUserId();
-        List<RecommendedLinkResponse> recommendations = curationRecommendBuilderService.buildRecommendedLinks(userId, curationId);
+    @Override
+    public ResponseEntity<ApiResponse<List<RecommendedLinkResponse>>> getRecommendedLinks(@CurrentUser CustomUserDetails userDetails, @RequestParam Long curationId) {
+        List<RecommendedLinkResponse> recommendations = curationRecommendBuilderService.buildRecommendedLinks(userDetails.getUserId(), curationId);
         return ResponseEntity.ok(ApiResponse.onSuccess(recommendations));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/DomainController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/DomainController.java
@@ -5,64 +5,32 @@ import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.DomainConverter;
 import com.umc.linkyou.service.domain.DomainService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.DomainApi;
 import com.umc.linkyou.web.dto.DomainDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
-@Tag(name = "domain-controller", description = "도메인 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/domain")
 @RequiredArgsConstructor
-public class DomainController {
+public class DomainController implements DomainApi {
 
     private final DomainService domainService;
 
-    @Operation(
-            summary = "도메인 생성",
-            description = "새로운 도메인을 생성합니다. 도메인 이름, 도메인 꼬리, 이미지를 포함할 수 있습니다."
-    )
-    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<DomainDTO.DomainReponseDTO> createLinku(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(required = false) String name,
-            @RequestParam(required = false) String domainTail,
-            @RequestParam(required = false) MultipartFile image
-    ) {
-        Long userId = userDetails.getUserId();
+    @Override
+    public ApiResponse<DomainDTO.DomainReponseDTO> createDomain(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam(required = false) String name, @RequestParam(required = false) String domainTail, @RequestParam(required = false) MultipartFile image) {
         DomainDTO.DomainRequestDTO domainCreateDTO = DomainConverter.toDomainCreateDTO(name, domainTail);
-
-        DomainDTO.DomainReponseDTO result = domainService.createDomain(userId,domainCreateDTO, image);
-        return ApiResponse.onSuccess(result);
+        return ApiResponse.onSuccess(domainService.createDomain(userDetails.getUserId(), domainCreateDTO, image));
     }
 
-    @Operation(
-            summary = "도메인 수정",
-            description = "기존 도메인의 정보를 수정합니다. 도메인 이름, 도메인 꼬리, 이미지를 수정할 수 있습니다."
-    )
-    @PatchMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<DomainDTO.DomainReponseDTO> updateLinku(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam Long id,
-            @RequestParam(required = false) String name,
-            @RequestParam(required = false) String domainTail,
-            @RequestParam(required = false) MultipartFile image
-    ) {
-        Long userId = userDetails.getUserId();
-        // id 포함한 DTO 생성
+    @Override
+    public ApiResponse<DomainDTO.DomainReponseDTO> updateDomain(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam Long id, @RequestParam(required = false) String name, @RequestParam(required = false) String domainTail, @RequestParam(required = false) MultipartFile image) {
         DomainDTO.DomainRequestDTO domainUpdateDTO = DomainDTO.DomainRequestDTO.builder()
                 .id(id)
                 .name(name)
                 .domainTail(domainTail)
                 .build();
-
-        DomainDTO.DomainReponseDTO result = domainService.updateDomain(userId, domainUpdateDTO, image);
-        return ApiResponse.onSuccess(result);
+        return ApiResponse.onSuccess(domainService.updateDomain(userDetails.getUserId(), domainUpdateDTO, image));
     }
-
 }

--- a/src/main/java/com/umc/linkyou/web/controller/FolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/FolderController.java
@@ -2,139 +2,64 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderSuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.FolderService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.FolderApi;
 import com.umc.linkyou.web.dto.folder.*;
 import com.umc.linkyou.web.dto.folder.linku.FolderLinkusResponseDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "folder-controller", description = "폴더 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/folders")
 @RequiredArgsConstructor
 @Validated
-public class FolderController {
+public class FolderController implements FolderApi {
+
     private final FolderService folderService;
 
-    @Operation(
-            summary = "소분류 폴더 생성",
-            description = "중분류 폴더 하위에 소분류 폴더를 생성합니다."
-    )
-    @PostMapping("/{parentFolderId}/subfolders")
-    public ApiResponse<FolderResponseDTO> createFolder(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long parentFolderId,
-            @RequestBody FolderCreateRequestDTO request
-    ) {
-        FolderResponseDTO response = folderService.createFolder(userDetails.getUserId(), parentFolderId, request);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_CREATED, response);
+    @Override
+    public ApiResponse<FolderResponseDTO> createFolder(@CurrentUser CustomUserDetails userDetails, @PathVariable Long parentFolderId, @RequestBody FolderCreateRequestDTO request) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_CREATED, folderService.createFolder(userDetails.getUserId(), parentFolderId, request));
     }
 
-    @Operation(
-            summary = "소분류 폴더 수정",
-            description = "기존 소분류 폴더의 정보를 수정합니다."
-    )
-    @PutMapping("/subfolders/{folderId}")
-    public ApiResponse<FolderResponseDTO> updateFolder(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId,
-            @RequestBody FolderUpdateRequestDTO request
-    ) {
-        FolderResponseDTO response = folderService.updateFolder(userDetails.getUserId(), folderId, request);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_UPDATED, response);
+    @Override
+    public ApiResponse<FolderResponseDTO> updateFolder(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId, @RequestBody FolderUpdateRequestDTO request) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_UPDATED, folderService.updateFolder(userDetails.getUserId(), folderId, request));
     }
 
-    @Operation(
-            summary = "소분류 폴더 삭제",
-            description = "소분류 폴더를 삭제합니다."
-    )
-    @DeleteMapping("/subfolders/{folderId}")
-    public ApiResponse<Object> deleteFolder(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
+    @Override
+    public ApiResponse<Object> deleteFolder(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
         folderService.deleteFolder(userDetails.getUserId(), folderId);
         return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_DELETED);
     }
 
-    @Operation(
-            summary = "내 폴더 목록(트리) 조회",
-            description = "사용자의 모든 폴더를 트리 구조로 조회합니다."
-    )
-    @GetMapping("/my")
-    public ApiResponse<List<FolderTreeResponseDTO>> getMyFolderTree(
-            @CurrentUser CustomUserDetails userDetails
-    ) {
-        List<FolderTreeResponseDTO> folderTree = folderService.getMyFolderTree(userDetails.getUserId());
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_OK, folderTree);
+    @Override
+    public ApiResponse<List<FolderTreeResponseDTO>> getMyFolderTree(@CurrentUser CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_OK, folderService.getMyFolderTree(userDetails.getUserId()));
     }
 
-    @Operation(
-            summary = "중분류 폴더 조회",
-            description = "사용자의 모든 중분류 폴더 목록을 조회합니다. sort: name(가나다순, 기본값), updatedAt(최근 수정순)"
-    )
-    @GetMapping("/parentFolders")
-    public ApiResponse<List<FolderListResponseDTO>> getParentFolderList(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "name") String sort
-    ) {
-        List<FolderListResponseDTO> folderList = folderService.getParentFolders(userDetails.getUserId(), sort);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_PARENT_OK, folderList);
+    @Override
+    public ApiResponse<List<FolderListResponseDTO>> getParentFolderList(@CurrentUser CustomUserDetails userDetails, @RequestParam(defaultValue = "name") String sort) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_PARENT_OK, folderService.getParentFolders(userDetails.getUserId(), sort));
     }
 
-    @Operation(
-            summary = "중분류 내부의 하위 폴더 조회",
-            description = "특정 중분류 폴더의 하위 소분류 폴더 목록을 조회합니다."
-    )
-    @GetMapping("/{parentFolderId}/subfolders")
-    public ApiResponse<List<FolderListResponseDTO>> getSubFolderList(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long parentFolderId
-    ) {
-        List<FolderListResponseDTO> folderList = folderService.getSubFolders(userDetails.getUserId(), parentFolderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_SUBFOLDER_OK, folderList);
+    @Override
+    public ApiResponse<List<FolderListResponseDTO>> getSubFolderList(@CurrentUser CustomUserDetails userDetails, @PathVariable Long parentFolderId) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_SUBFOLDER_OK, folderService.getSubFolders(userDetails.getUserId(), parentFolderId));
     }
 
-    @Operation(
-            summary = "북마크 설정/해제",
-            description = "폴더의 북마크 상태를 설정하거나 해제합니다."
-    )
-    @PatchMapping("/{folderId}/bookmark")
-    public ApiResponse<BookmarkUpdateResponseDTO> updateBookmark(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId,
-            @RequestBody BookmarkUpdateRequestDTO request
-    ) {
-        BookmarkUpdateResponseDTO response = folderService.updateBookmark(
-                userDetails.getUserId(), folderId, request.getIsBookmarked()
-        );
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_BOOKMARK_OK, response);
+    @Override
+    public ApiResponse<BookmarkUpdateResponseDTO> updateBookmark(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId, @RequestBody BookmarkUpdateRequestDTO request) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_BOOKMARK_OK, folderService.updateBookmark(userDetails.getUserId(), folderId, request.getIsBookmarked()));
     }
 
-    @Operation(
-            summary = "폴더 내부 링크, 폴더 목록 조회",
-            description = "특정 폴더 내부의 링크와 하위 폴더 목록을 조회합니다. 커서 기반 페이지네이션을 지원합니다."
-    )
-    @GetMapping("/{folderId}/linkus")
-    public ApiResponse<FolderLinkusResponseDTO> getFolderLinkus(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId,
-            @RequestParam(defaultValue = "20") @Min(1) int limit,
-            @RequestParam(required = false) String cursor,
-            @RequestParam(defaultValue = "name") String sort
-    ) {
-        FolderLinkusResponseDTO response = folderService.getFolderLinkus(
-                userDetails.getUserId(), folderId, limit, cursor, sort);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_LINK_OK, response);
+    @Override
+    public ApiResponse<FolderLinkusResponseDTO> getFolderLinkus(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId, @RequestParam(defaultValue = "20") int limit, @RequestParam(required = false) String cursor, @RequestParam(defaultValue = "name") String sort) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_LINK_OK, folderService.getFolderLinkus(userDetails.getUserId(), folderId, limit, cursor, sort));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/InvitationController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/InvitationController.java
@@ -2,41 +2,28 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderSuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.share.InvitationService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.InvitationApi;
 import com.umc.linkyou.web.dto.folder.share.InvitationInfoResponseDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "invitation-controller", description = "초대 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/invitations")
 @RequiredArgsConstructor
-public class InvitationController {
+public class InvitationController implements InvitationApi {
 
     private final InvitationService invitationService;
 
-    @Operation(summary = "초대장 미리보기", description = "토큰을 통해 초대된 폴더명과 초대자 닉네임을 확인합니다.")
-    @GetMapping("/{token}")
-    public ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(
-            @PathVariable String token
-    ) {
-        InvitationInfoResponseDTO info = invitationService.getInvitationInfo(token);
-        return ApiResponse.onSuccess(FolderSuccessStatus.INVITATION_INFO_OK, info);
+    @Override
+    public ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(@PathVariable String token) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.INVITATION_INFO_OK, invitationService.getInvitationInfo(token));
     }
 
-    @Operation(summary = "초대 수락하기", description = "초대를 수락합니다.")
-    @PostMapping("/{token}")
-    public ApiResponse<Long> acceptInvitation(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable String token
-    ) {
-        Long folderId = invitationService.acceptInvitation(userDetails.getUserId(), token);
-        return ApiResponse.onSuccess(FolderSuccessStatus.INVITATION_ACCEPTED, folderId);
+    @Override
+    public ApiResponse<Long> acceptInvitation(@CurrentUser CustomUserDetails userDetails, @PathVariable String token) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.INVITATION_ACCEPTED, invitationService.acceptInvitation(userDetails.getUserId(), token));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
@@ -5,47 +5,31 @@ import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.keyword.KeywordService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.KeywordApi;
 import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "keyword-controller", description = "키워드 통계 관련 API")
 @ApiV1
 @Validated
 @RequiredArgsConstructor
-@RequestMapping("/keywords")
-public class KeywordController {
+public class KeywordController implements KeywordApi {
 
     private final KeywordService keywordService;
 
-    @Operation(summary = "내 월별 상위 키워드 조회")
-    @GetMapping("/my")
-    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getMyTopKeywords(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
-            @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit
-    ) {
-        Long userId = userDetails.getUserId();
-        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getMyTopKeywords(userId, month, limit)));
+    @Override
+    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getMyTopKeywords(@CurrentUser CustomUserDetails userDetails, @RequestParam String month, @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getMyTopKeywords(userDetails.getUserId(), month, limit)));
     }
 
-    @Operation(summary = "같은 직업 유저들의 상위 키워드 조회")
-    @GetMapping("/job")
-    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getJobTopKeywords(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "15") @Min(1) @Max(50) int limit
-    ) {
-        Long userId = userDetails.getUserId();
-        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userId, limit)));
+    @Override
+    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getJobTopKeywords(@CurrentUser CustomUserDetails userDetails, @RequestParam(defaultValue = "15") @Min(1) @Max(50) int limit) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userDetails.getUserId(), limit)));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuSuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.converter.LinkuConverter;
 import com.umc.linkyou.service.Linku.LinkuCreateService;
@@ -9,165 +10,74 @@ import com.umc.linkyou.service.Linku.LinkuRecommendService;
 import com.umc.linkyou.service.Linku.LinkuSearchService;
 import com.umc.linkyou.service.Linku.LinkuService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.LinkuApi;
 import com.umc.linkyou.web.dto.linku.LinkuRequestDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import com.umc.linkyou.web.dto.linku.LinkuSearchSuggestionResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-@Tag(name = "linku-controller", description = "링크(Linku) 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/linku")
 @RequiredArgsConstructor
-public class LinkuController {
+public class LinkuController implements LinkuApi {
 
     private final LinkuService linkuService;
     private final LinkuCreateService linkuCreateService;
     private final LinkuSearchService linkuSearchService;
     private final LinkuRecommendService linkuRecommendService;
 
-    @Operation(
-            summary = "링크 생성",
-            description = "새로운 링크를 생성합니다. URL, 메모, 감정 ID, 이미지를 포함할 수 있습니다."
-    )
-    @PostMapping(value = "", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> createLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String linku,
-            @RequestParam(required = false) String memo,
-            @RequestParam(required = false) Long emotionId,
-            @RequestParam(required = false) MultipartFile image
-    ) {
-        Long userId = userDetails.getUserId();
-        LinkuRequestDTO.LinkuCreateDTO linkuCreateDTO =
-                LinkuConverter.toLinkuCreateDTO(linku, memo, emotionId);
-
-        LinkuResponseDTO.LinkuCreateResult serviceResult = linkuCreateService.createLinku(userId, linkuCreateDTO, image);
-
+    @Override
+    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> createLinku(@CurrentUser CustomUserDetails userDetails, @RequestParam String linku, @RequestParam(required = false) String memo, @RequestParam(required = false) Long emotionId, @RequestParam(required = false) MultipartFile image) {
+        LinkuRequestDTO.LinkuCreateDTO linkuCreateDTO = LinkuConverter.toLinkuCreateDTO(linku, memo, emotionId);
+        LinkuResponseDTO.LinkuCreateResult serviceResult = linkuCreateService.createLinku(userDetails.getUserId(), linkuCreateDTO, image);
         if (serviceResult.isValidUrl()) {
             return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_CREATED, serviceResult.getData());
         } else {
             return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_SUSPICIOUS_URL, serviceResult.getData());
         }
-    }//linku 생성
+    }
 
-    @Operation(
-            summary = "링크 존재 여부 확인",
-            description = "해당 URL의 링크가 이미 존재하는지 확인합니다."
-    )
-    @GetMapping("/exist")
-    public ApiResponse<LinkuResponseDTO.LinkuIsExistDTO> existLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String url
-    ){
-        Long userId = userDetails.getUserId();
-        return linkuService.existLinku(userId, url);
-    }//linku 존재여부 확인
+    @Override
+    public ApiResponse<LinkuResponseDTO.LinkuIsExistDTO> existLinku(@CurrentUser CustomUserDetails userDetails, @RequestParam String url) {
+        return linkuService.existLinku(userDetails.getUserId(), url);
+    }
 
-    @Operation(
-            summary = "링크 상세 조회 (인증된 사용자)",
-            description = "인증된 사용자의 링크 상세 정보를 조회합니다."
-    )
-    @GetMapping("/{linkuid}")
-    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable("linkuid") Long linkuid
-    ){
-        Long userId = userDetails.getUserId();
-        return linkuService.detailGetLinku(userId, linkuid);
-    } //linku 상세보기
+    @Override
+    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(@CurrentUser CustomUserDetails userDetails, @PathVariable("linkuid") Long linkuid) {
+        return linkuService.detailGetLinku(userDetails.getUserId(), linkuid);
+    }
 
-    @Operation(
-            summary = "링크 상세 조회 (사용자 ID 지정)",
-            description = "특정 사용자 ID와 링크 ID로 링크 상세 정보를 조회합니다."
-    )
-    @GetMapping("/{userId}/{linkuId}")
-    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(
-            @PathVariable Long userId,
-            @PathVariable Long linkuId) {
+    @Override
+    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> detailLinku(@PathVariable Long userId, @PathVariable Long linkuId) {
         return linkuService.detailGetLinku(userId, linkuId);
-    }//userId를 받아서 상세보기
-
-    @Operation(
-            summary = "최근 열람한 링크 조회",
-            description = "사용자가 최근에 열람한 링크 목록을 조회합니다. limit 파라미터로 조회 개수를 지정할 수 있습니다."
-    )
-    @GetMapping("/recent")
-    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getRecentViewedLinkus(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "10") int limit) {
-        Long userId = userDetails.getUserId();
-        List<LinkuResponseDTO.LinkuSimpleDTO> result = linkuService.getRecentViewedLinkus(userId, limit);
-        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_RECENT_OK, result);
-    } //최근 열람한 링크 보기
-
-    @Operation(
-            summary = "링크 수정",
-            description = "기존 링크의 정보(URL, 메모, 감정, 도메인, 제목 등)를 수정합니다."
-    )
-    @PatchMapping(value = "/{linkuId}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> updateLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long linkuId,
-            @RequestBody LinkuRequestDTO.LinkuUpdateDTO updateDTO
-    ) {
-        Long userId = userDetails.getUserId();
-        LinkuResponseDTO.LinkuResultDTO result = linkuService.updateLinku(userId, linkuId, updateDTO);
-        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_UPDATED, result);
-    } //링큐 수정하기
-
-    @Operation(
-            summary = "링크 추천",
-            description = "상황(situation)과 감정(emotion)을 기반으로 링크를 추천합니다. 페이지네이션을 지원합니다."
-    )
-    @GetMapping("/recommend")
-    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> recommendLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam Long situationId,
-            @RequestParam Long emotionId,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "5") int size
-    ) {
-        Long userId = userDetails.getUserId();
-        return linkuRecommendService.recommendLinku(userId, situationId, emotionId, page, size);
-    }//linku 추천 내부로
-
-    // 빠른 검색 (사용자가 저장한 링크 전체 대상)
-    @Operation(
-            summary = "빠른 검색 (사용자 저장 링크 전체 대상)",
-            description = "사용자가 저장한 링크 전체를 대상으로 키워드가 포함된 추천 검색어 목록을 조회합니다."
-    )
-    @GetMapping("/search/quick")
-    public ApiResponse<List<LinkuSearchSuggestionResponse>> quickSearch(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String keyword
-    ) {
-        Long userId = userDetails.getUserId();
-        List<LinkuSearchSuggestionResponse> result = linkuSearchService.suggest(userId, keyword);
-        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_SEARCH_OK, result);
     }
 
-    @Operation(
-            summary = "링크 삭제",
-            description = "사용자가 저장한 링크를 삭제합니다."
-    )
-    @DeleteMapping("/{userLinkuId}")
-    public ApiResponse<Object> deleteUsersLinku(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long userLinkuId
-    ) {
-        Long userId = userDetails.getUserId();
-        linkuService.deleteUsersLinku(userId, userLinkuId);
+    @Override
+    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getRecentViewedLinkus(@CurrentUser CustomUserDetails userDetails, @RequestParam(defaultValue = "10") int limit) {
+        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_RECENT_OK, linkuService.getRecentViewedLinkus(userDetails.getUserId(), limit));
+    }
+
+    @Override
+    public ApiResponse<LinkuResponseDTO.LinkuResultDTO> updateLinku(@CurrentUser CustomUserDetails userDetails, @PathVariable Long linkuId, @RequestBody LinkuRequestDTO.LinkuUpdateDTO updateDTO) {
+        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_UPDATED, linkuService.updateLinku(userDetails.getUserId(), linkuId, updateDTO));
+    }
+
+    @Override
+    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> recommendLinku(@CurrentUser CustomUserDetails userDetails, @RequestParam Long situationId, @RequestParam Long emotionId, @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "5") int size) {
+        return linkuRecommendService.recommendLinku(userDetails.getUserId(), situationId, emotionId, page, size);
+    }
+
+    @Override
+    public ApiResponse<List<LinkuSearchSuggestionResponse>> quickSearch(@CurrentUser CustomUserDetails userDetails, @RequestParam String keyword) {
+        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_SEARCH_OK, linkuSearchService.suggest(userDetails.getUserId(), keyword));
+    }
+
+    @Override
+    public ApiResponse<Object> deleteUsersLinku(@CurrentUser CustomUserDetails userDetails, @PathVariable Long userLinkuId) {
+        linkuService.deleteUsersLinku(userDetails.getUserId(), userLinkuId);
         return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_DELETED);
-
     }
-
 }

--- a/src/main/java/com/umc/linkyou/web/controller/PasswordResetPageController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/PasswordResetPageController.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.service.email.PasswordResetService;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+@Hidden
 @Controller
 @RequiredArgsConstructor
 public class PasswordResetPageController {

--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -2,83 +2,54 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderSuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.share.ShareFolderService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.ShareFolderApi;
 import com.umc.linkyou.web.dto.folder.share.FolderPermissionRequestDTO;
 import com.umc.linkyou.web.dto.folder.share.ShareFolderResponseDTO;
 import com.umc.linkyou.web.dto.folder.share.ViewerResponseDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "share-folder-controller", description = "폴더 공유 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/folders/share")
 @RequiredArgsConstructor
-public class ShareFolderController {
+public class ShareFolderController implements ShareFolderApi {
+
     private final ShareFolderService shareFolderService;
 
     @Value("${app.deeplink.base-url}")
     private String deeplinkBaseUrl;
 
-    @Operation(summary = "초대 링크 생성", description = "해당 폴더의 초대용 토큰을 생성합니다.")
-    @PostMapping("/{folderId}/invitation")
-    public ApiResponse<String> createInviteLink(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
+    @Override
+    public ApiResponse<String> createInviteLink(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
         String token = shareFolderService.createInviteLink(userDetails.getUserId(), folderId);
         return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_CREATED, deeplinkBaseUrl + "/open?action=share&folderId=" + token);
     }
 
-    @Operation(summary = "초대 링크 삭제", description = "초대 링크를 비활성화합니다.")
-    @DeleteMapping("/{folderId}/invitation")
-    public ApiResponse<Object> deactivateInviteLink(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
+    @Override
+    public ApiResponse<Object> deactivateInviteLink(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
         shareFolderService.deactivateInviteLink(userDetails.getUserId(), folderId);
         return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_DEACTIVATED);
     }
 
-    @Operation(summary = "폴더 멤버 조회", description = "공유된 폴더의 멤버 목록을 조회합니다.")
-    @GetMapping("/{folderId}/members")
-    public ApiResponse<List<ViewerResponseDTO>> getFolderViewers(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
-        List<ViewerResponseDTO> viewers = shareFolderService.getViewers(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_MEMBERS_OK, viewers);
+    @Override
+    public ApiResponse<List<ViewerResponseDTO>> getFolderViewers(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_MEMBERS_OK, shareFolderService.getViewers(userDetails.getUserId(), folderId));
     }
 
-    @Operation(summary = "폴더 권한 수정", description = "폴더 공유 멤버의 권한(뷰어/라이터)을 수정합니다.")
-    @PutMapping("/{folderId}/members/{userFolderId}")
-    public ApiResponse<ShareFolderResponseDTO> updateViewerPermission(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId,
-            @PathVariable Long userFolderId,
-            @Valid @RequestBody FolderPermissionRequestDTO request
-    ) {
-        ShareFolderResponseDTO response = shareFolderService.updateViewerPermission(
-                userDetails.getUserId(), folderId, userFolderId, request);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_PERMISSION_OK, response);
+    @Override
+    public ApiResponse<ShareFolderResponseDTO> updateViewerPermission(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId, @PathVariable Long userFolderId, @Valid @RequestBody FolderPermissionRequestDTO request) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_PERMISSION_OK, shareFolderService.updateViewerPermission(userDetails.getUserId(), folderId, userFolderId, request));
     }
 
-    @Operation(summary = "폴더 비공개 전환", description = "공유된 폴더를 비공개로 전환하고 모든 공유 권한을 제거합니다.")
-    @PostMapping("/{folderId}/unshare")
-    public ApiResponse<ShareFolderResponseDTO> unshareFolder(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
-        ShareFolderResponseDTO response = shareFolderService.unshare(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_UNSHARE_OK, response);
+    @Override
+    public ApiResponse<ShareFolderResponseDTO> unshareFolder(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_UNSHARE_OK, shareFolderService.unshare(userDetails.getUserId(), folderId));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/SharedFolderController.java
@@ -2,41 +2,30 @@ package com.umc.linkyou.web.controller;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderSuccessStatus;
+import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.folder.shared.SharedFolderService;
 import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.SharedFolderApi;
 import com.umc.linkyou.web.dto.folder.share.SharedFolderGroupResponseDTO;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "shared-folder-controller", description = "공유 받은 폴더 관련 API")
 @ApiV1
-@RestController
-@RequestMapping("/folders/shared")
 @RequiredArgsConstructor
-public class SharedFolderController {
+public class SharedFolderController implements SharedFolderApi {
+
     private final SharedFolderService sharedFolderService;
 
-    @Operation(summary = "공유 받은 폴더 목록 조회", description = "사용자가 공유 받은 폴더를 소유자별로 그룹핑하여 조회합니다.")
-    @GetMapping
-    public ApiResponse<List<SharedFolderGroupResponseDTO>> getSharedFolders(
-            @CurrentUser CustomUserDetails userDetails
-    ) {
-        List<SharedFolderGroupResponseDTO> result = sharedFolderService.getSharedFolders(userDetails.getUserId());
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_SHARED_OK, result);
+    @Override
+    public ApiResponse<List<SharedFolderGroupResponseDTO>> getSharedFolders(@CurrentUser CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_SHARED_OK, sharedFolderService.getSharedFolders(userDetails.getUserId()));
     }
 
-    @Operation(summary = "공유 받은 폴더 삭제", description = "공유 받은 폴더를 자신의 목록에서 제거합니다. (폴더 자체는 삭제되지 않습니다)")
-    @DeleteMapping("/{folderId}")
-    public ApiResponse<Object> deleteSharedFolder(
-            @CurrentUser CustomUserDetails userDetails,
-            @PathVariable Long folderId
-    ) {
+    @Override
+    public ApiResponse<Object> deleteSharedFolder(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
         sharedFolderService.deleteSharedFolder(userDetails.getUserId(), folderId);
         return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_LEAVE_OK);
     }

--- a/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/AuthController.java
@@ -18,6 +18,7 @@ import com.umc.linkyou.web.dto.EmailRequestDTO;
 import com.umc.linkyou.web.dto.PasswordResetRequestDTO;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
+import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/test/java/com/umc/linkyou/service/email/EmailVerificationServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/email/EmailVerificationServiceTest.java
@@ -1,0 +1,155 @@
+package com.umc.linkyou.service.email;
+
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.domain.redis.EmailVerificationCache;
+import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
+import com.umc.linkyou.repository.redis.EmailVerificationRedisRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class EmailVerificationServiceTest {
+
+    // SHA-256("test@example.com")
+    private static final String HASHED_EMAIL = "973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b";
+
+    @InjectMocks
+    private EmailVerificationService emailVerificationService;
+
+    @Mock
+    private AuthAccountRepository authAccountRepository;
+
+    @Mock
+    private EmailVerificationRedisRepository emailVerificationRedisRepository;
+
+    @Mock
+    private StringRedisTemplate stringRedisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private EmailRateLimiter rateLimiter;
+
+    @Mock
+    private EmailDomainValidator emailAddressValidator;
+
+    @Test
+    @DisplayName("유효하지 않은 이메일 주소면 인증 코드를 전송하지 않는다")
+    void sendCode_whenEmailAddressInvalid_throwsBadRequest() {
+        given(emailAddressValidator.isDeliverableAddress("test@invalid-domain.invalid")).willReturn(false);
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> emailVerificationService.sendCode("test@invalid-domain.invalid"));
+
+        assertEquals(UserErrorStatus._INVALID_EMAIL_ADDRESS, exception.getCode());
+        verifyNoInteractions(authAccountRepository, emailVerificationRedisRepository, emailService);
+    }
+
+    @Test
+    @DisplayName("cooldown 중이면 인증 코드를 전송하지 않는다")
+    void sendCode_whenCooldownActive_throwsTooManyRequests() {
+        given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
+        given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
+        willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
+                .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> emailVerificationService.sendCode("test@example.com"));
+
+        assertEquals(ErrorStatus._TOO_MANY_REQUESTS, exception.getCode());
+        verifyNoInteractions(emailVerificationRedisRepository, emailService);
+    }
+
+    @Test
+    @DisplayName("일일 제한을 넘기면 인증 코드를 전송하지 않는다")
+    void sendCode_whenDailyLimitExceeded_throwsTooManyRequests() {
+        given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
+        given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
+        willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
+                .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> emailVerificationService.sendCode("test@example.com"));
+
+        assertEquals(ErrorStatus._TOO_MANY_REQUESTS, exception.getCode());
+        verifyNoInteractions(emailVerificationRedisRepository, emailService);
+    }
+
+    @Test
+    @DisplayName("제한 이내면 인증 코드를 저장하고 메일을 전송한다")
+    void sendCode_whenAllowed_savesCodeAndSendsEmail() {
+        given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
+        given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
+
+        emailVerificationService.sendCode("test@example.com");
+
+        verify(emailVerificationRedisRepository).save(any());
+        verify(emailService).sendVerificationEmailTemplate(eq("test@example.com"), eq("링큐 회원"), anyString(), eq(10));
+    }
+
+    @Test
+    @DisplayName("인증 코드가 틀리면 실패 카운터를 증가시키고 검증 실패 예외를 던진다")
+    void verifyCode_whenCodeMismatch_incrementsFailureCount() {
+        given(emailVerificationRedisRepository.findById(HASHED_EMAIL))
+                .willReturn(java.util.Optional.of(EmailVerificationCache.of(HASHED_EMAIL, "123456")));
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("email:verification:failure:" + HASHED_EMAIL)).willReturn(1L);
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> emailVerificationService.verifyCode("test@example.com", "000000"));
+
+        assertEquals(UserErrorStatus._VERIFICATION_FAILED, exception.getCode());
+        verify(stringRedisTemplate).expire(eq("email:verification:failure:" + HASHED_EMAIL), any());
+    }
+
+    @Test
+    @DisplayName("인증 코드 실패가 5회째면 코드를 만료 처리한다")
+    void verifyCode_whenFailureCountReached_expiresCode() {
+        given(emailVerificationRedisRepository.findById(HASHED_EMAIL))
+                .willReturn(java.util.Optional.of(EmailVerificationCache.of(HASHED_EMAIL, "123456")));
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.increment("email:verification:failure:" + HASHED_EMAIL)).willReturn(5L);
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> emailVerificationService.verifyCode("test@example.com", "000000"));
+
+        assertEquals(UserErrorStatus._EXPIRED_VERIFICATION_CODE, exception.getCode());
+        verify(emailVerificationRedisRepository).deleteById(HASHED_EMAIL);
+        verify(stringRedisTemplate).delete("email:verification:failure:" + HASHED_EMAIL);
+    }
+
+    @Test
+    @DisplayName("인증 코드가 맞으면 실패 카운터를 초기화한다")
+    void verifyCode_whenSuccess_resetsFailureCount() {
+        given(emailVerificationRedisRepository.findById(HASHED_EMAIL))
+                .willReturn(java.util.Optional.of(EmailVerificationCache.of(HASHED_EMAIL, "123456")));
+
+        emailVerificationService.verifyCode("test@example.com", "123456");
+
+        verify(emailVerificationRedisRepository).deleteById(HASHED_EMAIL);
+        verify(stringRedisTemplate).delete("email:verification:failure:" + HASHED_EMAIL);
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/email/EmailVerificationServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/email/EmailVerificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.service.email;
 
+import jakarta.mail.internet.AddressException;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
@@ -58,7 +59,7 @@ class EmailVerificationServiceTest {
 
     @Test
     @DisplayName("유효하지 않은 이메일 주소면 인증 코드를 전송하지 않는다")
-    void sendCode_whenEmailAddressInvalid_throwsBadRequest() {
+    void sendCode_whenEmailAddressInvalid_throwsBadRequest() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("test@invalid-domain.invalid")).willReturn(false);
 
         UserHandler exception = assertThrows(UserHandler.class,
@@ -70,7 +71,7 @@ class EmailVerificationServiceTest {
 
     @Test
     @DisplayName("cooldown 중이면 인증 코드를 전송하지 않는다")
-    void sendCode_whenCooldownActive_throwsTooManyRequests() {
+    void sendCode_whenCooldownActive_throwsTooManyRequests() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
         given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
         willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
@@ -85,7 +86,7 @@ class EmailVerificationServiceTest {
 
     @Test
     @DisplayName("일일 제한을 넘기면 인증 코드를 전송하지 않는다")
-    void sendCode_whenDailyLimitExceeded_throwsTooManyRequests() {
+    void sendCode_whenDailyLimitExceeded_throwsTooManyRequests() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
         given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
         willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
@@ -100,7 +101,7 @@ class EmailVerificationServiceTest {
 
     @Test
     @DisplayName("제한 이내면 인증 코드를 저장하고 메일을 전송한다")
-    void sendCode_whenAllowed_savesCodeAndSendsEmail() {
+    void sendCode_whenAllowed_savesCodeAndSendsEmail() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("test@example.com")).willReturn(true);
         given(authAccountRepository.existsByEmail("test@example.com")).willReturn(false);
 

--- a/src/test/java/com/umc/linkyou/service/email/PasswordResetServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/email/PasswordResetServiceTest.java
@@ -1,0 +1,148 @@
+package com.umc.linkyou.service.email;
+
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
+import com.umc.linkyou.repository.redis.PasswordResetRedisRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordResetServiceTest {
+
+    @InjectMocks
+    private PasswordResetService passwordResetService;
+
+    @Mock
+    private AuthAccountRepository authAccountRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private PasswordResetRedisRepository passwordResetRedisRepository;
+
+    @Mock
+    private EmailService emailService;
+
+    @Mock
+    private EmailRateLimiter rateLimiter;
+
+    @Mock
+    private EmailDomainValidator emailAddressValidator;
+
+    @Test
+    @DisplayName("유효하지 않은 이메일 주소면 비밀번호 재설정 링크를 전송하지 않는다")
+    void sendResetLink_whenEmailAddressInvalid_throwsBadRequest() {
+        given(emailAddressValidator.isDeliverableAddress("user@invalid-domain.invalid")).willReturn(false);
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> passwordResetService.sendResetLink("user@invalid-domain.invalid"));
+
+        assertEquals(UserErrorStatus._INVALID_EMAIL_ADDRESS, exception.getCode());
+        verifyNoInteractions(authAccountRepository, passwordResetRedisRepository, emailService, userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 요청이 cooldown 중이면 차단한다")
+    void sendResetLink_whenCooldownActive_throwsTooManyRequests() {
+        given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
+        willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
+                .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> passwordResetService.sendResetLink("user@example.com"));
+
+        assertEquals(ErrorStatus._TOO_MANY_REQUESTS, exception.getCode());
+        verifyNoInteractions(authAccountRepository, passwordResetRedisRepository, emailService, userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("비밀번호 재설정 요청이 일일 제한을 넘기면 차단한다")
+    void sendResetLink_whenDailyLimitExceeded_throwsTooManyRequests() {
+        given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
+        willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
+                .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
+
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> passwordResetService.sendResetLink("user@example.com"));
+
+        assertEquals(ErrorStatus._TOO_MANY_REQUESTS, exception.getCode());
+        verifyNoInteractions(authAccountRepository, passwordResetRedisRepository, emailService, userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("일반 계정이 없으면 비밀번호 재설정 링크를 보내지 않고 성공처럼 종료한다")
+    void sendResetLink_absentGeneralAccount_returnsSilently() {
+        given(emailAddressValidator.isDeliverableAddress("missing@example.com")).willReturn(true);
+        given(authAccountRepository.findUserByEmailAndProvider("missing@example.com", com.umc.linkyou.domain.enums.Provider.GENERAL))
+                .willReturn(Optional.empty());
+
+        passwordResetService.sendResetLink("missing@example.com");
+
+        verify(authAccountRepository).findUserByEmailAndProvider("missing@example.com", com.umc.linkyou.domain.enums.Provider.GENERAL);
+        verifyNoInteractions(passwordResetRedisRepository, emailService, userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("일반 계정이면 비밀번호 재설정 링크를 전송한다")
+    void sendResetLink_generalAccount_sendsResetEmail() {
+        given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
+        Users user = Users.builder()
+                .id(1L)
+                .nickName("링큐유저")
+                .password("encoded")
+                .build();
+        given(authAccountRepository.findUserByEmailAndProvider("user@example.com", com.umc.linkyou.domain.enums.Provider.GENERAL))
+                .willReturn(Optional.of(user));
+
+        passwordResetService.sendResetLink("user@example.com");
+
+        verify(passwordResetRedisRepository).save(any());
+        verify(emailService).sendPasswordResetEmail(eq("user@example.com"), eq("링큐유저"), any(), eq(10));
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 비어 있으면 잘못된 비밀번호 예외를 던진다")
+    void resetPassword_blankPassword_throwsInvalidPassword() {
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> passwordResetService.resetPassword("token", " ", "Valid123!"));
+
+        assertEquals(UserErrorStatus._INVALID_PASSWORD, exception.getCode());
+        verifyNoInteractions(passwordResetRedisRepository, authAccountRepository, userRepository, passwordEncoder);
+    }
+
+    @Test
+    @DisplayName("새 비밀번호가 정책에 맞지 않으면 잘못된 비밀번호 예외를 던진다")
+    void resetPassword_invalidPolicy_throwsInvalidPassword() {
+        UserHandler exception = assertThrows(UserHandler.class,
+                () -> passwordResetService.resetPassword("token", "short1!", "short1!"));
+
+        assertEquals(UserErrorStatus._INVALID_PASSWORD, exception.getCode());
+        verifyNoInteractions(passwordResetRedisRepository, authAccountRepository, userRepository, passwordEncoder);
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/email/PasswordResetServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/email/PasswordResetServiceTest.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.service.email;
 
+import jakarta.mail.internet.AddressException;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
@@ -57,7 +58,7 @@ class PasswordResetServiceTest {
 
     @Test
     @DisplayName("유효하지 않은 이메일 주소면 비밀번호 재설정 링크를 전송하지 않는다")
-    void sendResetLink_whenEmailAddressInvalid_throwsBadRequest() {
+    void sendResetLink_whenEmailAddressInvalid_throwsBadRequest() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("user@invalid-domain.invalid")).willReturn(false);
 
         UserHandler exception = assertThrows(UserHandler.class,
@@ -69,7 +70,7 @@ class PasswordResetServiceTest {
 
     @Test
     @DisplayName("비밀번호 재설정 요청이 cooldown 중이면 차단한다")
-    void sendResetLink_whenCooldownActive_throwsTooManyRequests() {
+    void sendResetLink_whenCooldownActive_throwsTooManyRequests() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
         willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
                 .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
@@ -83,7 +84,7 @@ class PasswordResetServiceTest {
 
     @Test
     @DisplayName("비밀번호 재설정 요청이 일일 제한을 넘기면 차단한다")
-    void sendResetLink_whenDailyLimitExceeded_throwsTooManyRequests() {
+    void sendResetLink_whenDailyLimitExceeded_throwsTooManyRequests() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
         willThrow(new UserHandler(ErrorStatus._TOO_MANY_REQUESTS))
                 .given(rateLimiter).enforce(anyString(), anyString(), anyString(), any(), any(), anyInt());
@@ -97,7 +98,7 @@ class PasswordResetServiceTest {
 
     @Test
     @DisplayName("일반 계정이 없으면 비밀번호 재설정 링크를 보내지 않고 성공처럼 종료한다")
-    void sendResetLink_absentGeneralAccount_returnsSilently() {
+    void sendResetLink_absentGeneralAccount_returnsSilently() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("missing@example.com")).willReturn(true);
         given(authAccountRepository.findUserByEmailAndProvider("missing@example.com", com.umc.linkyou.domain.enums.Provider.GENERAL))
                 .willReturn(Optional.empty());
@@ -110,7 +111,7 @@ class PasswordResetServiceTest {
 
     @Test
     @DisplayName("일반 계정이면 비밀번호 재설정 링크를 전송한다")
-    void sendResetLink_generalAccount_sendsResetEmail() {
+    void sendResetLink_generalAccount_sendsResetEmail() throws AddressException {
         given(emailAddressValidator.isDeliverableAddress("user@example.com")).willReturn(true);
         Users user = Users.builder()
                 .id(1L)

--- a/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
@@ -7,6 +7,9 @@ import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.SecurityErrorResponseWriter;
+import com.umc.linkyou.config.common.WebConfig;
+import com.umc.linkyou.jwt.CurrentUserArgumentResolver;
+import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.service.AiArticleService;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import org.junit.jupiter.api.AfterEach;
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(AiArticleController.class)
 @AutoConfigureMockMvc(addFilters = false)
+@Import({WebConfig.class, CurrentUserArgumentResolver.class})
 @DisplayName("AiArticleController 테스트")
 class AiArticleControllerTest {
 
@@ -44,6 +49,9 @@ class AiArticleControllerTest {
 
     @MockitoBean
     private AiArticleService aiArticleService;
+
+    @MockitoBean
+    private AiArticleRepository aiArticleRepository;
 
     @MockitoBean
     private JwtTokenProvider jwtTokenProvider;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)
#311 
#309 
---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement

#### test: 이메일 서비스 단위 테스트 추가
  - `EmailVerificationServiceTest` — 인증 코드 발송/검증 주요 케이스 커버
  - `PasswordResetServiceTest` — 비밀번호 재설정 링크 발송 주요 케이스 커버

#### refactor: 컨트롤러 Swagger 어노테이션 API 인터페이스로 분리
  - 기존에 적용되지 않았던 컨트롤러를 설명을 포함하는 인터페이스로 분리: Category, Curation, Domain, Folder, Invitation, Keyword, Linku, ShareFolder, SharedFolder
  도메인에 `*Api` 인터페이스 추출 
  - 컨트롤러는 인터페이스를 구현하는 구조로 변경
  - 추가: ApiV1 어노테이션에서 RestController 빈 등록 로직을 제거
#### refactor: Swagger 설정 개선
  - `ApiDomainErrorCodes` 어노테이션 추가 — 클래스 단위로 에러 코드 일괄 주입 가능
  - `SwaggerConfig`에 에러 코드 레퍼런스 테이블 자동 생성 (API 명세서 하단에 전체 에러 코드 표
  노출)
  - `ApiErrorCode`에 `CurationErrorStatus` 지원 추가
  - 비밀번호 재설정 페이지용 엔드포인트 `@Hidden` 처리

### 2️⃣ Functional Requirement
#### feat: 이메일 도메인 유효성 검증
  - `EmailDomainValidator` 추가 — JNDI 레코드 조회로 실제 수신 가능한 도메인인지 사전 검증
  - 인증 코드 발송 및 비밀번호 재설정 링크 발송시  도메인 검증 선행
  - `UserErrorStatus._INVALID_EMAIL_ADDRESS` 에러코드 추가
  - 이메일 발송 실패 시 불필요한 try-catch 제거 
  - 도메인 검증만 진행하고, SMTP에서는 바운스되기 때문에 200 OK가 뜨도록 두었습니다(Google,Naver 등도 해당 정책 사용한다고 합니다!) 
---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.
### 에러코드 정리
<img width="1170" height="808" alt="image" src="https://github.com/user-attachments/assets/f0667bee-639e-4999-b424-320938e9d6ad" />

### 에러코드 정리 - 토글로도 닫을 수 있습니다.!
<img width="1150" height="421" alt="image" src="https://github.com/user-attachments/assets/edcbd29d-56c0-4f5d-b133-446e658b86d1" />

### 각 컨트롤러마다 에러코드 표시 적용(이전에는 일부 API만 적용)
<img width="1135" height="861" alt="image" src="https://github.com/user-attachments/assets/68c5143e-f70d-49eb-bb74-97a516f97974" />


---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.

컨트롤러 및 SwaggerConfig를 일괄 수정하였으니 pull을 꼭 받고 작업 진행해주시기 바랍니다!
ApiV1 어노테이션에서 RestController 빈 등록 로직을 제거해서 이제 RestController 어노테이션 붙여줘야 합니다!
컨트롤러 수정하는 김에 일괄 수정 진행했습니다!

CurationInfo에서 month 컬럼명이 사용되고 있는데, 이부분 h2 예약어이기 때문에 테스트가 아예 실패해서 해당 PR에 맞지는 않지만 테스트 성공을 위해서 base_month로 수정했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 카테고리, 큐레이션, 도메인, 폴더 공유, 키워드 통계, 링크, 초대 관련 새로운 API 엔드포인트 추가
  * 폴더 색상 수정 및 공유 기능 추가

* **Bug Fixes**
  * 이메일 주소 검증 및 도메인 전달 가능 여부 확인 기능 추가

* **Documentation**
  * Swagger API 문서에 에러 코드 레퍼런스 및 도메인별 오류 상태 코드 명시 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->