### PR TITLE
Refactor/#346 folder errorcode

### DIFF
--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -199,25 +199,26 @@ LinkU API는 아래 공통 응답 포맷을 사용한다.
 
 | 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
 | --- | --- | --- | --- |
-| `FOLDER404` | `_FOLDER_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 폴더를 찾을 수 없습니다. |
-| `FOLDER_PARENT404` | `_FOLDER_PARENT_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 부모 폴더가 없습니다. |
-| `FOLDER_CATEGORY404` | `_FOLDER_CATEGORY_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 카테고리가 없습니다. |
-| `FOLDER_CREATE403` | `_FOLDER_CREATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더를 생성할 권한이 없습니다. |
-| `FOLDER_UPDATE403` | `_FOLDER_UPDATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 수정 권한이 없습니다. |
-| `FOLDER_DELETE403` | `_FOLDER_DELETE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 삭제 권한이 없습니다. |
-| `FOLDER_ACCESS403` | `_FOLDER_ACCESS_FORBIDDEN` | `403 (FORBIDDEN)` | 해당 폴더에 접근 권한이 없습니다. |
-| `FOLDER_NAME409` | `_FOLDER_NAME_CONFLICT` | `409 (CONFLICT)` | 카테고리명과 동일한 폴더명은 사용할 수 없습니다. |
-| `FOLDER_CURSOR400` | `_FOLDER_INVALID_CURSOR` | `400 (BAD_REQUEST)` | 유효하지 않은 커서 값입니다. |
-| `FOLDER_OWNER500` | `_FOLDER_OWNER_NOT_FOUND` | `500 (INTERNAL_SERVER_ERROR)` | 폴더의 소유자 정보를 찾을 수 없습니다. |
-| `FOLDER_PERMISSION404` | `_FOLDER_PERMISSION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 폴더 권한 정보를 찾을 수 없습니다. |
-| `FOLDER_TOKEN404` | `INVITATION_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 토큰을 찾을 수 없습니다. |
-| `FOLDER_TOKEN_INVALID404` | `INVITATION_EXPIRED` | `404 (NOT_FOUND)` | 공유 폴더 토큰이 유효하지 않습니다. |
-| `FOLDER_LINK_INVALID404` | `INVITATION_LINK_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 링크가 유효하지 않습니다. |
-| `FOLDER_OWNER_403` | `_FOLDER_PERMISSION_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 수정 권한을 가지고 있지 않습니다. |
-| `FOLDER_OWNER_403` | `_FOLDER_OWNER_UPDATE_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 주인의 권한은 수정할 수 없습니다. |
-| `FOLDER_CREATOR403` | `INVITATION_CREATOR_CANNOT_ACCEPT` | `403 (FORBIDDEN)` | 초대 생성자는 자신의 링크로 참여할 수 없습니다. |
-| `PERMISSION400` | `_INVALID_PERMISSION_TYPE` | `400 (BAD_REQUEST)` | 유효하지 않은 권한 타입입니다. |
+| `FOLDER4001` | `_FOLDER_INVALID_CURSOR` | `400 (BAD_REQUEST)` | 유효하지 않은 커서 값입니다. |
+| `FOLDER4031` | `_FOLDER_CREATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더를 생성할 권한이 없습니다. |
+| `FOLDER4032` | `_FOLDER_UPDATE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 수정 권한이 없습니다. |
+| `FOLDER4033` | `_FOLDER_DELETE_FORBIDDEN` | `403 (FORBIDDEN)` | 해당하는 폴더의 삭제 권한이 없습니다. |
+| `FOLDER4034` | `_FOLDER_ACCESS_FORBIDDEN` | `403 (FORBIDDEN)` | 해당 폴더에 접근 권한이 없습니다. |
+| `FOLDER4041` | `_FOLDER_NOT_FOUND` | `404 (NOT_FOUND)` | 해당하는 폴더를 찾을 수 없습니다. |
+| `FOLDER4042` | `_FOLDER_PARENT_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 부모 폴더가 없습니다. |
+| `FOLDER4043` | `_FOLDER_CATEGORY_NOT_FOUND` | `404 (NOT_FOUND)` | 폴더의 카테고리가 없습니다. |
+| `FOLDER4091` | `_FOLDER_CREATE_DUPLICATE` | `409 (CONFLICT)` | 중복된 폴더명입니다. |
+| `FOLDER4092` | `_FOLDER_NAME_CONFLICT` | `409 (CONFLICT)` | 카테고리명과 동일한 폴더명은 사용할 수 없습니다. |
+| `FOLDER5001` | `_FOLDER_OWNER_NOT_FOUND` | `500 (INTERNAL_SERVER_ERROR)` | 폴더의 소유자 정보를 찾을 수 없습니다. |
 | `FOLDER_BOOKMARK404` | `_FOLDER_BOOKMARK_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 북마크 정보가 존재하지 않습니다. |
+| `SHAREFOLDER4001` | `_INVALID_PERMISSION_TYPE` | `400 (BAD_REQUEST)` | 유효하지 않은 권한 타입입니다. |
+| `SHAREFOLDER4031` | `_FOLDER_PERMISSION_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 수정 권한을 가지고 있지 않습니다. |
+| `SHAREFOLDER4032` | `_FOLDER_OWNER_UPDATE_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 주인의 권한은 수정할 수 없습니다. |
+| `SHAREFOLDER4033` | `INVITATION_CREATOR_CANNOT_ACCEPT` | `403 (FORBIDDEN)` | 초대 생성자는 자신의 링크로 참여할 수 없습니다. |
+| `SHAREFOLDER4041` | `_FOLDER_PERMISSION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 폴더 권한 정보를 찾을 수 없습니다. |
+| `SHAREFOLDER4042` | `INVITATION_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 토큰을 찾을 수 없습니다. |
+| `SHAREFOLDER4043` | `INVITATION_EXPIRED` | `404 (NOT_FOUND)` | 공유 폴더 토큰이 유효하지 않습니다. |
+| `SHAREFOLDER4044` | `INVITATION_LINK_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 링크가 유효하지 않습니다. |
 
 ## 11. AI Article / Gemini 에러
 

--- a/docs/api-response-format.md
+++ b/docs/api-response-format.md
@@ -214,13 +214,18 @@ LinkU API는 아래 공통 응답 포맷을 사용한다.
 | `SHAREFOLDER4001` | `_INVALID_PERMISSION_TYPE` | `400 (BAD_REQUEST)` | 유효하지 않은 권한 타입입니다. |
 | `SHAREFOLDER4031` | `_FOLDER_PERMISSION_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 수정 권한을 가지고 있지 않습니다. |
 | `SHAREFOLDER4032` | `_FOLDER_OWNER_UPDATE_NOT_ALLOWED` | `403 (FORBIDDEN)` | 폴더 주인의 권한은 수정할 수 없습니다. |
-| `SHAREFOLDER4033` | `INVITATION_CREATOR_CANNOT_ACCEPT` | `403 (FORBIDDEN)` | 초대 생성자는 자신의 링크로 참여할 수 없습니다. |
 | `SHAREFOLDER4041` | `_FOLDER_PERMISSION_NOT_FOUND` | `404 (NOT_FOUND)` | 해당 유저의 폴더 권한 정보를 찾을 수 없습니다. |
-| `SHAREFOLDER4042` | `INVITATION_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 토큰을 찾을 수 없습니다. |
-| `SHAREFOLDER4043` | `INVITATION_EXPIRED` | `404 (NOT_FOUND)` | 공유 폴더 토큰이 유효하지 않습니다. |
-| `SHAREFOLDER4044` | `INVITATION_LINK_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 링크가 유효하지 않습니다. |
 
-## 11. AI Article / Gemini 에러
+## 11. 초대 관련 에러
+
+| 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
+| --- | --- | --- | --- |
+| `INVITATION4031` | `INVITATION_CREATOR_CANNOT_ACCEPT` | `403 (FORBIDDEN)` | 초대 생성자는 자신의 링크로 참여할 수 없습니다. |
+| `INVITATION4041` | `INVITATION_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 토큰을 찾을 수 없습니다. |
+| `INVITATION4042` | `INVITATION_EXPIRED` | `404 (NOT_FOUND)` | 공유 폴더 토큰이 유효하지 않습니다. |
+| `INVITATION4043` | `INVITATION_LINK_NOT_FOUND` | `404 (NOT_FOUND)` | 공유 폴더 링크가 유효하지 않습니다. |
+
+## 12. AI Article / Gemini 에러
 
 | 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
 | --- | --- | --- | --- |
@@ -239,7 +244,7 @@ LinkU API는 아래 공통 응답 포맷을 사용한다.
 | `GEMINI5022` | `GEMINI_PARSE_ERROR` | `502 (BAD_GATEWAY)` | AI 응답 JSON 파싱에 실패했습니다. |
 | `GEMINI5041` | `GEMINI_TIMEOUT` | `504 (GATEWAY_TIMEOUT)` | Gemini 응답 시간이 초과되었습니다. |
 
-## 12. 알림 관련 에러
+## 13. 알림 관련 에러
 
 | 예외 코드 | 예외 이름(서버에서 사용) | Http 코드 | 메시지 |
 | --- | --- | --- | --- |
@@ -248,7 +253,7 @@ LinkU API는 아래 공통 응답 포맷을 사용한다.
 | `ALARM5001` | `ALARM_TOPIC_SUBSCRIPTION_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 알림 주제 구독 상태 변경에 실패했습니다. |
 | `ALARM5002` | `ALARM_SEND_FAILED` | `500 (INTERNAL_SERVER_ERROR)` | 알림 전송에 실패했습니다. |
 
-## 13. 구현 기준 메모
+## 14. 구현 기준 메모
 
 - 성공 응답 생성: `ApiResponse.onSuccess(...)`
 - 실패 응답 생성: `ApiResponse.onFailure(...)`

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -51,33 +51,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _RECOMMEND_LINKU_NO_RECOMMENDATION(HttpStatus.BAD_REQUEST, "LINKU4004", "추천할 만한 링크가 없습니다."),
     _RECOMMEND_LINKU_NEW_USER(HttpStatus.BAD_REQUEST, "LINKU4005", "신규 사용자는 추천 기능을 이용할 수 없습니다."),
 
-    // 폴더 관련 오류
-    _FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER404", "해당하는 폴더를 찾을 수 없습니다."),
-    _FOLDER_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_PARENT404", "폴더의 부모 폴더가 없습니다."),
-    _FOLDER_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_CATEGORY404", "폴더의 카테고리가 없습니다."),
-    _FOLDER_CREATE_DUPLICATE(HttpStatus.CONFLICT, "FOLDER_CATEGORY404", "중복된 폴더명입니다."),
-
-    _FOLDER_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_CREATE403", "해당하는 폴더를 생성할 권한이 없습니다."),
-    _FOLDER_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_UPDATE403", "해당하는 폴더의 수정 권한이 없습니다."),
-    _FOLDER_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_DELETE403", "해당하는 폴더의 삭제 권한이 없습니다."),
-    _FOLDER_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER_ACCESS403", "해당 폴더에 접근 권한이 없습니다."),
-
-    _FOLDER_NAME_CONFLICT(HttpStatus.CONFLICT, "FOLDER_NAME409", "카테고리명과 동일한 폴더명은 사용할 수 없습니다."),
-    _FOLDER_INVALID_CURSOR(HttpStatus.BAD_REQUEST, "FOLDER_CURSOR400", "유효하지 않은 커서 값입니다."),
-    _FOLDER_OWNER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "FOLDER_OWNER500", "폴더의 소유자 정보를 찾을 수 없습니다."),
-
-    // 공유 폴더 관련 응답
-    _FOLDER_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_PERMISSION404", "해당 유저의 폴더 권한 정보를 찾을 수 없습니다."),
-    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_TOKEN404", "공유 폴더 토큰을 찾을 수 없습니다."),
-    INVITATION_EXPIRED(HttpStatus.NOT_FOUND, "FOLDER_TOKEN_INVALID404", "공유 폴더 토큰이 유효하지 않습니다."),
-    INVITATION_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_LINK_INVALID404", "공유 폴더 링크가 유효하지 않습니다."),
-
-    _FOLDER_PERMISSION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOLDER_OWNER_403", "폴더 수정 권한을 가지고 있지 않습니다."),
-    _FOLDER_OWNER_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "FOLDER_OWNER_403", "폴더 주인의 권한은 수정할 수 없습니다."),
-    INVITATION_CREATOR_CANNOT_ACCEPT(HttpStatus.FORBIDDEN, "FOLDER_CREATOR403", "초대 생성자는 자신의 링크로 참여할 수 없습니다."),
-
-    _INVALID_PERMISSION_TYPE(HttpStatus.BAD_REQUEST, "PERMISSION400", "유효하지 않은 권한 타입입니다."),
-
     // 북마크 관련 오류
     _FOLDER_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER_BOOKMARK404", "해당 유저의 북마크 정보가 존재하지 않습니다."),;
 

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/ErrorStatus.java
@@ -37,8 +37,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _SOCIAL_EXTERNAL_ID_REQUIRED(HttpStatus.BAD_REQUEST, "OAUTH4009", "소셜 계정 ID가 필요합니다."),
     _INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "OAUTH4010", "올바른 이메일 형식이 아닙니다."),
 
-    //카테고리(폴더종류) 관련 에러
-    _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4041", "해당하는 카테고리를 찾을 수 없습니다."),
     //감정 관련 에러
     _EMOTION_NOT_FOUND(HttpStatus.NOT_FOUND, "EMOTION4041", "해당하는 감정을 찾을 수 없습니다."),
     //도메인 관련 에러

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/category/CategoryErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/category/CategoryErrorStatus.java
@@ -1,0 +1,38 @@
+package com.umc.linkyou.apiPayload.code.status.category;
+
+import com.umc.linkyou.apiPayload.code.BaseErrorCode;
+import com.umc.linkyou.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CategoryErrorStatus implements BaseErrorCode {
+
+    // 404 Not Found
+    _CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4041", "해당하는 카테고리를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/FolderErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/FolderErrorStatus.java
@@ -1,0 +1,56 @@
+package com.umc.linkyou.apiPayload.code.status.folder;
+
+import com.umc.linkyou.apiPayload.code.BaseErrorCode;
+import com.umc.linkyou.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FolderErrorStatus implements BaseErrorCode {
+
+    // 400 Bad Request
+    _FOLDER_INVALID_CURSOR(HttpStatus.BAD_REQUEST, "FOLDER4001", "유효하지 않은 커서 값입니다."),
+
+    // 403 Forbidden
+    _FOLDER_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER4031", "해당하는 폴더를 생성할 권한이 없습니다."),
+    _FOLDER_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER4032", "해당하는 폴더의 수정 권한이 없습니다."),
+    _FOLDER_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER4033", "해당하는 폴더의 삭제 권한이 없습니다."),
+    _FOLDER_ACCESS_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER4034", "해당 폴더에 접근 권한이 없습니다."),
+
+    // 404 Not Found
+    _FOLDER_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4041", "해당하는 폴더를 찾을 수 없습니다."),
+    _FOLDER_PARENT_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4042", "폴더의 부모 폴더가 없습니다."),
+    _FOLDER_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLDER4043", "폴더의 카테고리가 없습니다."),
+
+    // 409 Conflict
+    _FOLDER_CREATE_DUPLICATE(HttpStatus.CONFLICT, "FOLDER4091", "중복된 폴더명입니다."),
+    _FOLDER_NAME_CONFLICT(HttpStatus.CONFLICT, "FOLDER4092", "카테고리명과 동일한 폴더명은 사용할 수 없습니다."),
+
+    // 500 Internal Server Error
+    _FOLDER_OWNER_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "FOLDER5001", "폴더의 소유자 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/InvitationErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/InvitationErrorStatus.java
@@ -8,17 +8,15 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor
-public enum ShareFolderErrorStatus implements BaseErrorCode {
-
-    // 400 Bad Request
-    _INVALID_PERMISSION_TYPE(HttpStatus.BAD_REQUEST, "SHAREFOLDER4001", "유효하지 않은 권한 타입입니다."),
+public enum InvitationErrorStatus implements BaseErrorCode {
 
     // 403 Forbidden
-    _FOLDER_PERMISSION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "SHAREFOLDER4031", "폴더 수정 권한을 가지고 있지 않습니다."),
-    _FOLDER_OWNER_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "SHAREFOLDER4032", "폴더 주인의 권한은 수정할 수 없습니다."),
+    INVITATION_CREATOR_CANNOT_ACCEPT(HttpStatus.FORBIDDEN, "INVITATION4031", "초대 생성자는 자신의 링크로 참여할 수 없습니다."),
 
     // 404 Not Found
-    _FOLDER_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SHAREFOLDER4041", "해당 유저의 폴더 권한 정보를 찾을 수 없습니다.");
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITATION4041", "공유 폴더 토큰을 찾을 수 없습니다."),
+    INVITATION_EXPIRED(HttpStatus.NOT_FOUND, "INVITATION4042", "공유 폴더 토큰이 유효하지 않습니다."),
+    INVITATION_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "INVITATION4043", "공유 폴더 링크가 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/ShareFolderErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/ShareFolderErrorStatus.java
@@ -1,0 +1,49 @@
+package com.umc.linkyou.apiPayload.code.status.folder;
+
+import com.umc.linkyou.apiPayload.code.BaseErrorCode;
+import com.umc.linkyou.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ShareFolderErrorStatus implements BaseErrorCode {
+
+    // 400 Bad Request
+    _INVALID_PERMISSION_TYPE(HttpStatus.BAD_REQUEST, "SHAREFOLDER4001", "유효하지 않은 권한 타입입니다."),
+
+    // 403 Forbidden
+    _FOLDER_PERMISSION_NOT_ALLOWED(HttpStatus.FORBIDDEN, "SHAREFOLDER4031", "폴더 수정 권한을 가지고 있지 않습니다."),
+    _FOLDER_OWNER_UPDATE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "SHAREFOLDER4032", "폴더 주인의 권한은 수정할 수 없습니다."),
+    INVITATION_CREATOR_CANNOT_ACCEPT(HttpStatus.FORBIDDEN, "SHAREFOLDER4033", "초대 생성자는 자신의 링크로 참여할 수 없습니다."),
+
+    // 404 Not Found
+    _FOLDER_PERMISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SHAREFOLDER4041", "해당 유저의 폴더 권한 정보를 찾을 수 없습니다."),
+    INVITATION_NOT_FOUND(HttpStatus.NOT_FOUND, "SHAREFOLDER4042", "공유 폴더 토큰을 찾을 수 없습니다."),
+    INVITATION_EXPIRED(HttpStatus.NOT_FOUND, "SHAREFOLDER4043", "공유 폴더 토큰이 유효하지 않습니다."),
+    INVITATION_LINK_NOT_FOUND(HttpStatus.NOT_FOUND, "SHAREFOLDER4044", "공유 폴더 링크가 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -13,6 +13,7 @@ import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.gemini.GeminiErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
@@ -215,6 +216,9 @@ public class SwaggerConfig {
             for (ShareFolderErrorStatus status : annotation.shareFolderErrorStatus()) {
                 addErrorCodeExample(responses, status);
             }
+            for (InvitationErrorStatus status : annotation.invitationErrorStatus()) {
+                addErrorCodeExample(responses, status);
+            }
         }
     }
 
@@ -236,6 +240,7 @@ public class SwaggerConfig {
                 CurationErrorStatus.class,
                 FolderErrorStatus.class,
                 ShareFolderErrorStatus.class,
+                InvitationErrorStatus.class,
                 GeminiErrorStatus.class,
                 LinkuErrorStatus.class,
                 CommonErrorStatus.class

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -12,6 +12,8 @@ import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.gemini.GeminiErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
@@ -207,6 +209,12 @@ public class SwaggerConfig {
             for (CurationErrorStatus status : annotation.curationErrorStatus()) {
                 addErrorCodeExample(responses, status);
             }
+            for (FolderErrorStatus status : annotation.folderErrorStatus()) {
+                addErrorCodeExample(responses, status);
+            }
+            for (ShareFolderErrorStatus status : annotation.shareFolderErrorStatus()) {
+                addErrorCodeExample(responses, status);
+            }
         }
     }
 
@@ -226,6 +234,8 @@ public class SwaggerConfig {
                 AlarmErrorStatus.class,
                 AiArticleErrorStatus.class,
                 CurationErrorStatus.class,
+                FolderErrorStatus.class,
+                ShareFolderErrorStatus.class,
                 GeminiErrorStatus.class,
                 LinkuErrorStatus.class,
                 CommonErrorStatus.class

--- a/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/linkyou/config/swagger/SwaggerConfig.java
@@ -11,6 +11,7 @@ import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthSuccessStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
@@ -219,6 +220,9 @@ public class SwaggerConfig {
             for (InvitationErrorStatus status : annotation.invitationErrorStatus()) {
                 addErrorCodeExample(responses, status);
             }
+            for (CategoryErrorStatus status : annotation.categoryErrorStatus()) {
+                addErrorCodeExample(responses, status);
+            }
         }
     }
 
@@ -241,6 +245,7 @@ public class SwaggerConfig {
                 FolderErrorStatus.class,
                 ShareFolderErrorStatus.class,
                 InvitationErrorStatus.class,
+                CategoryErrorStatus.class,
                 GeminiErrorStatus.class,
                 LinkuErrorStatus.class,
                 CommonErrorStatus.class

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuCreateService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuCreateService.java
@@ -11,6 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.awss3.AwsS3Service;
 import com.umc.linkyou.converter.AiArticleConverter;
@@ -146,7 +147,7 @@ public class LinkuCreateService {
         return Optional.ofNullable(aiCategoryId)
                 .flatMap(categoryRepository::findById)
                 .or(() -> categoryRepository.findById(DEFAULT_CATEGORY_ID))
-                .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(CategoryErrorStatus._CATEGORY_NOT_FOUND));
     }
 
 

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.service.Linku;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
@@ -165,7 +166,7 @@ public class LinkuService {
         // 4. 카테고리 변경 (DTO에 categoryId가 있으면 Linku category 교체)
         if (dto.getCategoryId() != null) {
             Category category = categoryRepository.findById(dto.getCategoryId())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus._CATEGORY_NOT_FOUND));
+                    .orElseThrow(() -> new GeneralException(CategoryErrorStatus._CATEGORY_NOT_FOUND));
             linku.setCategory(category);
             linkuModified = true;
         }

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.service.Linku;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.LinkuConverter;
@@ -150,7 +151,7 @@ public class LinkuService {
         // 3. 폴더 변경(해당 링크를 다른 폴더로 이동)
         if (dto.getFolderId() != null) {
             Folder folder = folderRepository.findById(dto.getFolderId())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+                    .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
             // 현재 링크-폴더 매핑 중 최신 1개 가져와서 폴더만 새로 세팅 (폴더 이동)
             LinkuFolder linkuFolder = linkuFolderRepository
                     .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId())

--- a/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.service.folder;
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.FolderConverter;
@@ -47,24 +48,24 @@ public class FolderServiceImpl implements FolderService {
 
         // 부모 폴더 존재 확인
         if (parent == null) {
-            throw new GeneralException(ErrorStatus._FOLDER_PARENT_NOT_FOUND);
+            throw new GeneralException(FolderErrorStatus._FOLDER_PARENT_NOT_FOUND);
         }
 
         // 부모 폴더에 대한 생성 권한 확인 (소유자 또는 편집자만 가능)
         if (!usersFolderRepository.existsFolderOwnerOrWriter(userId, parentFolderId)) {
-            throw new GeneralException(ErrorStatus._FOLDER_CREATE_FORBIDDEN);
+            throw new GeneralException(FolderErrorStatus._FOLDER_CREATE_FORBIDDEN);
         }
 
         // 카테고리명과 동일한 이름 사용 방지
         if (categoryRepository.existsByCategoryName(req.getFolderName())) {
-            throw new GeneralException(ErrorStatus._FOLDER_NAME_CONFLICT);
+            throw new GeneralException(FolderErrorStatus._FOLDER_NAME_CONFLICT);
         }
 
         // 해당 부모 아래 중복 이름 체크
         boolean isDuplicate = folderRepository.existsByParentIdAndName(parentFolderId, req.getFolderName());
 
         if (isDuplicate) {
-            throw new GeneralException(ErrorStatus._FOLDER_CREATE_DUPLICATE);
+            throw new GeneralException(FolderErrorStatus._FOLDER_CREATE_DUPLICATE);
         }
 
         // 폴더 테이블에 저장
@@ -100,32 +101,32 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public FolderResponseDTO updateFolder(Long userId, Long folderId, FolderUpdateRequestDTO req) {
         // 폴더 조회
-        Folder folder = folderRepository.findById(folderId).orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+        Folder folder = folderRepository.findById(folderId).orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
 
         // 주인 여부 확인
         UsersFolder usersFolder = usersFolderRepository.findByUserIdAndFolderId(userId, folderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_UPDATE_FORBIDDEN));
+                .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN));
         if (usersFolder.getPermissionType() != PermissionType.OWNER) {
-            throw new GeneralException(ErrorStatus._FOLDER_UPDATE_FORBIDDEN);
+            throw new GeneralException(FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN);
         }
 
         if (req.getFolderName() != null)
         {
             // 부모 폴더 존재 확인
             if (folder.getParentFolder() == null) {
-                throw new GeneralException(ErrorStatus._FOLDER_PARENT_NOT_FOUND);
+                throw new GeneralException(FolderErrorStatus._FOLDER_PARENT_NOT_FOUND);
             }
 
             // 카테고리명과 동일한 이름 사용 방지
             if (categoryRepository.existsByCategoryName(req.getFolderName())) {
-                throw new GeneralException(ErrorStatus._FOLDER_NAME_CONFLICT);
+                throw new GeneralException(FolderErrorStatus._FOLDER_NAME_CONFLICT);
             }
 
             // 해당 부모 아래 중복 이름 체크
             boolean isDuplicate = folderRepository.existsByParentIdAndName(folder.getParentFolder().getFolderId(), req.getFolderName());
 
             if (isDuplicate) {
-                throw new GeneralException(ErrorStatus._FOLDER_CREATE_DUPLICATE);
+                throw new GeneralException(FolderErrorStatus._FOLDER_CREATE_DUPLICATE);
             }
 
             folder.setFolderName(req.getFolderName());
@@ -138,12 +139,12 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public void deleteFolder(Long userId, Long folderId) {
         // 폴더 조회
-        Folder folder = folderRepository.findById(folderId).orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+        Folder folder = folderRepository.findById(folderId).orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
 
         // 주인 여부 확인
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
         if (!isOwner) {
-            throw new GeneralException(ErrorStatus._FOLDER_DELETE_FORBIDDEN);
+            throw new GeneralException(FolderErrorStatus._FOLDER_DELETE_FORBIDDEN);
         }
 
         folderRepository.delete(folder);
@@ -265,13 +266,13 @@ public class FolderServiceImpl implements FolderService {
     public FolderLinkusResponseDTO getFolderLinkus(Long userId, Long folderId, int limit, String cursor, String sort) {
         // check folder exist
         Folder folder = folderRepository.findById(folderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
 
         // 접근 권한 확인 (소유자 또는 활성 공유 멤버)
         boolean hasAccess = usersFolderRepository.existsFolderOwner(userId, folderId)
                 || usersFolderRepository.existsActiveMember(userId, folderId);
         if (!hasAccess) {
-            throw new GeneralException(ErrorStatus._FOLDER_ACCESS_FORBIDDEN);
+            throw new GeneralException(FolderErrorStatus._FOLDER_ACCESS_FORBIDDEN);
         }
 
         // 정렬 기준: "updatedAt" → 최근 수정순, 그 외 → 가나다순
@@ -315,7 +316,7 @@ public class FolderServiceImpl implements FolderService {
             try {
                 cursorId = Long.parseLong(cursor);
             } catch (NumberFormatException e) {
-                throw new GeneralException(ErrorStatus._FOLDER_INVALID_CURSOR);
+                throw new GeneralException(FolderErrorStatus._FOLDER_INVALID_CURSOR);
             }
         }
 
@@ -361,7 +362,7 @@ public class FolderServiceImpl implements FolderService {
     // 유저의 카테고리에 해당하는 중분류 폴더 조회
     public Folder findFolder(Long userId, Category category) {
         return usersFolderRepository.findFolderByUserIdAndCategory(userId, category)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.umc.linkyou.service.folder.share;
 
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Users;
@@ -28,10 +28,10 @@ public class InvitationServiceImpl implements InvitationService {
     // 초대 정보 조회
     public InvitationInfoResponseDTO getInvitationInfo(String token) {
         FolderShareLink link = folderShareLinkRepository.findByToken(token)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.INVITATION_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_NOT_FOUND));
 
         if (!link.isValid()) {
-            throw new GeneralException(ErrorStatus.INVITATION_EXPIRED);
+            throw new GeneralException(ShareFolderErrorStatus.INVITATION_EXPIRED);
         }
 
         return InvitationInfoResponseDTO.builder()
@@ -45,10 +45,10 @@ public class InvitationServiceImpl implements InvitationService {
     public Long acceptInvitation(Long userId, String token) {
         // 토큰 유효성 검증
         FolderShareLink link = folderShareLinkRepository.findByToken(token)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.INVITATION_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_NOT_FOUND));
 
         if (!link.isValid()) {
-            throw new GeneralException(ErrorStatus.INVITATION_EXPIRED);
+            throw new GeneralException(ShareFolderErrorStatus.INVITATION_EXPIRED);
         }
 
         Folder folder = link.getFolder();
@@ -57,8 +57,7 @@ public class InvitationServiceImpl implements InvitationService {
 
         //Owner caanot accpet its own
         if (link.getCreator().getId().equals(userId)) {
-            throw new GeneralException(ErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT);
-            // 또는 기존: ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED
+            throw new GeneralException(ShareFolderErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT);
         }
         // 이미 참여 중인지 확인
         boolean isAlreadyMember = usersFolderRepository.existsActiveMember(userId, folder.getFolderId());

--- a/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
@@ -1,6 +1,6 @@
 package com.umc.linkyou.service.folder.share;
 
-import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Users;
@@ -28,10 +28,10 @@ public class InvitationServiceImpl implements InvitationService {
     // 초대 정보 조회
     public InvitationInfoResponseDTO getInvitationInfo(String token) {
         FolderShareLink link = folderShareLinkRepository.findByToken(token)
-                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(InvitationErrorStatus.INVITATION_NOT_FOUND));
 
         if (!link.isValid()) {
-            throw new GeneralException(ShareFolderErrorStatus.INVITATION_EXPIRED);
+            throw new GeneralException(InvitationErrorStatus.INVITATION_EXPIRED);
         }
 
         return InvitationInfoResponseDTO.builder()
@@ -45,10 +45,10 @@ public class InvitationServiceImpl implements InvitationService {
     public Long acceptInvitation(Long userId, String token) {
         // 토큰 유효성 검증
         FolderShareLink link = folderShareLinkRepository.findByToken(token)
-                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(InvitationErrorStatus.INVITATION_NOT_FOUND));
 
         if (!link.isValid()) {
-            throw new GeneralException(ShareFolderErrorStatus.INVITATION_EXPIRED);
+            throw new GeneralException(InvitationErrorStatus.INVITATION_EXPIRED);
         }
 
         Folder folder = link.getFolder();
@@ -57,7 +57,7 @@ public class InvitationServiceImpl implements InvitationService {
 
         //Owner caanot accpet its own
         if (link.getCreator().getId().equals(userId)) {
-            throw new GeneralException(ShareFolderErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT);
+            throw new GeneralException(InvitationErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT);
         }
         // 이미 참여 중인지 확인
         boolean isAlreadyMember = usersFolderRepository.existsActiveMember(userId, folder.getFolderId());

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.service.folder.share;
 
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.enums.PermissionType;
@@ -36,12 +37,12 @@ public class ShareFolderServiceImpl implements ShareFolderService {
     public String createInviteLink(Long userId, Long folderId) {
         // 폴더 존재 및 소유권 확인
         Folder folder = folderRepository.findById(folderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
 
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
 
         if (!isOwner) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
         // 이미 존재하는 링크 확인
@@ -86,11 +87,11 @@ public class ShareFolderServiceImpl implements ShareFolderService {
         // 폴더 주인 확인
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
         if (!isOwner) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
         FolderShareLink link = folderShareLinkRepository.findByFolder_FolderIdAndIsActiveTrue(folderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.INVITATION_LINK_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_LINK_NOT_FOUND));
 
         link.deactivate();
     }
@@ -100,7 +101,7 @@ public class ShareFolderServiceImpl implements ShareFolderService {
     public List<ViewerResponseDTO> getViewers(Long userId, Long folderId) {
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
         if (!isOwner) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
         List<UsersFolder> participants = usersFolderRepository.findAllParticipantsByFolderId(folderId);
@@ -120,25 +121,25 @@ public class ShareFolderServiceImpl implements ShareFolderService {
     public ShareFolderResponseDTO updateViewerPermission(Long userId, Long folderId, Long userFolderId, FolderPermissionRequestDTO request) {
         // 요청자가 폴더 소유자인지 확인
         if (!usersFolderRepository.existsFolderOwner(userId, folderId)) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
-        UsersFolder usersFolder = usersFolderRepository.findById(userFolderId).orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_FOUND));
+        UsersFolder usersFolder = usersFolderRepository.findById(userFolderId).orElseThrow(() -> new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_FOUND));
 
         if (!usersFolder.getFolder().getFolderId().equals(folderId)) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
         // 오너의 권한은 변경 불가
         if (usersFolder.getPermissionType() == PermissionType.OWNER) {
-            throw new GeneralException(ErrorStatus._FOLDER_OWNER_UPDATE_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_OWNER_UPDATE_NOT_ALLOWED);
         }
 
         PermissionType permission = request.getPermission();
 
         // OWNER 권한으로 변경은 허용하지 않음
         if (permission == PermissionType.OWNER) {
-            throw new GeneralException(ErrorStatus._INVALID_PERMISSION_TYPE);
+            throw new GeneralException(ShareFolderErrorStatus._INVALID_PERMISSION_TYPE);
         }
 
         usersFolder.setPermissionType(permission);
@@ -158,7 +159,7 @@ public class ShareFolderServiceImpl implements ShareFolderService {
         boolean isOwner = usersFolderRepository
                 .existsFolderOwner(ownerId, folderId);
         if (!isOwner) {
-            throw new GeneralException(ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
+            throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
         }
 
         // 활성화된 초대 링크가 있다면 만료

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.service.folder.share;
 
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
@@ -91,7 +92,7 @@ public class ShareFolderServiceImpl implements ShareFolderService {
         }
 
         FolderShareLink link = folderShareLinkRepository.findByFolder_FolderIdAndIsActiveTrue(folderId)
-                .orElseThrow(() -> new GeneralException(ShareFolderErrorStatus.INVITATION_LINK_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(InvitationErrorStatus.INVITATION_LINK_NOT_FOUND));
 
         link.deactivate();
     }

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
@@ -85,6 +85,10 @@ public class ShareFolderServiceImpl implements ShareFolderService {
 
     // 초대 링크 비활성화
     public void deactivateInviteLink(Long userId, Long folderId) {
+        if (!folderRepository.existsById(folderId)) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND);
+        }
+
         // 폴더 주인 확인
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
         if (!isOwner) {
@@ -100,6 +104,10 @@ public class ShareFolderServiceImpl implements ShareFolderService {
     // 폴더 viewer and writer 조회
     @Transactional(readOnly = true)
     public List<ViewerResponseDTO> getViewers(Long userId, Long folderId) {
+        if (!folderRepository.existsById(folderId)) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND);
+        }
+
         boolean isOwner = usersFolderRepository.existsFolderOwner(userId, folderId);
         if (!isOwner) {
             throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
@@ -120,6 +128,10 @@ public class ShareFolderServiceImpl implements ShareFolderService {
 
     // 유저의 폴더 권한 수정
     public ShareFolderResponseDTO updateViewerPermission(Long userId, Long folderId, Long userFolderId, FolderPermissionRequestDTO request) {
+        if (!folderRepository.existsById(folderId)) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND);
+        }
+
         // 요청자가 폴더 소유자인지 확인
         if (!usersFolderRepository.existsFolderOwner(userId, folderId)) {
             throw new GeneralException(ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED);
@@ -156,6 +168,10 @@ public class ShareFolderServiceImpl implements ShareFolderService {
 
     // 폴더 비공개 전환
     public ShareFolderResponseDTO unshare(Long ownerId, Long folderId) {
+        if (!folderRepository.existsById(folderId)) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND);
+        }
+
         // 폴더 주인인지 확인
         boolean isOwner = usersFolderRepository
                 .existsFolderOwner(ownerId, folderId);

--- a/src/main/java/com/umc/linkyou/service/folder/shared/SharedFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/shared/SharedFolderServiceImpl.java
@@ -1,6 +1,6 @@
 package com.umc.linkyou.service.folder.shared;
 
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.FolderConverter;
 import com.umc.linkyou.domain.Users;
@@ -64,7 +64,7 @@ public class SharedFolderServiceImpl implements SharedFolderService {
                 .collect(Collectors.groupingBy(folder -> {
                     Users owner = folderOwnerMap.get(folder.getFolderId());
                     if (owner == null) {
-                        throw new GeneralException(ErrorStatus._FOLDER_OWNER_NOT_FOUND);
+                        throw new GeneralException(FolderErrorStatus._FOLDER_OWNER_NOT_FOUND);
                     }
                     return owner.getId();
                 }));
@@ -98,11 +98,11 @@ public class SharedFolderServiceImpl implements SharedFolderService {
         // 폴더 조회
         UsersFolder usersFolder = usersFolderRepository
                 .findByUserIdAndFolderId(userId, folderId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_NOT_FOUND));
+                .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
 
         // 소유자는 이 API로 삭제 불가 (소유자는 FolderController.deleteFolder 사용)
         if (usersFolder.getPermissionType() == PermissionType.OWNER) {
-            throw new GeneralException(ErrorStatus._FOLDER_DELETE_FORBIDDEN);
+            throw new GeneralException(FolderErrorStatus._FOLDER_DELETE_FORBIDDEN);
         }
 
         // 유저 폴더 테이블에서 삭제

--- a/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
@@ -7,6 +7,7 @@ import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
@@ -26,4 +27,5 @@ public @interface ApiErrorCode {
     LinkuErrorStatus[] linkuErrorStatus() default {};
     FolderErrorStatus[] folderErrorStatus() default {};
     ShareFolderErrorStatus[] shareFolderErrorStatus() default {};
+    InvitationErrorStatus[] invitationErrorStatus() default {};
 }

--- a/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
@@ -28,4 +29,5 @@ public @interface ApiErrorCode {
     FolderErrorStatus[] folderErrorStatus() default {};
     ShareFolderErrorStatus[] shareFolderErrorStatus() default {};
     InvitationErrorStatus[] invitationErrorStatus() default {};
+    CategoryErrorStatus[] categoryErrorStatus() default {};
 }

--- a/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
+++ b/src/main/java/com/umc/linkyou/validation/annotation/swagger/ApiErrorCode.java
@@ -6,6 +6,8 @@ import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.alarm.AlarmErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.auth.AuthErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.curation.CurationErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import java.lang.annotation.*;
@@ -22,4 +24,6 @@ public @interface ApiErrorCode {
     CommonErrorStatus[] commonErrorStatus() default {};
     CurationErrorStatus[] curationErrorStatus() default {};
     LinkuErrorStatus[] linkuErrorStatus() default {};
+    FolderErrorStatus[] folderErrorStatus() default {};
+    ShareFolderErrorStatus[] shareFolderErrorStatus() default {};
 }

--- a/src/main/java/com/umc/linkyou/web/api/CategoryApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/CategoryApi.java
@@ -1,7 +1,7 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -25,7 +25,7 @@ public interface CategoryApi {
     );
 
     @Operation(summary = "유저 카테고리(중분류 폴더) 색상 수정", description = "사용자의 카테고리(중분류 폴더) 색상을 수정합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._CATEGORY_NOT_FOUND})
+    @ApiErrorCode(categoryErrorStatus = {CategoryErrorStatus._CATEGORY_NOT_FOUND})
     @PutMapping("/{categoryId}/color")
     ApiResponse<UserCategoryColorResponseDTO> updateUserCategoryColor(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface FolderApi {
 
     @Operation(summary = "소분류 폴더 생성", description = "중분류 폴더 하위에 소분류 폴더를 생성합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_PARENT_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN, FolderErrorStatus._FOLDER_NAME_CONFLICT, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
     @PostMapping("/{parentFolderId}/subfolders")
     ApiResponse<FolderResponseDTO> createFolder(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -19,7 +20,7 @@ import java.util.List;
 public interface FolderApi {
 
     @Operation(summary = "소분류 폴더 생성", description = "중분류 폴더 하위에 소분류 폴더를 생성합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_CREATE_FORBIDDEN, ErrorStatus._FOLDER_CREATE_DUPLICATE})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
     @PostMapping("/{parentFolderId}/subfolders")
     ApiResponse<FolderResponseDTO> createFolder(
             @CurrentUser CustomUserDetails userDetails,
@@ -28,7 +29,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "소분류 폴더 수정", description = "기존 소분류 폴더의 정보를 수정합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN})
     @PutMapping("/subfolders/{folderId}")
     ApiResponse<FolderResponseDTO> updateFolder(
             @CurrentUser CustomUserDetails userDetails,
@@ -37,7 +38,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "소분류 폴더 삭제", description = "소분류 폴더를 삭제합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_DELETE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_DELETE_FORBIDDEN})
     @DeleteMapping("/subfolders/{folderId}")
     ApiResponse<Object> deleteFolder(
             @CurrentUser CustomUserDetails userDetails,
@@ -58,7 +59,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "중분류 내부의 하위 폴더 조회", description = "특정 중분류 폴더의 하위 소분류 폴더 목록을 조회합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_ACCESS_FORBIDDEN})
     @GetMapping("/{parentFolderId}/subfolders")
     ApiResponse<List<FolderListResponseDTO>> getSubFolderList(
             @CurrentUser CustomUserDetails userDetails,
@@ -66,7 +67,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "북마크 설정/해제", description = "폴더의 북마크 상태를 설정하거나 해제합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_BOOKMARK_NOT_FOUND})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, errorStatus = {ErrorStatus._FOLDER_BOOKMARK_NOT_FOUND})
     @PatchMapping("/{folderId}/bookmark")
     ApiResponse<BookmarkUpdateResponseDTO> updateBookmark(
             @CurrentUser CustomUserDetails userDetails,
@@ -75,7 +76,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "폴더 내부 링크, 폴더 목록 조회", description = "특정 폴더 내부의 링크와 하위 폴더 목록을 조회합니다. 커서 기반 페이지네이션을 지원합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN, ErrorStatus._FOLDER_INVALID_CURSOR})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_ACCESS_FORBIDDEN, FolderErrorStatus._FOLDER_INVALID_CURSOR})
     @GetMapping("/{folderId}/linkus")
     ApiResponse<FolderLinkusResponseDTO> getFolderLinkus(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -29,7 +29,7 @@ public interface FolderApi {
     );
 
     @Operation(summary = "소분류 폴더 수정", description = "기존 소분류 폴더의 정보를 수정합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN, FolderErrorStatus._FOLDER_PARENT_NOT_FOUND, FolderErrorStatus._FOLDER_NAME_CONFLICT, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
     @PutMapping("/subfolders/{folderId}")
     ApiResponse<FolderResponseDTO> updateFolder(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 public interface InvitationApi {
 
     @Operation(summary = "초대장 미리보기", description = "토큰을 통해 초대된 폴더명과 초대자 닉네임을 확인합니다.")
-    @ApiErrorCode(invitationErrorStatus = {InvitationErrorStatus.INVITATION_NOT_FOUND, InvitationErrorStatus.INVITATION_EXPIRED, InvitationErrorStatus.INVITATION_LINK_NOT_FOUND})
+    @ApiErrorCode(invitationErrorStatus = {InvitationErrorStatus.INVITATION_NOT_FOUND, InvitationErrorStatus.INVITATION_EXPIRED})
     @GetMapping("/{token}")
     ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(
             @PathVariable String token

--- a/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
@@ -1,7 +1,7 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public interface InvitationApi {
 
     @Operation(summary = "초대장 미리보기", description = "토큰을 통해 초대된 폴더명과 초대자 닉네임을 확인합니다.")
-    @ApiErrorCode(shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND, ShareFolderErrorStatus.INVITATION_EXPIRED, ShareFolderErrorStatus.INVITATION_LINK_NOT_FOUND})
+    @ApiErrorCode(invitationErrorStatus = {InvitationErrorStatus.INVITATION_NOT_FOUND, InvitationErrorStatus.INVITATION_EXPIRED, InvitationErrorStatus.INVITATION_LINK_NOT_FOUND})
     @GetMapping("/{token}")
     ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(
             @PathVariable String token
     );
 
     @Operation(summary = "초대 수락하기", description = "초대를 수락합니다.")
-    @ApiErrorCode(shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND, ShareFolderErrorStatus.INVITATION_EXPIRED, ShareFolderErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT})
+    @ApiErrorCode(invitationErrorStatus = {InvitationErrorStatus.INVITATION_NOT_FOUND, InvitationErrorStatus.INVITATION_EXPIRED, InvitationErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT})
     @PostMapping("/{token}")
     ApiResponse<Long> acceptInvitation(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
@@ -1,7 +1,7 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -15,14 +15,14 @@ import org.springframework.web.bind.annotation.*;
 public interface InvitationApi {
 
     @Operation(summary = "초대장 미리보기", description = "토큰을 통해 초대된 폴더명과 초대자 닉네임을 확인합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus.INVITATION_NOT_FOUND, ErrorStatus.INVITATION_EXPIRED, ErrorStatus.INVITATION_LINK_NOT_FOUND})
+    @ApiErrorCode(shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND, ShareFolderErrorStatus.INVITATION_EXPIRED, ShareFolderErrorStatus.INVITATION_LINK_NOT_FOUND})
     @GetMapping("/{token}")
     ApiResponse<InvitationInfoResponseDTO> getInvitationInfo(
             @PathVariable String token
     );
 
     @Operation(summary = "초대 수락하기", description = "초대를 수락합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus.INVITATION_NOT_FOUND, ErrorStatus.INVITATION_EXPIRED, ErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT})
+    @ApiErrorCode(shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND, ShareFolderErrorStatus.INVITATION_EXPIRED, ShareFolderErrorStatus.INVITATION_CREATOR_CANNOT_ACCEPT})
     @PostMapping("/{token}")
     ApiResponse<Long> acceptInvitation(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -38,7 +38,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "폴더 멤버 조회", description = "공유된 폴더의 멤버 목록을 조회합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_ACCESS_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED})
     @GetMapping("/{folderId}/members")
     ApiResponse<List<ViewerResponseDTO>> getFolderViewers(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
@@ -29,7 +30,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "초대 링크 삭제", description = "초대 링크를 비활성화합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND})
+    @ApiErrorCode(shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED}, invitationErrorStatus = {InvitationErrorStatus.INVITATION_LINK_NOT_FOUND})
     @DeleteMapping("/{folderId}/invitation")
     ApiResponse<Object> deactivateInviteLink(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -1,7 +1,8 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -20,7 +21,7 @@ import java.util.List;
 public interface ShareFolderApi {
 
     @Operation(summary = "초대 링크 생성", description = "해당 폴더의 초대용 토큰을 생성합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_CREATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN})
     @PostMapping("/{folderId}/invitation")
     ApiResponse<String> createInviteLink(
             @CurrentUser CustomUserDetails userDetails,
@@ -28,7 +29,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "초대 링크 삭제", description = "초대 링크를 비활성화합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus.INVITATION_NOT_FOUND})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus.INVITATION_NOT_FOUND})
     @DeleteMapping("/{folderId}/invitation")
     ApiResponse<Object> deactivateInviteLink(
             @CurrentUser CustomUserDetails userDetails,
@@ -36,7 +37,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "폴더 멤버 조회", description = "공유된 폴더의 멤버 목록을 조회합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_ACCESS_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_ACCESS_FORBIDDEN})
     @GetMapping("/{folderId}/members")
     ApiResponse<List<ViewerResponseDTO>> getFolderViewers(
             @CurrentUser CustomUserDetails userDetails,
@@ -44,7 +45,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "폴더 권한 수정", description = "폴더 공유 멤버의 권한(뷰어/라이터)을 수정합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED, ErrorStatus._FOLDER_OWNER_UPDATE_NOT_ALLOWED, ErrorStatus._INVALID_PERMISSION_TYPE})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_FOUND, ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED, ShareFolderErrorStatus._FOLDER_OWNER_UPDATE_NOT_ALLOWED, ShareFolderErrorStatus._INVALID_PERMISSION_TYPE})
     @PutMapping("/{folderId}/members/{userFolderId}")
     ApiResponse<ShareFolderResponseDTO> updateViewerPermission(
             @CurrentUser CustomUserDetails userDetails,
@@ -54,7 +55,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "폴더 비공개 전환", description = "공유된 폴더를 비공개로 전환하고 모든 공유 권한을 제거합니다.")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN})
     @PostMapping("/{folderId}/unshare")
     ApiResponse<ShareFolderResponseDTO> unshareFolder(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -22,7 +22,7 @@ import java.util.List;
 public interface ShareFolderApi {
 
     @Operation(summary = "초대 링크 생성", description = "해당 폴더의 초대용 토큰을 생성합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED})
     @PostMapping("/{folderId}/invitation")
     ApiResponse<String> createInviteLink(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/ShareFolderApi.java
@@ -56,7 +56,7 @@ public interface ShareFolderApi {
     );
 
     @Operation(summary = "폴더 비공개 전환", description = "공유된 폴더를 비공개로 전환하고 모든 공유 권한을 제거합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_UPDATE_FORBIDDEN})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_ALLOWED})
     @PostMapping("/{folderId}/unshare")
     ApiResponse<ShareFolderResponseDTO> unshareFolder(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
@@ -1,7 +1,8 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
-import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -23,7 +24,7 @@ public interface SharedFolderApi {
     );
 
     @Operation(summary = "공유 받은 폴더 삭제", description = "공유 받은 폴더를 자신의 목록에서 제거합니다. (폴더 자체는 삭제되지 않습니다)")
-    @ApiErrorCode(errorStatus = {ErrorStatus._FOLDER_NOT_FOUND, ErrorStatus._FOLDER_PERMISSION_NOT_FOUND})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_FOUND})
     @DeleteMapping("/{folderId}")
     ApiResponse<Object> deleteSharedFolder(
             @CurrentUser CustomUserDetails userDetails,

--- a/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
@@ -2,7 +2,6 @@ package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
-import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
@@ -24,7 +23,7 @@ public interface SharedFolderApi {
     );
 
     @Operation(summary = "공유 받은 폴더 삭제", description = "공유 받은 폴더를 자신의 목록에서 제거합니다. (폴더 자체는 삭제되지 않습니다)")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}, shareFolderErrorStatus = {ShareFolderErrorStatus._FOLDER_PERMISSION_NOT_FOUND})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND, FolderErrorStatus._FOLDER_DELETE_FORBIDDEN})
     @DeleteMapping("/{folderId}")
     ApiResponse<Object> deleteSharedFolder(
             @CurrentUser CustomUserDetails userDetails,


### PR DESCRIPTION
## 🔗 관련 이슈
> closes #346

---

## 📌 작업 내용
> 통합 ErrorStatus에 섞여 있던 폴더 관련 에러 코드를 도메인별 클래스로 분리합니다.

### 1️⃣ Non-Functional Requirement
폴더/공유폴더 관련 에러를 FolderErrorStatus, ShareFolderErrorStatus로 분리
ShareFolderErrorStatus에 혼재되어 있던 초대(Invitation) 관련 에러를 InvitationErrorStatus로 분리
카테고리 관련 에러를 CategoryErrorStatus로 분리

---

## 🧪 테스트 결과
<img width="569" height="694" alt="image" src="https://github.com/user-attachments/assets/9ffcee17-f8d6-494e-811e-12b061026278" />

---

## 📎 참고 사항 (선택)
> 기존 폴더 엔드포인트의 Share / Shared 구조를 Share / Invite 구조로 바꿀 예정입니다. 맞춰서 에러 코드도 분리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * API 에러 응답 포맷을 폴더/초대/공유/카테고리 영역별로 더 세분화된 에러 코드로 재정리했습니다.
  * 초대 관련 에러를 별도 섹션으로 분리해 문서에서 구분이 더 명확해졌습니다.
  * API 에러 코드 예시 및 레퍼런스 범위를 확장해 문서에서 확인 가능한 코드가 늘었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->