### PR TITLE
feat: 로그인 사용자 닉네임 조회 API 추가

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserSuccessStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/user/UserSuccessStatus.java
@@ -16,7 +16,8 @@ public enum UserSuccessStatus implements BaseSuccessCode {
     SOCIAL_PROFILE_COMPLETED(HttpStatus.OK, "USERS2004", "소셜 프로필 설정이 완료되었습니다."),
     TERMS_BATCH_OK(HttpStatus.OK, "USERS2005", "약관 일괄 동의가 완료되었습니다."),
     TERMS_UPDATE_OK(HttpStatus.OK, "USERS2006", "약관 동의 상태가 수정되었습니다."),
-    TERMS_STATUS_OK(HttpStatus.OK, "USERS2007", "약관 동의 상태 조회에 성공했습니다.");
+    TERMS_STATUS_OK(HttpStatus.OK, "USERS2007", "약관 동의 상태 조회에 성공했습니다."),
+    USER_NICKNAME_OK(HttpStatus.OK, "USERS2008", "닉네임 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -265,6 +265,14 @@ public class UserService {
         validateNickNameNotDuplicate(nickname);
     }
 
+    // 닉네임 조회
+    @Transactional(readOnly = true)
+    public UserResponseDTO.NicknameDTO getNickname(Long userId) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(UserErrorStatus._USER_NOT_FOUND));
+        return new UserResponseDTO.NicknameDTO(user.getNickName());
+    }
+
     // 마이페이지 조회
     @Transactional
     public UserResponseDTO.UserProfileSummaryDto userInfo(Long userId, String loginProvider) {

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -120,6 +120,18 @@ public interface UserApi {
             @CurrentUser CustomUserDetails userDetails,
             @RequestBody @Valid UserRequestDTO.TermsAgreeDTO request); // 두 번째 PR: Map 기반 DTO 사용
 
+    // 닉네임 조회
+    @Operation(
+            summary = "닉네임 조회",
+            description = "로그인한 사용자의 닉네임을 조회합니다."
+    )
+    @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(authErrorStatus = {AuthErrorStatus.UNAUTHORIZED})
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @GetMapping("/nickname")
+    ApiResponse<UserResponseDTO.NicknameDTO> getNickname(
+            @CurrentUser CustomUserDetails userDetails);
+
     // 약관 상태 조회
     @Operation(
             summary = "약관 상태 조회",

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -62,6 +62,11 @@ public class UserController implements UserApi {
     }
 
     @Override
+    public ApiResponse<UserResponseDTO.NicknameDTO> getNickname(@CurrentUser CustomUserDetails userDetails) {
+        return ApiResponse.onSuccess(UserSuccessStatus.USER_NICKNAME_OK, userService.getNickname(userDetails.getUserId()));
+    }
+
+    @Override
     public ApiResponse<UserResponseDTO.TermsStatusDTO> getTermsStatus(@CurrentUser CustomUserDetails userDetails) {
         return ApiResponse.onSuccess(termsAgreementService.getTermsStatus(userDetails));
     }

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -106,6 +106,13 @@ public class UserResponseDTO {
     }
 
 
+    @Schema(description = "닉네임 조회 응답")
+    public record NicknameDTO(
+            @Schema(description = "사용자 닉네임", example = "링큐유저")
+            String nickname
+    ) {
+    }
+
     @Getter @Setter
     @Builder
     @NoArgsConstructor @AllArgsConstructor

--- a/src/test/java/com/umc/linkyou/integration/TermsIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/TermsIntegrationTest.java
@@ -68,8 +68,8 @@ class TermsIntegrationTest {
                     "pass1234",
                     1,
                     job.getId(),
-                    List.of("GROWTH"),
-                    List.of("TECH"),
+                    List.of("CAREER"),
+                    List.of("IT"),
                     Map.of(TermsType.TERMS_OF_USE, true)
             );
 


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
없음

### 2️⃣ Functional Requirement
- 로그인 사용자 닉네임 조회 API 추가했습니다. 

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 사용자는 닉네임을 조회할 수 있는 신규 API 엔드포인트를 추가했습니다. 성공 시 200 상태 코드와 닉네임 정보가 반환됩니다.
  * 닉네임 조회 응답용 응답 DTO를 추가했습니다.
* **테스트**
  * 약관 동의 요청에 포함되는 약관 타입 목록을 `GROWTH`, `TECH`에서 `CAREER`, `IT`로 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->