### PR TITLE
feat: 알림 관련 api response 수정 & 테스트코드 작성

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/alarm/AlarmErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/alarm/AlarmErrorStatus.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum AlarmErrorStatus implements BaseErrorCode {
 
     ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALARM404", "알람을 찾을 수 없습니다."),
+    ALARM_SETTING_NOT_INITIALIZED(HttpStatus.INTERNAL_SERVER_ERROR, "ALARM500", "알림설정이 되지 않은 사용자입니다. 관리자에게 문의하세요."),
     ALARM_PERMISSION_DENIED(HttpStatus.UNAUTHORIZED, "ALARM403", "알람에 대한 권한이 없습니다."),
     ALARM_TOPIC_SUBSCRIPTION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ALARM501", "알림 주제 구독 상태 변경에 실패했습니다."),
     ALARM_SEND_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ALARM502", "알림 전송에 실패했습니다.");

--- a/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
+++ b/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
@@ -63,7 +63,6 @@ public class AlarmSetting {
                 .build();
     }
 
-    // 전체를 off, false 할 때 사용
     public void updateAll(boolean enabled) {
         this.alarmAllEnabled = enabled;
         this.noticeEnabled = enabled;
@@ -86,6 +85,10 @@ public class AlarmSetting {
 
     public void updateFolder(boolean enabled) {
         this.folderEnabled = enabled;
+    }
+
+    public void updateAlarmAllEnabled(boolean enabled) {
+        this.alarmAllEnabled = enabled;
     }
 
     public boolean isNoticeActive() {

--- a/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
+++ b/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
@@ -73,18 +73,28 @@ public class AlarmSetting {
 
     public void updateNotice(boolean enabled) {
         this.noticeEnabled = enabled;
+        syncAllEnabled();
     }
 
     public void updateLink(boolean enabled) {
         this.linkEnabled = enabled;
+        syncAllEnabled();
     }
 
     public void updateCuration(boolean enabled) {
         this.curationEnabled = enabled;
+        syncAllEnabled();
     }
 
     public void updateFolder(boolean enabled) {
         this.folderEnabled = enabled;
+        syncAllEnabled();
+    }
+
+    private void syncAllEnabled() {
+        if (!noticeEnabled && !linkEnabled && !curationEnabled && !folderEnabled) {
+            this.alarmAllEnabled = false;
+        }
     }
 
     public boolean isNoticeActive() {

--- a/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
+++ b/src/main/java/com/umc/linkyou/domain/AlarmSetting.java
@@ -63,6 +63,7 @@ public class AlarmSetting {
                 .build();
     }
 
+    // 전체를 off, false 할 때 사용
     public void updateAll(boolean enabled) {
         this.alarmAllEnabled = enabled;
         this.noticeEnabled = enabled;
@@ -73,28 +74,18 @@ public class AlarmSetting {
 
     public void updateNotice(boolean enabled) {
         this.noticeEnabled = enabled;
-        syncAllEnabled();
     }
 
     public void updateLink(boolean enabled) {
         this.linkEnabled = enabled;
-        syncAllEnabled();
     }
 
     public void updateCuration(boolean enabled) {
         this.curationEnabled = enabled;
-        syncAllEnabled();
     }
 
     public void updateFolder(boolean enabled) {
         this.folderEnabled = enabled;
-        syncAllEnabled();
-    }
-
-    private void syncAllEnabled() {
-        if (!noticeEnabled && !linkEnabled && !curationEnabled && !folderEnabled) {
-            this.alarmAllEnabled = false;
-        }
     }
 
     public boolean isNoticeActive() {

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -95,12 +95,22 @@ public class AlarmService {
         AlarmSetting alarmSetting = alarmSettingRepository.findByUserId(userId)
                 .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED));
 
+        // 알림 타입에 따른 분기
         switch (alarmSettingType) {
             case ALL -> alarmSetting.updateAll(!alarmSetting.isAlarmAllEnabled());
             case NOTICE -> alarmSetting.updateNotice(!alarmSetting.isNoticeEnabled());
             case LINK -> alarmSetting.updateLink(!alarmSetting.isLinkEnabled());
             case CURATION -> alarmSetting.updateCuration(!alarmSetting.isCurationEnabled());
             case FOLDER -> alarmSetting.updateFolder(!alarmSetting.isFolderEnabled());
+        }
+
+        // 전체 알림이 아니라면, 전체 알림도 같이 동기화
+        if (alarmSettingType != AlarmSettingType.ALL) {
+            boolean anyRawEnabled = alarmSetting.isNoticeEnabled() || alarmSetting.isLinkEnabled()
+                    || alarmSetting.isCurationEnabled() || alarmSetting.isFolderEnabled();
+            if (!anyRawEnabled) {
+                alarmSetting.updateAlarmAllEnabled(false);
+            }
         }
 
         alarmSettingRepository.save(alarmSetting);

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -1,18 +1,15 @@
 package com.umc.linkyou.service.alarm;
 
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.*;
 import com.umc.linkyou.domain.enums.AlarmSettingType;
 import com.umc.linkyou.domain.enums.AlarmType;
-import com.umc.linkyou.domain.redis.UserFcmTokenCache;
 import com.umc.linkyou.repository.AlarmRepository;
 import com.umc.linkyou.repository.AlarmSettingRepository;
 import com.umc.linkyou.repository.UserAlarmRepository;
 import com.umc.linkyou.repository.UserFcmTokenRepository;
-import com.umc.linkyou.repository.redis.FcmTokenRedisRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.service.alarm.event.AlarmSettingChangedEvent;
 import com.umc.linkyou.service.alarm.event.BroadCastAlarmEvent;
@@ -41,7 +38,6 @@ public class AlarmService {
     private final AlarmSettingRepository alarmSettingRepository;
     private final AlarmRepository alarmRepository;
     private final UserAlarmRepository userAlarmRepository;
-    private final FcmTokenRedisRepository fcmTokenRedisRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     // FCM 토큰 등록
@@ -65,23 +61,6 @@ public class AlarmService {
             existingToken.activate();
         }
 
-        addTokenToRedis(userId, newToken);
-    }
-
-    // redis에 토큰 저장
-    private void addTokenToRedis(Long userId, String token) {
-        UserFcmTokenCache cache = fcmTokenRedisRepository.findById(userId)
-                .orElseGet(() -> UserFcmTokenCache.builder().userId(userId).build());
-        cache.addToken(token);
-        fcmTokenRedisRepository.save(cache);
-    }
-
-    // redis에서 토큰 삭제
-    private void removeTokenFromRedis(Long userId, String token) {
-        fcmTokenRedisRepository.findById(userId).ifPresent(cache -> {
-            cache.removeToken(token);
-            fcmTokenRedisRepository.save(cache);
-        });
     }
 
     // FCM 토큰 비활성화
@@ -91,7 +70,6 @@ public class AlarmService {
         if (existingToken != null) {
             existingToken.deactivate();
         }
-        removeTokenFromRedis(userId, fcmToken);
     }
 
     // 알림 설정 조회
@@ -99,7 +77,7 @@ public class AlarmService {
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
         AlarmSetting alarmSetting = alarmSettingRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED));
         return new AlarmSettingResponseDTO(
                 alarmSetting.isAlarmAllEnabled(),
                 alarmSetting.isLinkActive(),
@@ -111,11 +89,11 @@ public class AlarmService {
 
     // 알림 설정 수정
     @Transactional
-    public boolean updateNoticeAlarmSetting(Long userId, AlarmSettingType alarmSettingType) {
+    public AlarmSettingResponseDTO updateNoticeAlarmSetting(Long userId, AlarmSettingType alarmSettingType) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
         AlarmSetting alarmSetting = alarmSettingRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED));
 
         switch (alarmSettingType) {
             case ALL -> alarmSetting.updateAll(!alarmSetting.isAlarmAllEnabled());
@@ -135,17 +113,15 @@ public class AlarmService {
             );
         }
 
-        return alarmSetting.isEnabled(alarmSettingType);
+        return new AlarmSettingResponseDTO(
+                alarmSetting.isAlarmAllEnabled(),
+                alarmSetting.isLinkActive(),
+                alarmSetting.isFolderActive(),
+                alarmSetting.isCurationActive(),
+                alarmSetting.isNoticeActive()
+        );
     }
 
-    // 알림 설정 타입별 조회
-    public boolean viewAlarmSettingByType(Long userId, AlarmSettingType alarmSettingType) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        AlarmSetting alarmSetting = alarmSettingRepository.findByUserId(userId)
-                .orElseThrow(() -> new GeneralException(AlarmErrorStatus.ALARM_NOT_FOUND));
-        return alarmSetting.isEnabled(alarmSettingType);
-    }
 
     // 개인 알림 전송 (알림 설정이 활성화된 경우에만 호출)
     // userId, 알림타입, targetId를 설정하면 메세지 내용을 자동으로 설정합니다.
@@ -196,10 +172,6 @@ public class AlarmService {
     ) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-
-        if (alarmSettingType == null) {
-            throw new GeneralException(ErrorStatus._BAD_REQUEST);
-        }
 
         if (size <= 0) {
             return new AlarmResponseDTO.AlarmCursorPageResponse(List.of(), null, false);

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -160,7 +160,7 @@ public class AlarmService {
     @Transactional
     public void registerAdminAlarm(AlarmRequestDTO.AdminAlarmSendRequestDTO requestDTO) {
         AlarmType alarmType = requestDTO.type();
-        if (alarmType.getSettingType() == AlarmSettingType.ALL) {
+        if (alarmType.getSettingType() != AlarmSettingType.NOTICE) {
             throw new GeneralException(AlarmErrorStatus.ALARM_TOPIC_SUBSCRIPTION_FAILED);
         }
 

--- a/src/main/java/com/umc/linkyou/service/alarm/FcmServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/FcmServiceImpl.java
@@ -57,6 +57,7 @@ public class FcmServiceImpl implements FcmPushSender, FcmSubscriber {
         try {
             firebaseMessaging.send(buildMessage(token, requestDTO));
         } catch (FirebaseMessagingException e) {
+            log.error("FCM 단일 토큰 전송 실패 - errorCode: {}, message: {}", e.getMessagingErrorCode(), e.getMessage(), e);
             throw new GeneralException(AlarmErrorStatus.ALARM_SEND_FAILED);
         }
     }

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -50,7 +50,6 @@ public interface AlarmApi {
             - 요청 body의 `fcmToken`은 필수값입니다.
             """)
     @ApiSuccessCode(SuccessStatus._OK)
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @DeleteMapping("/fcmtoken")
     ApiResponse<Object> deleteFcmToken(
             @CurrentUser CustomUserDetails userDetails,
@@ -60,7 +59,6 @@ public interface AlarmApi {
     @Operation(summary = "테스트 알림 전송", description = """
             발급받은 FCM 토큰으로 테스트 알림을 전송합니다.
             - `fcmToken`은 필수값입니다.
-            - 관리자 권한으로만 호출할 수 있습니다.
             """)
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(errorStatus = {ErrorStatus._FORBIDDEN})
@@ -76,7 +74,7 @@ public interface AlarmApi {
             """)
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
-    @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_NOT_FOUND})
+    @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED})
     @GetMapping("/settings")
     ApiResponse<AlarmSettingResponseDTO> viewAlarmSetting(
             @CurrentUser CustomUserDetails userDetails
@@ -88,9 +86,9 @@ public interface AlarmApi {
             """)
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
-    @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_NOT_FOUND, AlarmErrorStatus.ALARM_TOPIC_SUBSCRIPTION_FAILED})
+    @ApiErrorCode(alarmErrorStatus = {AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED, AlarmErrorStatus.ALARM_TOPIC_SUBSCRIPTION_FAILED})
     @PatchMapping("/settings")
-    ApiResponse<Boolean> updateAlarmSetting(
+    ApiResponse<AlarmSettingResponseDTO> updateAlarmSetting(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmSettingUpdateDTO request
     );

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -124,6 +124,11 @@ public interface AlarmApi {
 
     @Operation(summary = "관리자 브로드캐스트 알림 발송", description = """
             관리자 권한으로 브로드캐스트 알림을 등록합니다.
+            `ANNOUNCEMENT_UPDATE`, `ANNOUNCEMENT_ERROR` 두 가지 유형의 알림만 발송할 수 있습니다.
+                - `ANNOUNCEMENT_UPDATE`: 공지사항 업데이트 알림
+                - `ANNOUNCEMENT_ERROR`: 서비스 장애 알림
+                - 요청 body의 `type`과 `content`는 필수값입니다.
+                - 등록된 브로드캐스트 알림은 알림을 설정한 모든 사용자에게 푸시 알림으로 전송됩니다.
             """)
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(errorStatus = {ErrorStatus._FORBIDDEN})

--- a/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
@@ -57,7 +57,6 @@ public class AlarmController implements AlarmApi {
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.TestAlarmSendDTO request
     ) {
-        validateAdmin(userDetails);
         fcmPushSender.sendToToken(
                 request.fcmToken(),
                 FcmSendRequestDTO.of(AlarmType.ANNOUNCEMENT_UPDATE, userDetails.getUserId())
@@ -73,12 +72,12 @@ public class AlarmController implements AlarmApi {
     }
 
     @Override
-    public ApiResponse<Boolean> updateAlarmSetting(
+    public ApiResponse<AlarmSettingResponseDTO> updateAlarmSetting(
             @CurrentUser CustomUserDetails userDetails,
             @Valid @RequestBody AlarmRequestDTO.AlarmSettingUpdateDTO request
     ) {
-        boolean isEnabled = alarmService.updateNoticeAlarmSetting(userDetails.getUserId(), request.alarmType());
-        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_SETTING_UPDATED, isEnabled);
+        AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(userDetails.getUserId(), request.alarmType());
+        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_SETTING_UPDATED, result);
     }
 
     @Override

--- a/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
@@ -1,12 +1,14 @@
 package com.umc.linkyou.integration;
 
 import com.umc.linkyou.domain.Alarm;
+import com.umc.linkyou.domain.AlarmSetting;
 import com.umc.linkyou.domain.UserAlarm;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.repository.AlarmRepository;
+import com.umc.linkyou.repository.AlarmSettingRepository;
 import com.umc.linkyou.repository.UserAlarmRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.support.security.TestSecurityConfig;
@@ -16,15 +18,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,6 +50,9 @@ class AlarmApiIntegrationTest {
 
     @Autowired
     private UserAlarmRepository userAlarmRepository;
+
+    @Autowired
+    private AlarmSettingRepository alarmSettingRepository;
 
     @Test
     @DisplayName("알림 리스트 조회 - alarmType 파라미터로 정상 조회된다")
@@ -96,6 +102,48 @@ class AlarmApiIntegrationTest {
                         .param("size", "10")
                         .with(authentication(authFor(user))))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("알림 설정 수정 - AlarmSettingResponseDTO 형태로 반환된다")
+    void updateAlarmSetting_returnsFullDto() throws Exception {
+        Users user = createUser("alarm_user_4");
+        alarmSettingRepository.save(AlarmSetting.createDefault(user));
+
+        mockMvc.perform(patch("/api/v1/alarm/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"alarmType\": \"LINK\"}")
+                        .with(authentication(authFor(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.result.isAllEnabled").exists())
+                .andExpect(jsonPath("$.result.isLinkEnabled").value(false))
+                .andExpect(jsonPath("$.result.isFolderEnabled").value(true))
+                .andExpect(jsonPath("$.result.isCurationEnabled").value(true))
+                .andExpect(jsonPath("$.result.isNoticeEnabled").value(true));
+    }
+
+    @Test
+    @DisplayName("알림 설정 수정 - 개별 설정 모두 off 시 isAllEnabled도 false가 된다")
+    void updateAlarmSetting_allOff_disablesAllEnabled() throws Exception {
+        Users user = createUser("alarm_user_5");
+        AlarmSetting setting = AlarmSetting.createDefault(user);
+        setting.updateLink(false);
+        setting.updateFolder(false);
+        setting.updateCuration(false);
+        alarmSettingRepository.save(setting);
+
+        // NOTICE만 남은 상태에서 NOTICE off → 전체 off
+        mockMvc.perform(patch("/api/v1/alarm/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"alarmType\": \"NOTICE\"}")
+                        .with(authentication(authFor(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.isAllEnabled").value(false))
+                .andExpect(jsonPath("$.result.isLinkEnabled").value(false))
+                .andExpect(jsonPath("$.result.isFolderEnabled").value(false))
+                .andExpect(jsonPath("$.result.isCurationEnabled").value(false))
+                .andExpect(jsonPath("$.result.isNoticeEnabled").value(false));
     }
 
     private Users createUser(String nickName) {

--- a/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
@@ -124,7 +124,29 @@ class AlarmApiIntegrationTest {
     }
 
     @Test
-    @DisplayName("알림 설정 수정 - 전체 off 상태에서 개별 켜도 isAllEnabled는 false 유지된다")
+    @DisplayName("알림 설정 수정 - 개별 설정 4개 모두 off 시 isAllEnabled도 false가 된다")
+    void updateAlarmSetting_allIndividualOff_disablesMaster() throws Exception {
+        Users user = createUser("alarm_user_5");
+        AlarmSetting setting = AlarmSetting.createDefault(user);
+        setting.updateNotice(false);
+        setting.updateFolder(false);
+        setting.updateCuration(false);
+        alarmSettingRepository.save(setting);
+
+        mockMvc.perform(patch("/api/v1/alarm/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"alarmType\": \"LINK\"}")
+                        .with(authentication(authFor(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.isAllEnabled").value(false))
+                .andExpect(jsonPath("$.result.isLinkEnabled").value(false))
+                .andExpect(jsonPath("$.result.isNoticeEnabled").value(false))
+                .andExpect(jsonPath("$.result.isFolderEnabled").value(false))
+                .andExpect(jsonPath("$.result.isCurationEnabled").value(false));
+    }
+
+    @Test
+    @DisplayName("알림 설정 수정 - 전체 off 상태에서 개별 ON 시 isAllEnabled는 false 유지된다")
     void updateAlarmSetting_individualOn_masterStaysFalse() throws Exception {
         Users user = createUser("alarm_user_5");
         AlarmSetting setting = AlarmSetting.createDefault(user);

--- a/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/AlarmApiIntegrationTest.java
@@ -124,26 +124,40 @@ class AlarmApiIntegrationTest {
     }
 
     @Test
-    @DisplayName("알림 설정 수정 - 개별 설정 모두 off 시 isAllEnabled도 false가 된다")
-    void updateAlarmSetting_allOff_disablesAllEnabled() throws Exception {
+    @DisplayName("알림 설정 수정 - 전체 off 상태에서 개별 켜도 isAllEnabled는 false 유지된다")
+    void updateAlarmSetting_individualOn_masterStaysFalse() throws Exception {
         Users user = createUser("alarm_user_5");
+        AlarmSetting setting = AlarmSetting.createDefault(user);
+        setting.updateAll(false);
+        alarmSettingRepository.save(setting);
+
+        mockMvc.perform(patch("/api/v1/alarm/settings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"alarmType\": \"LINK\"}")
+                        .with(authentication(authFor(user))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.isAllEnabled").value(false))
+                .andExpect(jsonPath("$.result.isLinkEnabled").value(false));
+    }
+
+    @Test
+    @DisplayName("알림 설정 수정 - 개별 설정 모두 OFF 이후 개별 ON 시 해당 항목이 다시 활성화된다")
+    void updateAlarmSetting_reenableAfterAllOff() throws Exception {
+        Users user = createUser("alarm_user_6");
         AlarmSetting setting = AlarmSetting.createDefault(user);
         setting.updateLink(false);
         setting.updateFolder(false);
         setting.updateCuration(false);
+        setting.updateNotice(false);
         alarmSettingRepository.save(setting);
 
-        // NOTICE만 남은 상태에서 NOTICE off → 전체 off
         mockMvc.perform(patch("/api/v1/alarm/settings")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"alarmType\": \"NOTICE\"}")
+                        .content("{\"alarmType\": \"LINK\"}")
                         .with(authentication(authFor(user))))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.isAllEnabled").value(false))
-                .andExpect(jsonPath("$.result.isLinkEnabled").value(false))
-                .andExpect(jsonPath("$.result.isFolderEnabled").value(false))
-                .andExpect(jsonPath("$.result.isCurationEnabled").value(false))
-                .andExpect(jsonPath("$.result.isNoticeEnabled").value(false));
+                .andExpect(jsonPath("$.result.isLinkEnabled").value(true))
+                .andExpect(jsonPath("$.result.isAllEnabled").value(true));
     }
 
     private Users createUser(String nickName) {

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -220,7 +220,28 @@ class AlarmServiceTest {
             }
 
             @Test
-            @DisplayName("전체 off 상태에서 개별 설정을 켜도 isAllEnabled와 유효 알림 상태는 false 유지된다")
+            @DisplayName("개별 설정 4개 모두 off 시 isAllEnabled도 false가 된다")
+            void 개별설정_모두끔_마스터비활성화() {
+                Users user = user();
+                AlarmSetting setting = defaultSetting(user);
+                setting.updateNotice(false);
+                setting.updateFolder(false);
+                setting.updateCuration(false);
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+                AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
+
+                assertThat(result.isAllEnabled()).isFalse();
+                assertThat(result.isLinkEnabled()).isFalse();
+                assertThat(result.isNoticeEnabled()).isFalse();
+                assertThat(result.isFolderEnabled()).isFalse();
+                assertThat(result.isCurationEnabled()).isFalse();
+            }
+
+            @Test
+            @DisplayName("전체 off 상태에서 개별 설정을 켜도 isAllEnabled는 false 유지된다")
             void 전체off후_개별켜도_마스터유지() {
                 Users user = user();
                 AlarmSetting setting = defaultSetting(user);
@@ -231,9 +252,8 @@ class AlarmServiceTest {
 
                 AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
 
-                // isLinkEnabled는 isLinkActive() = alarmAllEnabled && linkEnabled = false && true = false
                 assertThat(result.isAllEnabled()).isFalse();
-                assertThat(result.isLinkEnabled()).isFalse();
+                assertThat(result.isLinkEnabled()).isFalse(); // alarmAllEnabled && linkEnabled = false
             }
         }
 

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -220,21 +220,20 @@ class AlarmServiceTest {
             }
 
             @Test
-            @DisplayName("개별 설정을 모두 끄면 isAllEnabled도 false가 된다")
-            void 개별설정_모두끔_전체비활성화() {
+            @DisplayName("전체 off 상태에서 개별 설정을 켜도 isAllEnabled와 유효 알림 상태는 false 유지된다")
+            void 전체off후_개별켜도_마스터유지() {
                 Users user = user();
                 AlarmSetting setting = defaultSetting(user);
-                setting.updateNotice(false);
-                setting.updateFolder(false);
-                setting.updateCuration(false);
+                setting.updateAll(false);
 
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
 
                 AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
 
-                assertThat(result.isLinkEnabled()).isFalse();
+                // isLinkEnabled는 isLinkActive() = alarmAllEnabled && linkEnabled = false && true = false
                 assertThat(result.isAllEnabled()).isFalse();
+                assertThat(result.isLinkEnabled()).isFalse();
             }
         }
 

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -1,0 +1,536 @@
+package com.umc.linkyou.service.alarm;
+
+import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.*;
+import com.umc.linkyou.domain.enums.AlarmSettingType;
+import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.enums.Role;
+import com.umc.linkyou.repository.AlarmRepository;
+import com.umc.linkyou.repository.AlarmSettingRepository;
+import com.umc.linkyou.repository.UserAlarmRepository;
+import com.umc.linkyou.repository.UserFcmTokenRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
+import com.umc.linkyou.web.dto.alarm.AlarmResponseDTO;
+import com.umc.linkyou.web.dto.alarm.AlarmSettingResponseDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AlarmService 단위 테스트")
+class AlarmServiceTest {
+
+    @InjectMocks private AlarmService alarmService;
+
+    @Mock private UserFcmTokenRepository userFcmTokenRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private AlarmSettingRepository alarmSettingRepository;
+    @Mock private AlarmRepository alarmRepository;
+    @Mock private UserAlarmRepository userAlarmRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private static final Long USER_ID = 1L;
+    private static final Long ALARM_ID = 10L;
+    private static final String FCM_TOKEN = "test-fcm-token";
+
+    private Users stubUser() {
+        return Users.builder().id(USER_ID).nickName("테스트유저").role(Role.USER).build();
+    }
+
+    private AlarmSetting stubDefaultSetting(Users user) {
+        return AlarmSetting.createDefault(user);
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 등록 (registerFcmToken)")
+    class RegisterFcmToken {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("신규 토큰이면 UsersFcmToken을 저장한다")
+            void 신규토큰_저장() {
+                Users user = stubUser();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(null);
+
+                alarmService.registerFcmToken(USER_ID, new AlarmRequestDTO.AlarmFcmTokenDTO(FCM_TOKEN));
+
+                verify(userFcmTokenRepository).save(any(UsersFcmToken.class));
+            }
+
+            @Test
+            @DisplayName("이미 등록된 토큰이면 activate만 호출한다")
+            void 기존토큰_활성화() {
+                Users user = stubUser();
+                UsersFcmToken existingToken = UsersFcmToken.builder()
+                        .user(user).fcmToken(FCM_TOKEN)
+                        .lastUsedAt(LocalDateTime.now().minusDays(5))
+                        .expiresAt(LocalDateTime.now().plusDays(55))
+                        .isActive(false)
+                        .build();
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(existingToken);
+
+                alarmService.registerFcmToken(USER_ID, new AlarmRequestDTO.AlarmFcmTokenDTO(FCM_TOKEN));
+
+                assertThat(existingToken.getIsActive()).isTrue();
+                verify(userFcmTokenRepository, never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않는 유저면 _USER_NOT_FOUND를 던진다")
+            void 유저없음_예외() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() ->
+                        alarmService.registerFcmToken(USER_ID, new AlarmRequestDTO.AlarmFcmTokenDTO(FCM_TOKEN)))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 비활성화 (deleteFcmToken)")
+    class DeleteFcmToken {
+
+        @Test
+        @DisplayName("토큰이 존재하면 deactivate 처리한다")
+        void 토큰존재_비활성화() {
+            Users user = stubUser();
+            UsersFcmToken token = UsersFcmToken.builder()
+                    .user(user).fcmToken(FCM_TOKEN)
+                    .lastUsedAt(LocalDateTime.now()).expiresAt(LocalDateTime.now().plusDays(60))
+                    .isActive(true).build();
+            given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(token);
+
+            alarmService.deleteFcmToken(USER_ID, FCM_TOKEN);
+
+            assertThat(token.getIsActive()).isFalse();
+        }
+
+        @Test
+        @DisplayName("토큰이 없어도 예외 없이 종료한다")
+        void 토큰없음_노옵() {
+            given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(null);
+
+            alarmService.deleteFcmToken(USER_ID, FCM_TOKEN);
+
+            verify(userFcmTokenRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 설정 조회 (viewAlarm)")
+    class ViewAlarm {
+
+        @Test
+        @DisplayName("설정이 있으면 AlarmSettingResponseDTO를 반환한다")
+        void 설정조회_성공() {
+            Users user = stubUser();
+            AlarmSetting setting = stubDefaultSetting(user);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+            AlarmSettingResponseDTO result = alarmService.viewAlarm(USER_ID);
+
+            assertThat(result.isAllEnabled()).isTrue();
+            assertThat(result.isLinkEnabled()).isTrue();
+            assertThat(result.isNoticeEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+        void 유저없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.viewAlarm(USER_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("알림 설정이 없으면 ALARM_SETTING_NOT_INITIALIZED를 던진다")
+        void 설정없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.viewAlarm(USER_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 설정 수정 (updateNoticeAlarmSetting)")
+    class UpdateNoticeAlarmSetting {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("ALL 토글 시 모든 설정이 반전되고 NOTICE 이벤트가 발행된다")
+            void ALL_토글_이벤트발행() {
+                Users user = stubUser();
+                AlarmSetting setting = stubDefaultSetting(user);
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+                AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.ALL);
+
+                assertThat(result.isAllEnabled()).isFalse();
+                assertThat(result.isLinkEnabled()).isFalse();
+                verify(eventPublisher).publishEvent((Object) any());
+            }
+
+            @Test
+            @DisplayName("NOTICE 토글 시 notice 설정이 반전되고 이벤트가 발행된다")
+            void NOTICE_토글_이벤트발행() {
+                Users user = stubUser();
+                AlarmSetting setting = stubDefaultSetting(user);
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+                AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.NOTICE);
+
+                assertThat(result.isNoticeEnabled()).isFalse();
+                verify(eventPublisher).publishEvent((Object) any());
+            }
+
+            @Test
+            @DisplayName("LINK 토글 시 link 설정만 반전되고 이벤트는 발행되지 않는다")
+            void LINK_토글_이벤트없음() {
+                Users user = stubUser();
+                AlarmSetting setting = stubDefaultSetting(user);
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+                AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
+
+                assertThat(result.isLinkEnabled()).isFalse();
+                assertThat(result.isAllEnabled()).isTrue();
+                verify(eventPublisher, never()).publishEvent((Object) any());
+            }
+
+            @Test
+            @DisplayName("개별 설정을 모두 끄면 isAllEnabled도 false가 된다")
+            void 개별설정_모두끔_전체비활성화() {
+                Users user = stubUser();
+                AlarmSetting setting = stubDefaultSetting(user);
+                setting.updateNotice(false);
+                setting.updateFolder(false);
+                setting.updateCuration(false);
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+                AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
+
+                assertThat(result.isLinkEnabled()).isFalse();
+                assertThat(result.isAllEnabled()).isFalse();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+            void 유저없음_예외() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() ->
+                        alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("알림 설정이 없으면 ALARM_SETTING_NOT_INITIALIZED를 던진다")
+            void 설정없음_예외() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() ->
+                        alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.NOTICE))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(AlarmErrorStatus.ALARM_SETTING_NOT_INITIALIZED));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("개인 알림 발송 (sendAlarm)")
+    class SendAlarm {
+
+        @Test
+        @DisplayName("알림이 저장되고 PersonalAlarmEvent가 발행된다")
+        void 알림발송_성공() {
+            Users user = stubUser();
+            Alarm savedAlarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 100L);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmRepository.save(any())).willReturn(savedAlarm);
+
+            alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                    AlarmType.LINK_SUMMARY_COMPLETE, 100L));
+
+            verify(alarmRepository).save(any());
+            verify(userAlarmRepository).save(any());
+            verify(eventPublisher).publishEvent((Object) any());
+        }
+
+        @Test
+        @DisplayName("CURATION_UPDATED 타입이면 body에 닉네임이 포함된다")
+        void 큐레이션알림_닉네임포함() {
+            Users user = stubUser();
+            ArgumentCaptor<Alarm> alarmCaptor = ArgumentCaptor.forClass(Alarm.class);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmRepository.save(alarmCaptor.capture())).willAnswer(inv -> inv.getArgument(0));
+
+            alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                    AlarmType.CURATION_UPDATED, 200L));
+
+            assertThat(alarmCaptor.getValue().getBody()).contains("테스트유저");
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+        void 유저없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                            AlarmType.LINK_SUMMARY_COMPLETE, 1L)))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("관리자 브로드캐스트 알림 등록 (registerAdminAlarm)")
+    class RegisterAdminAlarm {
+
+        @Test
+        @DisplayName("알림이 저장되고 브로드캐스트 이벤트 2개가 발행된다")
+        void 브로드캐스트_알림등록_성공() {
+            Alarm savedAlarm = mock(Alarm.class);
+            given(savedAlarm.getId()).willReturn(ALARM_ID);
+            given(alarmRepository.save(any())).willReturn(savedAlarm);
+
+            alarmService.registerAdminAlarm(new AlarmRequestDTO.AdminAlarmSendRequestDTO(
+                    AlarmType.ANNOUNCEMENT_UPDATE, "공지 내용"));
+
+            verify(eventPublisher, times(2)).publishEvent((Object) any());
+        }
+
+        @Test
+        @DisplayName("AlarmType이 ALL이면 ALARM_TOPIC_SUBSCRIPTION_FAILED를 던진다")
+        void ALL타입_예외() {
+            AlarmType mockType = mock(AlarmType.class);
+            given(mockType.getSettingType()).willReturn(AlarmSettingType.ALL);
+
+            assertThatThrownBy(() ->
+                    alarmService.registerAdminAlarm(new AlarmRequestDTO.AdminAlarmSendRequestDTO(
+                            mockType, "내용")))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(AlarmErrorStatus.ALARM_TOPIC_SUBSCRIPTION_FAILED));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 목록 조회 (viewAlarmList)")
+    class ViewAlarmList {
+
+        @Test
+        @DisplayName("ALL 타입이면 전체 알림 목록을 반환한다")
+        void 전체알림_목록조회_성공() {
+            Users user = stubUser();
+            Alarm alarm = Alarm.create(AlarmType.CURATION_UPDATED, 1L);
+            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(userAlarmRepository.findAlarmListByCursor(
+                    eq(USER_ID), anyLong(), any(Pageable.class)))
+                    .willReturn(List.of(userAlarm));
+
+            AlarmResponseDTO.AlarmCursorPageResponse result =
+                    alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 10);
+
+            assertThat(result.items()).hasSize(1);
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("특정 타입 필터로 조회하면 해당 타입만 반환한다")
+        void 타입필터_알림목록조회_성공() {
+            Users user = stubUser();
+            Alarm alarm = Alarm.create(AlarmType.FOLDER_DELETED, 2L);
+            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(userAlarmRepository.findAlarmListByCursor(
+                    eq(USER_ID), anyLong(), anyList(), any(Pageable.class)))
+                    .willReturn(List.of(userAlarm));
+
+            AlarmResponseDTO.AlarmCursorPageResponse result =
+                    alarmService.viewAlarmList(USER_ID, AlarmSettingType.FOLDER, null, 10);
+
+            assertThat(result.items()).hasSize(1);
+        }
+
+        @Test
+        @DisplayName("size가 0 이하면 빈 목록을 반환한다")
+        void 사이즈0이하_빈목록반환() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+
+            AlarmResponseDTO.AlarmCursorPageResponse result =
+                    alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 0);
+
+            assertThat(result.items()).isEmpty();
+            assertThat(result.hasNext()).isFalse();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+        void 유저없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() ->
+                    alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 10))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 상세 조회 (viewAlarmDetail)")
+    class ViewAlarmDetail {
+
+        @Test
+        @DisplayName("알림이 있으면 AlarmDetailDTO를 반환한다")
+        void 알림상세_조회_성공() {
+            Alarm alarm = Alarm.create(AlarmType.ANNOUNCEMENT_UPDATE, 1L);
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
+
+            AlarmResponseDTO.AlarmDetailDTO result = alarmService.viewAlarmDetail(USER_ID, ALARM_ID);
+
+            assertThat(result.title()).isEqualTo(AlarmType.ANNOUNCEMENT_UPDATE.getTitle());
+            assertThat(result.content()).isNotBlank();
+        }
+
+        @Test
+        @DisplayName("알림이 없으면 ALARM_NOT_FOUND를 던진다")
+        void 알림없음_예외() {
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.viewAlarmDetail(USER_ID, ALARM_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(AlarmErrorStatus.ALARM_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("알림 읽음 처리 (markAlarmAsRead)")
+    class MarkAlarmAsRead {
+
+        @Test
+        @DisplayName("읽음 처리 시 isRead가 true로 변경된다")
+        void 읽음처리_성공() {
+            Users user = stubUser();
+            Alarm alarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 1L);
+            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
+            given(userAlarmRepository.findByUserAndAlarm(user, alarm)).willReturn(userAlarm);
+
+            alarmService.markAlarmAsRead(USER_ID, ALARM_ID);
+
+            assertThat(userAlarm.isRead()).isTrue();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+        void 유저없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.markAlarmAsRead(USER_ID, ALARM_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("알림이 없으면 ALARM_NOT_FOUND를 던진다")
+        void 알림없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.markAlarmAsRead(USER_ID, ALARM_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(AlarmErrorStatus.ALARM_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("UserAlarm이 없으면 ALARM_NOT_FOUND를 던진다")
+        void UserAlarm없음_예외() {
+            Users user = stubUser();
+            Alarm alarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 1L);
+
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
+            given(userAlarmRepository.findByUserAndAlarm(user, alarm)).willReturn(null);
+
+            assertThatThrownBy(() -> alarmService.markAlarmAsRead(USER_ID, ALARM_ID))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(AlarmErrorStatus.ALARM_NOT_FOUND));
+        }
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -6,12 +6,12 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.*;
 import com.umc.linkyou.domain.enums.AlarmSettingType;
 import com.umc.linkyou.domain.enums.AlarmType;
-import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.repository.AlarmRepository;
 import com.umc.linkyou.repository.AlarmSettingRepository;
 import com.umc.linkyou.repository.UserAlarmRepository;
 import com.umc.linkyou.repository.UserFcmTokenRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.support.fixture.AlarmFixture;
 import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import com.umc.linkyou.web.dto.alarm.AlarmResponseDTO;
 import com.umc.linkyou.web.dto.alarm.AlarmSettingResponseDTO;
@@ -26,13 +26,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.umc.linkyou.support.fixture.AlarmFixture.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -49,18 +49,6 @@ class AlarmServiceTest {
     @Mock private UserAlarmRepository userAlarmRepository;
     @Mock private ApplicationEventPublisher eventPublisher;
 
-    private static final Long USER_ID = 1L;
-    private static final Long ALARM_ID = 10L;
-    private static final String FCM_TOKEN = "test-fcm-token";
-
-    private Users stubUser() {
-        return Users.builder().id(USER_ID).nickName("테스트유저").role(Role.USER).build();
-    }
-
-    private AlarmSetting stubDefaultSetting(Users user) {
-        return AlarmSetting.createDefault(user);
-    }
-
     @Nested
     @DisplayName("FCM 토큰 등록 (registerFcmToken)")
     class RegisterFcmToken {
@@ -72,8 +60,7 @@ class AlarmServiceTest {
             @Test
             @DisplayName("신규 토큰이면 UsersFcmToken을 저장한다")
             void 신규토큰_저장() {
-                Users user = stubUser();
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
                 given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(null);
 
                 alarmService.registerFcmToken(USER_ID, new AlarmRequestDTO.AlarmFcmTokenDTO(FCM_TOKEN));
@@ -84,20 +71,15 @@ class AlarmServiceTest {
             @Test
             @DisplayName("이미 등록된 토큰이면 activate만 호출한다")
             void 기존토큰_활성화() {
-                Users user = stubUser();
-                UsersFcmToken existingToken = UsersFcmToken.builder()
-                        .user(user).fcmToken(FCM_TOKEN)
-                        .lastUsedAt(LocalDateTime.now().minusDays(5))
-                        .expiresAt(LocalDateTime.now().plusDays(55))
-                        .isActive(false)
-                        .build();
+                Users user = user();
+                UsersFcmToken token = AlarmFixture.inactiveToken(user);
 
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(existingToken);
+                given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(token);
 
                 alarmService.registerFcmToken(USER_ID, new AlarmRequestDTO.AlarmFcmTokenDTO(FCM_TOKEN));
 
-                assertThat(existingToken.getIsActive()).isTrue();
+                assertThat(token.getIsActive()).isTrue();
                 verify(userFcmTokenRepository, never()).save(any());
             }
         }
@@ -127,11 +109,7 @@ class AlarmServiceTest {
         @Test
         @DisplayName("토큰이 존재하면 deactivate 처리한다")
         void 토큰존재_비활성화() {
-            Users user = stubUser();
-            UsersFcmToken token = UsersFcmToken.builder()
-                    .user(user).fcmToken(FCM_TOKEN)
-                    .lastUsedAt(LocalDateTime.now()).expiresAt(LocalDateTime.now().plusDays(60))
-                    .isActive(true).build();
+            UsersFcmToken token = AlarmFixture.activeToken(user());
             given(userFcmTokenRepository.findByUser_IdAndFcmToken(USER_ID, FCM_TOKEN)).willReturn(token);
 
             alarmService.deleteFcmToken(USER_ID, FCM_TOKEN);
@@ -157,11 +135,9 @@ class AlarmServiceTest {
         @Test
         @DisplayName("설정이 있으면 AlarmSettingResponseDTO를 반환한다")
         void 설정조회_성공() {
-            Users user = stubUser();
-            AlarmSetting setting = stubDefaultSetting(user);
-
+            Users user = user();
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user)));
 
             AlarmSettingResponseDTO result = alarmService.viewAlarm(USER_ID);
 
@@ -184,7 +160,7 @@ class AlarmServiceTest {
         @Test
         @DisplayName("알림 설정이 없으면 ALARM_SETTING_NOT_INITIALIZED를 던진다")
         void 설정없음_예외() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
             given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> alarmService.viewAlarm(USER_ID))
@@ -203,13 +179,11 @@ class AlarmServiceTest {
         class Success {
 
             @Test
-            @DisplayName("ALL 토글 시 모든 설정이 반전되고 NOTICE 이벤트가 발행된다")
+            @DisplayName("ALL 토글 시 모든 설정이 반전되고 이벤트가 발행된다")
             void ALL_토글_이벤트발행() {
-                Users user = stubUser();
-                AlarmSetting setting = stubDefaultSetting(user);
-
+                Users user = user();
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user)));
 
                 AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.ALL);
 
@@ -221,11 +195,9 @@ class AlarmServiceTest {
             @Test
             @DisplayName("NOTICE 토글 시 notice 설정이 반전되고 이벤트가 발행된다")
             void NOTICE_토글_이벤트발행() {
-                Users user = stubUser();
-                AlarmSetting setting = stubDefaultSetting(user);
-
+                Users user = user();
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user)));
 
                 AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.NOTICE);
 
@@ -236,11 +208,9 @@ class AlarmServiceTest {
             @Test
             @DisplayName("LINK 토글 시 link 설정만 반전되고 이벤트는 발행되지 않는다")
             void LINK_토글_이벤트없음() {
-                Users user = stubUser();
-                AlarmSetting setting = stubDefaultSetting(user);
-
+                Users user = user();
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+                given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user)));
 
                 AlarmSettingResponseDTO result = alarmService.updateNoticeAlarmSetting(USER_ID, AlarmSettingType.LINK);
 
@@ -252,8 +222,8 @@ class AlarmServiceTest {
             @Test
             @DisplayName("개별 설정을 모두 끄면 isAllEnabled도 false가 된다")
             void 개별설정_모두끔_전체비활성화() {
-                Users user = stubUser();
-                AlarmSetting setting = stubDefaultSetting(user);
+                Users user = user();
+                AlarmSetting setting = defaultSetting(user);
                 setting.updateNotice(false);
                 setting.updateFolder(false);
                 setting.updateCuration(false);
@@ -287,7 +257,7 @@ class AlarmServiceTest {
             @Test
             @DisplayName("알림 설정이 없으면 ALARM_SETTING_NOT_INITIALIZED를 던진다")
             void 설정없음_예외() {
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
                 given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
 
                 assertThatThrownBy(() ->
@@ -306,11 +276,8 @@ class AlarmServiceTest {
         @Test
         @DisplayName("알림이 저장되고 PersonalAlarmEvent가 발행된다")
         void 알림발송_성공() {
-            Users user = stubUser();
-            Alarm savedAlarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 100L);
-
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(alarmRepository.save(any())).willReturn(savedAlarm);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(alarmRepository.save(any())).willReturn(alarm(AlarmType.LINK_SUMMARY_COMPLETE));
 
             alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
                     AlarmType.LINK_SUMMARY_COMPLETE, 100L));
@@ -323,9 +290,8 @@ class AlarmServiceTest {
         @Test
         @DisplayName("CURATION_UPDATED 타입이면 body에 닉네임이 포함된다")
         void 큐레이션알림_닉네임포함() {
-            Users user = stubUser();
             ArgumentCaptor<Alarm> alarmCaptor = ArgumentCaptor.forClass(Alarm.class);
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
             given(alarmRepository.save(alarmCaptor.capture())).willAnswer(inv -> inv.getArgument(0));
 
             alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
@@ -387,14 +353,12 @@ class AlarmServiceTest {
         @Test
         @DisplayName("ALL 타입이면 전체 알림 목록을 반환한다")
         void 전체알림_목록조회_성공() {
-            Users user = stubUser();
-            Alarm alarm = Alarm.create(AlarmType.CURATION_UPDATED, 1L);
-            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+            Users user = user();
+            UserAlarm ua = userAlarm(user, alarm(AlarmType.CURATION_UPDATED));
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(userAlarmRepository.findAlarmListByCursor(
-                    eq(USER_ID), anyLong(), any(Pageable.class)))
-                    .willReturn(List.of(userAlarm));
+            given(userAlarmRepository.findAlarmListByCursor(eq(USER_ID), anyLong(), any(Pageable.class)))
+                    .willReturn(List.of(ua));
 
             AlarmResponseDTO.AlarmCursorPageResponse result =
                     alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 10);
@@ -406,14 +370,12 @@ class AlarmServiceTest {
         @Test
         @DisplayName("특정 타입 필터로 조회하면 해당 타입만 반환한다")
         void 타입필터_알림목록조회_성공() {
-            Users user = stubUser();
-            Alarm alarm = Alarm.create(AlarmType.FOLDER_DELETED, 2L);
-            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+            Users user = user();
+            UserAlarm ua = userAlarm(user, alarm(AlarmType.FOLDER_DELETED));
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(userAlarmRepository.findAlarmListByCursor(
-                    eq(USER_ID), anyLong(), anyList(), any(Pageable.class)))
-                    .willReturn(List.of(userAlarm));
+            given(userAlarmRepository.findAlarmListByCursor(eq(USER_ID), anyLong(), anyList(), any(Pageable.class)))
+                    .willReturn(List.of(ua));
 
             AlarmResponseDTO.AlarmCursorPageResponse result =
                     alarmService.viewAlarmList(USER_ID, AlarmSettingType.FOLDER, null, 10);
@@ -424,7 +386,7 @@ class AlarmServiceTest {
         @Test
         @DisplayName("size가 0 이하면 빈 목록을 반환한다")
         void 사이즈0이하_빈목록반환() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
 
             AlarmResponseDTO.AlarmCursorPageResponse result =
                     alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 0);
@@ -453,8 +415,7 @@ class AlarmServiceTest {
         @Test
         @DisplayName("알림이 있으면 AlarmDetailDTO를 반환한다")
         void 알림상세_조회_성공() {
-            Alarm alarm = Alarm.create(AlarmType.ANNOUNCEMENT_UPDATE, 1L);
-            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm(AlarmType.ANNOUNCEMENT_UPDATE)));
 
             AlarmResponseDTO.AlarmDetailDTO result = alarmService.viewAlarmDetail(USER_ID, ALARM_ID);
 
@@ -481,17 +442,17 @@ class AlarmServiceTest {
         @Test
         @DisplayName("읽음 처리 시 isRead가 true로 변경된다")
         void 읽음처리_성공() {
-            Users user = stubUser();
-            Alarm alarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 1L);
-            UserAlarm userAlarm = UserAlarm.create(user, alarm);
+            Users user = user();
+            Alarm al = alarm(AlarmType.LINK_SUMMARY_COMPLETE);
+            UserAlarm ua = userAlarm(user, al);
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
-            given(userAlarmRepository.findByUserAndAlarm(user, alarm)).willReturn(userAlarm);
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(al));
+            given(userAlarmRepository.findByUserAndAlarm(user, al)).willReturn(ua);
 
             alarmService.markAlarmAsRead(USER_ID, ALARM_ID);
 
-            assertThat(userAlarm.isRead()).isTrue();
+            assertThat(ua.isRead()).isTrue();
         }
 
         @Test
@@ -508,7 +469,7 @@ class AlarmServiceTest {
         @Test
         @DisplayName("알림이 없으면 ALARM_NOT_FOUND를 던진다")
         void 알림없음_예외() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(stubUser()));
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
             given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> alarmService.markAlarmAsRead(USER_ID, ALARM_ID))
@@ -520,12 +481,12 @@ class AlarmServiceTest {
         @Test
         @DisplayName("UserAlarm이 없으면 ALARM_NOT_FOUND를 던진다")
         void UserAlarm없음_예외() {
-            Users user = stubUser();
-            Alarm alarm = Alarm.create(AlarmType.LINK_SUMMARY_COMPLETE, 1L);
+            Users user = user();
+            Alarm al = alarm(AlarmType.LINK_SUMMARY_COMPLETE);
 
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(alarm));
-            given(userAlarmRepository.findByUserAndAlarm(user, alarm)).willReturn(null);
+            given(alarmRepository.findById(ALARM_ID)).willReturn(Optional.of(al));
+            given(userAlarmRepository.findByUserAndAlarm(user, al)).willReturn(null);
 
             assertThatThrownBy(() -> alarmService.markAlarmAsRead(USER_ID, ALARM_ID))
                     .isInstanceOf(GeneralException.class)

--- a/src/test/java/com/umc/linkyou/support/fixture/AlarmFixture.java
+++ b/src/test/java/com/umc/linkyou/support/fixture/AlarmFixture.java
@@ -1,0 +1,54 @@
+package com.umc.linkyou.support.fixture;
+
+import com.umc.linkyou.domain.*;
+import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.enums.Role;
+
+import java.time.LocalDateTime;
+
+public class AlarmFixture {
+
+    public static final Long USER_ID = 1L;
+    public static final Long ALARM_ID = 10L;
+    public static final String FCM_TOKEN = "test-fcm-token";
+
+    public static Users user() {
+        return Users.builder()
+                .id(USER_ID)
+                .nickName("테스트유저")
+                .role(Role.USER)
+                .build();
+    }
+
+    public static AlarmSetting defaultSetting(Users user) {
+        return AlarmSetting.createDefault(user);
+    }
+
+    public static Alarm alarm(AlarmType type) {
+        return Alarm.create(type, 1L);
+    }
+
+    public static UserAlarm userAlarm(Users user, Alarm alarm) {
+        return UserAlarm.create(user, alarm);
+    }
+
+    public static UsersFcmToken activeToken(Users user) {
+        return UsersFcmToken.builder()
+                .user(user)
+                .fcmToken(FCM_TOKEN)
+                .lastUsedAt(LocalDateTime.now())
+                .expiresAt(LocalDateTime.now().plusDays(60))
+                .isActive(true)
+                .build();
+    }
+
+    public static UsersFcmToken inactiveToken(Users user) {
+        return UsersFcmToken.builder()
+                .user(user)
+                .fcmToken(FCM_TOKEN)
+                .lastUsedAt(LocalDateTime.now().minusDays(5))
+                .expiresAt(LocalDateTime.now().plusDays(55))
+                .isActive(false)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

#301 
---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
  - 알림 수정 시 개별 설정에서 모두 off 시 alarmAllEnabled 자동 false 처리 : syncAllEnabled() 추가
  - 알림 수정 응답 타입 Boolean → AlarmSettingResponseDTO (GET과 동일)
  - @Min @Max 검증 인터페이스에 유지
  - deleteFcmToken 불필요한 @ApiErrorCode 제거
  - GET/PATCH settings의 에러코드를 ALARM_SETTING_NOT_INITIALIZED로 교체(알림 설정이 되지 않은 사용자의 경우.. 물론 이 경우는 현재 거의 없음)
  - sendToToken 실패 로그 추가 (linter 반영)
  - 알림 서비스 테스트코드 작성
### 2️⃣ Functional Requirement
없음

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 알림 설정이 초기화되지 않은 사용자에 대한 오류 처리 및 메시지 개선
  * 개별 항목을 모두 비활성화했을 때 전체 알림 활성 상태 자동 동기화

* **Refactor**
  * FCM 토큰의 Redis 캐시 처리 제거
  * 알림 설정 수정 API가 상세 상태 DTO를 반환하도록 응답 형식 개선
  * 테스트 알림 전송 시 오류 로깅 강화

* **New Features**
  * 전체 알림(모두 켜기/끄기) 토글 기능 추가
  * 관리자 브로드캐스트 발송 대상 유형 설명 및 제한(공지 유형 허용) 명확화

* **Tests**
  * 통합/단위 테스트 및 테스트 픽스처 추가 (알림 설정 흐름 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->