### PR TITLE
Fix/#304 bug interests purposes

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserErrorStatus.java
@@ -17,6 +17,8 @@ public enum UserErrorStatus implements BaseErrorCode {
     _INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USERS4005", "잘못된 비밀번호입니다."),
     _PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USERS4006", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     _INVALID_EMAIL_ADDRESS(HttpStatus.BAD_REQUEST, "USERS4008", "유효하지 않은 이메일 주소입니다."),
+    _INVALID_PURPOSE(HttpStatus.BAD_REQUEST, "USERS4009", "유효하지 않은 purpose 값입니다."),
+    _INVALID_INTEREST(HttpStatus.BAD_REQUEST, "USERS4010", "유효하지 않은 interest 값입니다."),
     // 401 Unauthorized
     _VERIFICATION_FAILED(HttpStatus.UNAUTHORIZED, "USERS4011", "인증 코드 검증 실패"),
     _LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "USERS4012", "이메일 주소 또는 비밀번호를 다시 확인하세요."),

--- a/src/main/java/com/umc/linkyou/converter/UserConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/UserConverter.java
@@ -8,6 +8,8 @@ import com.umc.linkyou.domain.classification.Interests;
 import com.umc.linkyou.domain.classification.Job;
 import com.umc.linkyou.domain.classification.Purposes;
 import com.umc.linkyou.domain.enums.Gender;
+import com.umc.linkyou.domain.enums.Interest;
+import com.umc.linkyou.domain.enums.Purpose;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
@@ -90,29 +92,12 @@ public class UserConverter {
     }
 
 
-
-    public static void setupUserPurposes(Users user, List<String> purposeNames) {
-        if (purposeNames == null) return;
-        if (user.getPurposes() != null) {
-            user.getPurposes().clear();
-        }
-        if (!purposeNames.isEmpty()) {
-            purposeNames.stream()
-                    .map(name -> new Purposes(name, user))
-                    .forEach(purpose -> user.getPurposes().add(purpose));
-        }
+    public static Purposes toPurposeEntity(String purposeName, Users user) {
+        return new Purposes(Purpose.valueOf(purposeName).name(), user);
     }
 
-    // 엔티티의 초기 Interests 설정
-    public static void setupUserInterests(Users user, List<String> interestNames) {
-        if (interestNames == null) return;
-        if (user.getInterests() != null) {
-            user.getInterests().clear();
-        }
-        if (!interestNames.isEmpty()) {
-            interestNames.stream()
-                    .map(name -> new Interests(name, user))
-                    .forEach(interest -> user.getInterests().add(interest));
-        }
+    public static Interests toInterestEntity(String interestName, Users user) {
+        return new Interests(Interest.valueOf(interestName).name(), user);
     }
+
 }

--- a/src/main/java/com/umc/linkyou/domain/classification/Interests.java
+++ b/src/main/java/com/umc/linkyou/domain/classification/Interests.java
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 public class Interests {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/umc/linkyou/domain/classification/Interests.java
+++ b/src/main/java/com/umc/linkyou/domain/classification/Interests.java
@@ -31,7 +31,6 @@ public class Interests {
         this.interest = enumInterest;
         this.user = newUser;
         this.selectedAt = LocalDateTime.now();
-        user.getInterests().add(this);
     }
 
     @PrePersist

--- a/src/main/java/com/umc/linkyou/domain/classification/Purposes.java
+++ b/src/main/java/com/umc/linkyou/domain/classification/Purposes.java
@@ -30,7 +30,6 @@ public class Purposes {
         this.purpose = enumPurpose;
         this.user = newUser;
         this.selectedAt = LocalDateTime.now();
-        user.getPurposes().add(this);
     }
 
     @PrePersist

--- a/src/main/java/com/umc/linkyou/domain/classification/Purposes.java
+++ b/src/main/java/com/umc/linkyou/domain/classification/Purposes.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 public class Purposes {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -369,10 +369,9 @@ public class UserService {
 
         user.getPurposes().clear();
 
-        for (String name : purposeNames) {
+        for (String name : purposeNames.stream().distinct().toList()) {
             try {
-                Purpose purpose = Purpose.valueOf(name);
-                user.getPurposes().add(new Purposes(purpose.name(), user));
+                user.getPurposes().add(UserConverter.toPurposeEntity(name, user));
             } catch (IllegalArgumentException | NullPointerException e) {
                 throw new GeneralException(UserErrorStatus._INVALID_PURPOSE);
             }
@@ -384,10 +383,9 @@ public class UserService {
 
         user.getInterests().clear();
 
-        for (String name : interestNames) {
+        for (String name : interestNames.stream().distinct().toList()) {
             try {
-                Interest interest = Interest.valueOf(name);
-                user.getInterests().add(new Interests(interest.name(), user));
+                user.getInterests().add(UserConverter.toInterestEntity(name, user));
             } catch (IllegalArgumentException | NullPointerException e) {
                 throw new GeneralException(UserErrorStatus._INVALID_INTEREST);
             }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -5,16 +5,15 @@ import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.domain.classification.Interests;
+import com.umc.linkyou.domain.classification.Purposes;
+import com.umc.linkyou.domain.enums.*;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
 import com.umc.linkyou.jwt.TokenIssueService;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.*;
-import com.umc.linkyou.domain.enums.DeviceType;
-import com.umc.linkyou.domain.enums.PermissionType;
-import com.umc.linkyou.domain.enums.Provider;
-import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.domain.folder.Fcolor;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.classification.Category;
@@ -108,8 +107,8 @@ public class UserService {
                     newUser.encodePassword(passwordEncoder.encode(request.password()));
 
                     // Purposes / Interests 설정
-                    UserConverter.setupUserPurposes(newUser, request.purposeList());
-                    UserConverter.setupUserInterests(newUser, request.interestList());
+                    replacePurposes(newUser, request.purposeList());
+                    replaceInterests(newUser, request.interestList());
 
                     Users savedUser = userRepository.save(newUser);
                     termsAgreementService.upsertTerms(savedUser, request.termsMap());
@@ -202,8 +201,8 @@ public class UserService {
 
 
         // Purposes / Interests 설정
-        UserConverter.setupUserPurposes(user, request.getPurposeList());
-        UserConverter.setupUserInterests(user, request.getInterestList());
+        replacePurposes(user, request.getPurposeList());
+        replaceInterests(user, request.getInterestList());
 
         termsAgreementService.upsertTerms(user, request.getTermsMap());
 
@@ -295,8 +294,8 @@ public class UserService {
             user.setNickName(request.getNickname());
         }
 
-        UserConverter.setupUserPurposes(user, request.getPurposes());
-        UserConverter.setupUserInterests(user, request.getInterests());
+        replacePurposes(user, request.getPurposes());
+        replaceInterests(user, request.getInterests());
 
         userRepository.save(user);
     }
@@ -360,6 +359,38 @@ public class UserService {
         long ttlMs = jwtTokenProvider.getRemainingExpiryMs(accessToken);
         if (ttlMs > 0) {
             accessTokenBlackListManager.addToBlacklist(accessToken, ttlMs);
+        }
+    }
+
+
+    // purpose, interest 지우고 새 입력값으로 다시 세팅함
+    private void replacePurposes(Users user, List<String> purposeNames) {
+        if (purposeNames == null) return;
+
+        user.getPurposes().clear();
+
+        for (String name : purposeNames) {
+            try {
+                Purpose purpose = Purpose.valueOf(name);
+                user.getPurposes().add(new Purposes(purpose.name(), user));
+            } catch (IllegalArgumentException | NullPointerException e) {
+                throw new GeneralException(UserErrorStatus._INVALID_PURPOSE);
+            }
+        }
+    }
+
+    private void replaceInterests(Users user, List<String> interestNames) {
+        if (interestNames == null) return;
+
+        user.getInterests().clear();
+
+        for (String name : interestNames) {
+            try {
+                Interest interest = Interest.valueOf(name);
+                user.getInterests().add(new Interests(interest.name(), user));
+            } catch (IllegalArgumentException | NullPointerException e) {
+                throw new GeneralException(UserErrorStatus._INVALID_INTEREST);
+            }
         }
     }
 }

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -43,16 +43,24 @@ public interface UserApi {
                     사용자의 프로필 정보를 변경합니다.
                     - 닉네임 변경 시 중복 여부를 체크합니다.
                     - 직업(Job ID), 관심사 리스트, 사용 목적 리스트를 전체 업데이트합니다.
+                    - 기존의 purpose, interest 지우고 새 입력값으로 다시 세팅합니다.
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
-    @ApiErrorCode(errorStatus = {ErrorStatus._BAD_REQUEST}) // 잘못된 Job ID 등
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND, UserErrorStatus._DUPLICATE_NICKNAME})
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(errorStatus = {ErrorStatus._BAD_REQUEST})
+    @ApiErrorCode(userErrorStatus = {
+            UserErrorStatus._USER_NOT_FOUND,
+            UserErrorStatus._DUPLICATE_NICKNAME,
+            UserErrorStatus._INVALID_INTEREST,
+            UserErrorStatus._INVALID_PURPOSE
+    })
     @PatchMapping("/profile")
     ApiResponse<Object> updateUserProfile(
             @CurrentUser CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.UpdateProfileDTO updateDTO);
 
+    // 소프트 회원탈퇴
     @Operation(
             summary = "회원 탈퇴 (비활성화)",
             description = """
@@ -62,6 +70,7 @@ public interface UserApi {
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @PostMapping("/inactive")
     ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(
@@ -78,8 +87,11 @@ public interface UserApi {
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
-    @ApiErrorCode(errorStatus = {ErrorStatus._ALREADY_ACTIVE_USER, ErrorStatus._BAD_REQUEST})
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._DUPLICATE_NICKNAME})
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(errorStatus = {
+            ErrorStatus._ALREADY_ACTIVE_USER,
+            ErrorStatus._BAD_REQUEST
+    })
     @PatchMapping("/social/complete")
     ApiResponse<UserResponseDTO.JoinResultDTO> completeSocialProfile(
             @RequestBody @Valid UserRequestDTO.SocialCompleteDTO request,
@@ -91,7 +103,11 @@ public interface UserApi {
     )
     // 첫 번째 PR: Common200 대신 SuccessStatus 또는 도메인별 성공코드 사용 규격 적용
     @ApiSuccessCode(com.umc.linkyou.apiPayload.code.status.SuccessStatus._OK)
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND, UserErrorStatus.INVALID_TERMS_TYPE})
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(userErrorStatus = {
+            UserErrorStatus._USER_NOT_FOUND,
+            UserErrorStatus.INVALID_TERMS_TYPE
+    })
     @PatchMapping("/terms/agree") // 두 번째 PR: POST에서 PATCH로 변경 및 경로 일치
     ApiResponse<UserResponseDTO.TermsStatusDTO> updateTermsAgree(
             @CurrentUser CustomUserDetails userDetails,
@@ -103,6 +119,7 @@ public interface UserApi {
             description = "사용자가 현재 어떤 약관에 동의했는지 전체 목록과 상태를 조회합니다."
     )
     @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @GetMapping("/terms/status")
     ApiResponse<UserResponseDTO.TermsStatusDTO> getTermsStatus(

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -88,6 +88,13 @@ public interface UserApi {
     )
     @ApiSuccessCode(SuccessStatus._OK)
     @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(userErrorStatus = {
+            UserErrorStatus._USER_NOT_FOUND,
+            UserErrorStatus._DUPLICATE_NICKNAME,
+            UserErrorStatus._INVALID_GENDER,
+            UserErrorStatus._INVALID_PURPOSE,
+            UserErrorStatus._INVALID_INTEREST
+            })
     @ApiErrorCode(errorStatus = {
             ErrorStatus._ALREADY_ACTIVE_USER,
             ErrorStatus._BAD_REQUEST

--- a/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.service.users;
 
+import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.properties.JwtProperties;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
@@ -38,8 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,21 +54,12 @@ class UserServiceImplTest {
 
     @Mock private UserRepository userRepository;
     @Mock private PasswordEncoder passwordEncoder;
-    @Mock private UserQueryRepository userQueryRepository;
-    @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private JobRepository jobRepository;
-    @Mock private InterestRepository interestRepository;
-    @Mock private PurposeRepository purposeRepository;
-    @Mock private FolderRepository folderRepository;
     @Mock private CategoryRepository categoryRepository;
-    @Mock private UsersFolderRepository usersFolderRepository;
     @Mock private UsersCategoryColorRepository usersCategoryColorRepository;
-    @Mock private RefreshTokenManager refreshTokenManager;
     @Mock private TokenIssueService tokenIssueService;
-    @Mock private AccessTokenBlackListManager accessTokenBlackListManager;
     @Mock private UserStatusValidator userStatusValidator;
     @Mock private AuthAccountRepository authAccountRepository;
-    @Mock private JwtProperties jwtProperties;
     @Mock private AlarmSettingRepository alarmSettingRepository;
     @Mock private TermsAgreementService termsAgreementService;
 
@@ -226,6 +217,116 @@ class UserServiceImplTest {
                         eq(request.deviceId()),
                         eq(request.deviceType())
                 );
+            }
+        }
+    }
+    @Nested
+    @DisplayName("마이페이지 수정 (updateUserProfile)")
+    class UpdateUserProfile {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("성공 - 닉네임, 직업, purpose, interest가 정상 수정된다")
+            void update_user_profile_success() {
+                // given
+                Users user = Users.builder()
+                        .id(1L)
+                        .nickName("기존닉네임")
+                        .job(Job.builder().id(1L).build())
+                        .purposes(new ArrayList<>())
+                        .interests(new ArrayList<>())
+                        .build();
+
+                UserRequestDTO.UpdateProfileDTO request = new UserRequestDTO.UpdateProfileDTO(
+                        "변경닉네임",
+                        2L,
+                        new ArrayList<>(java.util.List.of("CAREER", "STUDY")),
+                        new ArrayList<>(java.util.List.of("IT", "DESIGN"))
+                );
+
+                Job newJob = Job.builder().id(2L).build();
+
+                when(userRepository.findById(eq(1L))).thenReturn(Optional.of(user));
+                when(jobRepository.findById(eq(2L))).thenReturn(Optional.of(newJob));
+                when(userRepository.findByNickName(eq("변경닉네임"))).thenReturn(Optional.empty());
+                when(userRepository.save(any(Users.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+                // when
+                userService.updateUserProfile(1L, request);
+
+                // then
+                assertEquals("변경닉네임", user.getNickName());
+                assertEquals(newJob, user.getJob());
+                assertEquals(2, user.getPurposes().size());
+                assertEquals(2, user.getInterests().size());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Fail {
+
+            @Test
+            @DisplayName("실패 - 존재하지 않는 purpose 값이면 예외가 발생한다")
+            void update_user_profile_invalid_purpose_fail() {
+                // given
+                Users user = Users.builder()
+                        .id(1L)
+                        .nickName("기존닉네임")
+                        .job(Job.builder().id(1L).build())
+                        .purposes(new ArrayList<>())
+                        .interests(new ArrayList<>())
+                        .build();
+
+                UserRequestDTO.UpdateProfileDTO request = new UserRequestDTO.UpdateProfileDTO(
+                        "변경닉네임",
+                        2L,
+                        new ArrayList<>(java.util.List.of("INVALID_PURPOSE")),
+                        new ArrayList<>(java.util.List.of("IT"))
+                );
+
+                Job newJob = Job.builder().id(2L).build();
+
+                when(userRepository.findById(eq(1L))).thenReturn(Optional.of(user));
+                when(jobRepository.findById(eq(2L))).thenReturn(Optional.of(newJob));
+                when(userRepository.findByNickName(eq("변경닉네임"))).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(GeneralException.class,
+                        () -> userService.updateUserProfile(1L, request));
+            }
+
+            @Test
+            @DisplayName("실패 - 존재하지 않는 interest 값이면 예외가 발생한다")
+            void update_user_profile_invalid_interest_fail() {
+                // given
+                Users user = Users.builder()
+                        .id(1L)
+                        .nickName("기존닉네임")
+                        .job(Job.builder().id(1L).build())
+                        .purposes(new ArrayList<>())
+                        .interests(new ArrayList<>())
+                        .build();
+
+                UserRequestDTO.UpdateProfileDTO request = new UserRequestDTO.UpdateProfileDTO(
+                        "변경닉네임",
+                        2L,
+                        new ArrayList<>(java.util.List.of("CAREER")),
+                        new ArrayList<>(java.util.List.of("INVALID_INTEREST"))
+                );
+
+                Job newJob = Job.builder().id(2L).build();
+
+                when(userRepository.findById(eq(1L))).thenReturn(Optional.of(user));
+                when(jobRepository.findById(eq(2L))).thenReturn(Optional.of(newJob));
+                when(userRepository.findByNickName(eq("변경닉네임"))).thenReturn(Optional.empty());
+
+                // when & then
+                assertThrows(GeneralException.class,
+                        () -> userService.updateUserProfile(1L, request));
             }
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
> #304

---

## 📌 작업 내용
> 회원가입/소셜 프로필 완성/마이페이지 수정 시 purpose, interest 값에 대한 enum 검증 로직을 추가하고, 잘못된 값이 들어올 경우 예외를 반환하도록 개선했습니다. 
> 또한 Purpose, Interest 엔티티의 기본키를 AUTO(SEQUENCE자동)에서 IDENTITY로 변경하였습니다.

### 1️⃣ Non-Functional Requirement
- userConverter에서 검증하던 ENUM검증단계를 UserService로 옮겼습니다.
- Swagger 명세에 메서드별 에러 응답을 추가하여 API 문서를 보강했습니다.

### 2️⃣ Functional Requirement
- 회원가입, 소셜 프로필 완성, 마이페이지 수정 시 purpose 및 interest enum 검증을 추가했습니다.
- 잘못된 purpose / interest 값이 입력되면 INVALID_PURPOSE, INVALID_INTEREST 에러가 발생하도록 수정했습니다.
- Purpose, Interest 엔티티의 기본키를 AUTO(SEQUENCE자동)에서 IDENTITY로 변경하였습니다.
- 마이페이지 수정 테스트를 추가하여 성공/실패 케이스를 검증했습니다.

---

## 🧪 테스트 결과
<img width="259" height="312" alt="image" src="https://github.com/user-attachments/assets/21d61aa5-827e-4c89-9325-6d1496deb5e0" />

---

## 📎 pr처리 후 원격 db 적용
1) 원격 접속해서 db 구조바꾸기
user_id 가 외래키라면 Users 테이블과는 상관없고, purposes 참조하는 다른 테이블 없어 auto_increment가 1부터 시작하도록 변경할 것입니다.

```
-- purposes
SELECT * FROM purposes;
-- purposes 테이블 개수 확인(COUNT(*) 결과 + 1 을 직접 숫자로 입력)
SELECT COUNT(*) AS purposes_count FROM purposes;

--실제 DDL변경
ALTER TABLE purposes MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;
ALTER TABLE purposes AUTO_INCREMENT = 17;

-- interests
SELECT * FROM interests;
-- interests 테이블 개수 확인(COUNT(*) 결과 + 1 을 직접 숫자로 입력)
SELECT COUNT(*) AS interests_count FROM interests;

--실제 DDL변경
ALTER TABLE interests MODIFY COLUMN id BIGINT NOT NULL AUTO_INCREMENT;
ALTER TABLE interests AUTO_INCREMENT = 5;  -- 현재 AUTO_INCREMENT=5였으니 실제 row 수 + 1로 확인해서 수정

-- seq 테이블 삭제
DROP TABLE IF EXISTS purposes_seq;
DROP TABLE IF EXISTS interests_seq;

-- 확인
SHOW CREATE TABLE purposes;
SHOW CREATE TABLE interests;
-- 테스트 후 확인
SELECT * FROM purposes ORDER BY id;
SELECT * FROM interests ORDER BY id;
```

2) git action 돌리기

3) 회원가입해서 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 목적 및 관심사 처리 오류에 대한 검증 및 오류 응답(새 오류 코드 포함) 개선

* **Documentation**
  * 주요 사용자 관련 API의 오류 응답 및 인증 오류 정보 업데이트
  * 프로필 수정 시 기존 목적/관심사 초기화 후 재설정 동작 명시

* **Tests**
  * 프로필 업데이트 정상/오류 시나리오 검증 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->