### PR TITLE
feat: #364 알림 기능 수정

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/alarm/AlarmSuccessStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/alarm/AlarmSuccessStatus.java
@@ -18,7 +18,8 @@ public enum AlarmSuccessStatus implements BaseSuccessCode {
     ALARM_LIST_OK(HttpStatus.OK, "ALARM2006", "알림 목록 조회에 성공했습니다."),
     ALARM_DETAIL_OK(HttpStatus.OK, "ALARM2007", "알림 상세 조회에 성공했습니다."),
     ALARM_BROADCAST_REGISTERED(HttpStatus.OK, "ALARM2008", "관리자 브로드캐스트 알림이 정상적으로 등록되었습니다."),
-    ALARM_READ(HttpStatus.OK, "ALARM2009", "알림이 읽음 처리되었습니다.");
+    ALARM_READ(HttpStatus.OK, "ALARM2009", "알림이 읽음 처리되었습니다."),
+    ALARM_UNREAD_EXISTS_OK(HttpStatus.OK, "ALARM2010", "읽지 않은 알림 존재 여부 조회에 성공했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/domain/AlarmPayload.java
+++ b/src/main/java/com/umc/linkyou/domain/AlarmPayload.java
@@ -1,0 +1,60 @@
+package com.umc.linkyou.domain;
+
+import com.umc.linkyou.domain.enums.AlarmPlaceholder;
+
+import java.util.Map;
+
+/**
+ * 알림 본문 placeholder 치환에 필요한 값들을 담는 payload
+ * - 매직 스트링 제거: 키는 {@link AlarmPlaceholder} 에서만 정의
+ * - 값 누락을 컴파일타임에 차단 (record 생성자 강제)
+ * 렌더러 경계에서만 {@link #toValues()} 로 Map 으로 변환
+ */
+public sealed interface AlarmPayload {
+
+    // placeholder, 필요한 정보
+    Map<String, String> toValues();
+
+    /** placeholder 가 없는 알림 (공지 등) */
+    record Empty() implements AlarmPayload {
+        @Override
+        public Map<String, String> toValues() {
+            return Map.of();
+        }
+    }
+
+    /** {linkTitle} 만 필요 (LINK_SUMMARY_COMPLETE) */
+    record LinkTitle(String linkTitle) implements AlarmPayload {
+        @Override
+        public Map<String, String> toValues() {
+            return Map.of(AlarmPlaceholder.LINK_TITLE.key(), linkTitle);
+        }
+    }
+
+    /** {nickname} 만 필요 (CURATION_UPDATED) */
+    record Nickname(String nickname) implements AlarmPayload {
+        @Override
+        public Map<String, String> toValues() {
+            return Map.of(AlarmPlaceholder.NICKNAME.key(), nickname);
+        }
+    }
+
+    /** {folderName} 만 필요 (FOLDER_PERMISSION_CHANGED) */
+    record FolderName(String folderName) implements AlarmPayload {
+        @Override
+        public Map<String, String> toValues() {
+            return Map.of(AlarmPlaceholder.FOLDER_NAME.key(), folderName);
+        }
+    }
+
+    /** {nickname} + {folderName} 필요 (SHARED_FOLDER_INVITE, FOLDER_DELETED) */
+    record NicknameAndFolder(String nickname, String folderName) implements AlarmPayload {
+        @Override
+        public Map<String, String> toValues() {
+            return Map.of(
+                    AlarmPlaceholder.NICKNAME.key(), nickname,
+                    AlarmPlaceholder.FOLDER_NAME.key(), folderName
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/linkyou/domain/UserAlarm.java
+++ b/src/main/java/com/umc/linkyou/domain/UserAlarm.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.persistence.Id;
@@ -28,6 +29,11 @@ import java.time.LocalDateTime;
         uniqueConstraints = @UniqueConstraint(
                 name = "uq_user_alarm_user_alarm",
                 columnNames = {"user_id", "alarm_id"}
+        ),
+        // 미읽음 알림 존재 여부 조회용 인덱스
+        indexes = @Index(
+                name = "idx_user_alarms_unread",
+                columnList = "user_id, is_read, created_at"
         )
 )
 public class UserAlarm extends BaseEntity {

--- a/src/main/java/com/umc/linkyou/domain/enums/AlarmPlaceholder.java
+++ b/src/main/java/com/umc/linkyou/domain/enums/AlarmPlaceholder.java
@@ -1,0 +1,29 @@
+package com.umc.linkyou.domain.enums;
+
+/**
+ * 알림 본문 템플릿의 치환 placeholder 키를 한 곳에서 정의한다.
+ * "{nickname}" 같은 매직 스트링이 여러 곳에 흩어지는 것을 막고,
+ * 템플릿({token})과 값 Map 키(key)의 단일 출처 역할을 한다.
+ */
+public enum AlarmPlaceholder {
+
+    NICKNAME("nickname"),
+    FOLDER_NAME("folderName"),
+    LINK_TITLE("linkTitle");
+
+    private final String key;
+
+    AlarmPlaceholder(String key) {
+        this.key = key;
+    }
+
+    /** 값 Map 의 key. 예) "nickname" */
+    public String key() {
+        return key;
+    }
+
+    /** 템플릿에 들어가는 토큰. 예) "{nickname}" */
+    public String token() {
+        return "{" + key + "}";
+    }
+}

--- a/src/main/java/com/umc/linkyou/domain/enums/AlarmType.java
+++ b/src/main/java/com/umc/linkyou/domain/enums/AlarmType.java
@@ -9,9 +9,16 @@ public enum AlarmType {
 
     LINK_SUMMARY_COMPLETE(
             "링크 요약 완료",
-            "저장한 링크 요약이 준비됐어요",
+            "'{linkTitle}' 링크에 대한 AI 요약이 완료되었어요",
             AlarmSettingType.LINK,
             AlarmResponseType.LINK
+    ),
+
+    SHARED_FOLDER_INVITE(
+            "공유폴더 초대",
+            "{nickname}님이 '{folderName}' 폴더를 공유했어요. 지금 바로 확인해보세요!",
+            AlarmSettingType.FOLDER,
+            AlarmResponseType.FOLDER
     ),
 
     FOLDER_DELETED(

--- a/src/main/java/com/umc/linkyou/repository/UserAlarmRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserAlarmRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,5 +45,7 @@ public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
     );
 
     UserAlarm findByUserAndAlarm(Users user, Alarm alarm);
+
+    boolean existsByUser_IdAndIsReadFalseAndCreatedAtAfter(Long userId, LocalDateTime after);
 
 }

--- a/src/main/java/com/umc/linkyou/service/AiArticleService.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleService.java
@@ -7,8 +7,10 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.AiArticleConverter;
 import com.umc.linkyou.domain.AiArticle;
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
 import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
@@ -17,7 +19,9 @@ import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
 import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.web.dto.AiArticleResponseDTO;
+import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -37,6 +41,7 @@ public class AiArticleService {
     private final AiArticleRepository aiArticleRepository;
     private final UsersLinkuRepository usersLinkuRepository;
     private final AiArticleAnalyzer aiArticleAnalyzer;
+    private final AlarmService alarmService;
 
     @Transactional
     public AiArticleResponseDTO.AiArticleResultDTO saveAiArticle(Long linkuId, Long userId) {
@@ -59,6 +64,11 @@ public class AiArticleService {
                 ));
 
         usersLinku.markAiExist(true);
+
+        // 요약 완료 시 링크 요약 알림 발송. 설정 필터링은 sendAlarm 내부에서 처리한다.
+        String linkTitle = usersLinku.getTitle() != null ? usersLinku.getTitle() : linku.getTitle();
+        alarmService.sendAlarm(userId, new AlarmRequestDTO.AlarmSendRequestDTO(
+                AlarmType.LINK_SUMMARY_COMPLETE, linkuId, new AlarmPayload.LinkTitle(linkTitle)));
 
         return AiArticleConverter.toDto(article, linku, usersLinku);
     }

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -28,7 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -140,28 +139,66 @@ public class AlarmService {
         );
     }
 
-    // 개인 알림 전송 (알림 설정이 활성화된 경우에만 호출)
+    // 개인 알림 전송
     // userId, 알림타입, targetId를 설정하면 메세지 내용을 자동으로 설정합니다.
+    // 알림 설정 검사는 여기서 중앙 처리한다: alarmType.getSettingType() 설정이
+    // 꺼졌거나 초기화되지 않은 유저면 발송을 스킵한다. (호출자는 별도 검사 불필요)
     @Transactional
     public void sendAlarm(Long userId, AlarmRequestDTO.AlarmSendRequestDTO requestDTO) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
         AlarmType alarmType = requestDTO.type();
 
-        Map<String, String> values = alarmType == AlarmType.CURATION_UPDATED
-                ? Map.of("nickname", user.getNickName())
-                : requestDTO.values();
+        // 해당 알림 종류의 설정이 켜진 유저에게만 발송한다.
+        boolean enabled = alarmSettingRepository.findByUserId(userId)
+                .map(setting -> setting.isEnabled(alarmType.getSettingType()))
+                .orElse(false);
+        if (!enabled) {
+            return;
+        }
 
-        String renderedBody = AlarmMessageRenderer.render(alarmType.getBody(), values);
+        // CURATION 은 서버가 nickname 을 채우고, 그 외에는 요청 payload 를 사용한다.
+        AlarmPayload payload = alarmType == AlarmType.CURATION_UPDATED
+                ? new AlarmPayload.Nickname(user.getNickName())
+                : (requestDTO.payload() != null ? requestDTO.payload() : new AlarmPayload.Empty());
+
+        String renderedBody = AlarmMessageRenderer.render(alarmType.getBody(), payload.toValues());
 
         Alarm alarm = alarmRepository.save(Alarm.create(alarmType, requestDTO.targetId(), renderedBody));
         userAlarmRepository.save(UserAlarm.create(user, alarm));
 
-        PersonalAlarmEvent event = (values == null || values.isEmpty())
-                ? PersonalAlarmEvent.of(userId, alarmType, requestDTO.targetId())
-                : PersonalAlarmEvent.withValues(userId, alarmType, requestDTO.targetId(), values);
+        eventPublisher.publishEvent(
+                PersonalAlarmEvent.withPayload(userId, alarmType, requestDTO.targetId(), payload));
+    }
 
-        eventPublisher.publishEvent(event);
+    // 다수 유저에게 동일 본문으로 일괄 발송
+    // 설정 검사는 여기서 중앙 처리하고, Alarm 1건 + UserAlarm N건을 배치 저장
+    // payload 는 모든 수신자에게 동일해야 함
+    @Transactional
+    public void sendAlarmBulk(List<Long> userIds, AlarmType alarmType, Long targetId, AlarmPayload payload) {
+        if (userIds == null || userIds.isEmpty()) {
+            return;
+        }
+
+        // 설정이 켜진 유저만 추림
+        List<Long> enabledUserIds = alarmSettingRepository.findAllByUserIdIn(userIds).stream()
+                .filter(setting -> setting.isEnabled(alarmType.getSettingType()))
+                .map(setting -> setting.getUser().getId())
+                .toList();
+        if (enabledUserIds.isEmpty()) {
+            return;
+        }
+
+        String renderedBody = AlarmMessageRenderer.render(alarmType.getBody(), payload.toValues());
+        Alarm alarm = alarmRepository.save(Alarm.create(alarmType, targetId, renderedBody));
+
+        List<UserAlarm> userAlarms = enabledUserIds.stream()
+                .map(uid -> UserAlarm.create(userRepository.getReferenceById(uid), alarm))
+                .toList();
+        userAlarmRepository.saveAll(userAlarms);
+
+        enabledUserIds.forEach(uid ->
+                eventPublisher.publishEvent(PersonalAlarmEvent.withPayload(uid, alarmType, targetId, payload)));
     }
 
     // 관리자 브로드캐스트 알림 등록, content 직접 입력
@@ -169,7 +206,7 @@ public class AlarmService {
     public void registerAdminAlarm(AlarmRequestDTO.AdminAlarmSendRequestDTO requestDTO) {
         AlarmType alarmType = requestDTO.type();
 
-        // targetId는 임시로 설정 - 알림이 생성되고 나서 id를 targetId로 업데이트하여 보내야 하므로 entity에서는 의미없음
+        // targetId는 임시로 설정
         Alarm alarm = alarmRepository.save(Alarm.create(alarmType, 0L, requestDTO.content()));
         // 알림 생성 후에 업데이트
         alarm.updateTargetId(alarm.getId());
@@ -245,6 +282,15 @@ public class AlarmService {
                 alarm.getBody(),
                 alarm.getCreatedAt()
         );
+    }
+
+    // 읽지 않은 알림 존재 여부 조회 (최근 한 달 이내 생성된 알림만 대상)
+    public AlarmResponseDTO.UnreadAlarmExistsDTO hasUnreadAlarm(Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
+        boolean hasUnread = userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(userId, oneMonthAgo);
+        return new AlarmResponseDTO.UnreadAlarmExistsDTO(hasUnread);
     }
 
     // 알림 읽음 처리

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -284,12 +284,12 @@ public class AlarmService {
         );
     }
 
-    // 읽지 않은 알림 존재 여부 조회 (최근 한 달 이내 생성된 알림만 대상)
+    // 읽지 않은 알림 존재 여부 조회 (최근 30일 이내 생성된 알림만 대상)
     public AlarmResponseDTO.UnreadAlarmExistsDTO hasUnreadAlarm(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        LocalDateTime oneMonthAgo = LocalDateTime.now().minusMonths(1);
-        boolean hasUnread = userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(userId, oneMonthAgo);
+        // userId 는 인증된 @CurrentUser 에서 오므로 별도 존재 검증 없이 바로 조회한다.
+        // (유저가 없어도 exists 가 false 를 반환해 무해하게 끝난다)
+        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
+        boolean hasUnread = userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(userId, thirtyDaysAgo);
         return new AlarmResponseDTO.UnreadAlarmExistsDTO(hasUnread);
     }
 

--- a/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/AlarmService.java
@@ -286,10 +286,8 @@ public class AlarmService {
 
     // 읽지 않은 알림 존재 여부 조회 (최근 30일 이내 생성된 알림만 대상)
     public AlarmResponseDTO.UnreadAlarmExistsDTO hasUnreadAlarm(Long userId) {
-        // userId 는 인증된 @CurrentUser 에서 오므로 별도 존재 검증 없이 바로 조회한다.
-        // (유저가 없어도 exists 가 false 를 반환해 무해하게 끝난다)
-        LocalDateTime thirtyDaysAgo = LocalDateTime.now().minusDays(30);
-        boolean hasUnread = userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(userId, thirtyDaysAgo);
+        LocalDateTime tenDaysAgo = LocalDateTime.now().minusDays(30);
+        boolean hasUnread = userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(userId, tenDaysAgo);
         return new AlarmResponseDTO.UnreadAlarmExistsDTO(hasUnread);
     }
 

--- a/src/main/java/com/umc/linkyou/service/alarm/event/PersonalAlarmEvent.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/event/PersonalAlarmEvent.java
@@ -1,23 +1,21 @@
 package com.umc.linkyou.service.alarm.event;
 
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.enums.AlarmType;
-
-import java.util.List;
-import java.util.Map;
 
 public record PersonalAlarmEvent(
         Long userId,
         AlarmType alarmType,
         Long targetId,
-        Map<String, String> values  // nullable, {placeholder}가 있는 알림 시에만 사용
+        AlarmPayload payload   // placeholder 치환값. 값 없는 알림은 AlarmPayload.Empty
 ) {
-    // nickname 없는 경우 (LINK, FOLDER 등)
+    // placeholder 없는 경우
     public static PersonalAlarmEvent of(Long userId, AlarmType alarmType, Long targetId) {
-        return new PersonalAlarmEvent(userId, alarmType, targetId, null);
+        return new PersonalAlarmEvent(userId, alarmType, targetId, new AlarmPayload.Empty());
     }
 
-    // nickname 있는 경우 (CURATION)
-    public static PersonalAlarmEvent withValues(Long userId, AlarmType alarmType, Long targetId, Map<String, String> values) {
-        return new PersonalAlarmEvent(userId, alarmType, targetId, values);
+    // placeholder 있는 경우
+    public static PersonalAlarmEvent withPayload(Long userId, AlarmType alarmType, Long targetId, AlarmPayload payload) {
+        return new PersonalAlarmEvent(userId, alarmType, targetId, payload);
     }
 }

--- a/src/main/java/com/umc/linkyou/service/alarm/listener/FolderDeletedAlarmEventListener.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/listener/FolderDeletedAlarmEventListener.java
@@ -1,44 +1,28 @@
 package com.umc.linkyou.service.alarm.listener;
 
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.enums.AlarmType;
-import com.umc.linkyou.repository.AlarmSettingRepository;
 import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.service.alarm.event.FolderDeletedAlarmEvent;
-import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import com.umc.linkyou.domain.AlarmSetting;
 
-import java.util.Map;
-
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FolderDeletedAlarmEventListener {
-    private final AlarmSettingRepository alarmSettingRepository;
     private final AlarmService alarmService;
 
     @Async("alarmBatchTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(FolderDeletedAlarmEvent event) {
-        Map<String, String> values = Map.of(
-                "nickname", event.deleterNickname(),
-                "folderName", event.folderName()
-        );
+        AlarmPayload payload = new AlarmPayload.NicknameAndFolder(
+                event.deleterNickname(), event.folderName());
 
-        alarmSettingRepository.findAllByUserIdIn(event.memberIds()).stream()
-                .filter(AlarmSetting::isFolderActive)
-                .forEach(setting -> {
-                    try {
-                        alarmService.sendAlarm(setting.getUser().getId(),
-                                new AlarmRequestDTO.AlarmSendRequestDTO(AlarmType.FOLDER_DELETED, event.folderId(), values));
-                    } catch (Exception e) {
-                        log.error("폴더 삭제 알림 발송 실패. userId={}", setting.getUser().getId(), e);
-                    }
-                });
+        // 멤버 전원에게 동일 본문으로 일괄 발송. 설정 필터링은 sendAlarmBulk 내부에서 처리한다.
+        alarmService.sendAlarmBulk(
+                event.memberIds(), AlarmType.FOLDER_DELETED, event.folderId(), payload);
     }
 }

--- a/src/main/java/com/umc/linkyou/service/alarm/listener/FolderPermissionChangedAlarmEventListener.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/listener/FolderPermissionChangedAlarmEventListener.java
@@ -1,5 +1,6 @@
 package com.umc.linkyou.service.alarm.listener;
 
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.service.alarm.event.FolderPermissionChangedAlarmEvent;
@@ -10,8 +11,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import java.util.Map;
-
 @Component
 @RequiredArgsConstructor
 public class FolderPermissionChangedAlarmEventListener {
@@ -21,6 +20,7 @@ public class FolderPermissionChangedAlarmEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(FolderPermissionChangedAlarmEvent event) {
         alarmService.sendAlarm(event.memberId(), new AlarmRequestDTO.AlarmSendRequestDTO(
-                AlarmType.FOLDER_PERMISSION_CHANGED, event.folderId(), Map.of("folderName", event.folderName())));
+                AlarmType.FOLDER_PERMISSION_CHANGED, event.folderId(),
+                new AlarmPayload.FolderName(event.folderName())));
     }
 }

--- a/src/main/java/com/umc/linkyou/service/alarm/listener/PersonalAlarmEventListener.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/listener/PersonalAlarmEventListener.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import java.util.Map;
+
 @Component
 @RequiredArgsConstructor
 public class PersonalAlarmEventListener {
@@ -18,9 +20,10 @@ public class PersonalAlarmEventListener {
     @Async("fcmTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handle(PersonalAlarmEvent event) {
-        FcmSendRequestDTO requestDTO = (event.values() != null && !event.values().isEmpty())
-                ? FcmSendRequestDTO.withValues(event.alarmType(), event.targetId(), event.values())
-                : FcmSendRequestDTO.of(event.alarmType(), event.targetId());
+        Map<String, String> values = event.payload().toValues();
+        FcmSendRequestDTO requestDTO = values.isEmpty()
+                ? FcmSendRequestDTO.of(event.alarmType(), event.targetId()) // data 없을 때
+                : FcmSendRequestDTO.withValues(event.alarmType(), event.targetId(), values); // data 있을 때
 
         fcmPushSender.sendToUser(event.userId(), requestDTO);
     }

--- a/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AlarmApi.java
@@ -111,6 +111,17 @@ public interface AlarmApi {
             @RequestParam(defaultValue = "20") @Min(1) @Max(20) int size
     );
 
+    @Operation(summary = "읽지 않은 알림 존재 여부 조회", description = """
+            사용자에게 최근 한 달 이내 생성된 알림 중 읽지 않은 알림이 있는지 여부를 조회합니다.
+            - `hasUnread`가 true이면 읽지 않은 알림이 존재합니다.
+            """)
+    @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @GetMapping("/unread")
+    ApiResponse<AlarmResponseDTO.UnreadAlarmExistsDTO> hasUnreadAlarm(
+            @CurrentUser CustomUserDetails userDetails
+    );
+
     @Operation(summary = "알림 상세 조회", description = """
             특정 알림의 상세 정보를 조회합니다.
             """)
@@ -151,4 +162,7 @@ public interface AlarmApi {
             @Parameter(description = "읽음 처리할 알림 ID")
             @PathVariable Long alarmId
     );
+
+
+
 }

--- a/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AlarmController.java
@@ -91,6 +91,13 @@ public class AlarmController implements AlarmApi {
     }
 
     @Override
+    public ApiResponse<AlarmResponseDTO.UnreadAlarmExistsDTO> hasUnreadAlarm(
+            @CurrentUser CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(AlarmSuccessStatus.ALARM_UNREAD_EXISTS_OK, alarmService.hasUnreadAlarm(userDetails.getUserId()));
+    }
+
+    @Override
     public ApiResponse<AlarmResponseDTO.AlarmDetailDTO> viewAlarmDetail(
             @CurrentUser CustomUserDetails userDetails,
             @PathVariable Long alarmId

--- a/src/main/java/com/umc/linkyou/web/dto/alarm/AlarmRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/alarm/AlarmRequestDTO.java
@@ -1,14 +1,12 @@
 package com.umc.linkyou.web.dto.alarm;
 
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.enums.AlarmSettingType;
 import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.validation.annotation.ValidEnum;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-
-import java.util.List;
-import java.util.Map;
 
 public final class AlarmRequestDTO {
 
@@ -40,7 +38,7 @@ public final class AlarmRequestDTO {
             AlarmType type,
             @NotNull(message = "targetId는 필수입니다.")
             Long targetId,
-            Map<String, String> values
+            AlarmPayload payload   // placeholder 치환값. 값 없으면 AlarmPayload.Empty
     ){}
 
     @Schema(description = "관리자 브로드캐스트 알림 요청 DTO")

--- a/src/main/java/com/umc/linkyou/web/dto/alarm/AlarmResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/alarm/AlarmResponseDTO.java
@@ -31,4 +31,9 @@ public record AlarmResponseDTO(
             Long nextCursor,
             boolean hasNext
     ){}
+
+    public record UnreadAlarmExistsDTO(
+            @Schema(description = "읽지 않은 알림 존재 여부")
+            boolean hasUnread
+    ){}
 }

--- a/src/main/resources/db/migration/V7__add_user_alarms_unread_index.sql
+++ b/src/main/resources/db/migration/V7__add_user_alarms_unread_index.sql
@@ -1,0 +1,5 @@
+-- 미읽음 알림 존재 여부 조회(hasUnreadAlarm) 최적화용 복합 인덱스
+-- 쿼리: WHERE user_id = ? AND is_read = false AND created_at > ?
+-- 컬럼 순서: 동등조건(user_id) -> 동등조건(is_read) -> 범위조건(created_at)
+CREATE INDEX IF NOT EXISTS idx_user_alarms_unread
+    ON user_alarms (user_id, is_read, created_at);

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -2,8 +2,10 @@ package com.umc.linkyou.service;
 
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.AiArticle;
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
 import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
@@ -11,7 +13,9 @@ import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
 import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.support.fixture.LinkuFixture;
+import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -40,6 +44,7 @@ class AiArticleServiceTest {
     @Mock private AiArticleRepository aiArticleRepository;
     @Mock private UsersLinkuRepository usersLinkuRepository;
     @Mock private AiArticleAnalyzer aiArticleAnalyzer;
+    @Mock private AlarmService alarmService;
 
     private static final Long LINKU_ID = 100L;
     private static final Long USER_ID = 1L;
@@ -118,6 +123,58 @@ class AiArticleServiceTest {
                 ArgumentCaptor<AiArticle> captor = ArgumentCaptor.forClass(AiArticle.class);
                 verify(aiArticleRepository).save(captor.capture());
                 assertEquals(SUMMARY, captor.getValue().getSummary());
+            }
+
+            @Test
+            @DisplayName("요약 완료 시 링크 요약 알림을 발송한다")
+            void 요약완료시_링크알림_발송() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                UsersLinku usersLinku = UsersLinku.builder()
+                        .userLinkuId(10L)
+                        .linku(linku)
+                        .user(user)
+                        .emotion(LinkuFixture.emotion())
+                        .emotionAi(true)
+                        .situationAi(true)
+                        .title("내가 지은 링크 제목")
+                        .build();
+                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUserAndLinku(user, linku)).willReturn(Optional.of(usersLinku));
+                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
+                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
+
+                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
+
+                verify(alarmService).sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                        AlarmType.LINK_SUMMARY_COMPLETE, LINKU_ID,
+                        new AlarmPayload.LinkTitle("내가 지은 링크 제목")));
+            }
+
+            @Test
+            @DisplayName("사용자 지정 제목이 없으면 링크 원제목으로 알림을 발송한다")
+            void 제목없으면_링크원제목으로_알림발송() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                UsersLinku usersLinku = buildUsersLinku(linku, user); // title 미설정
+                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUserAndLinku(user, linku)).willReturn(Optional.of(usersLinku));
+                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
+                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
+
+                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
+
+                verify(alarmService).sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                        AlarmType.LINK_SUMMARY_COMPLETE, LINKU_ID,
+                        new AlarmPayload.LinkTitle(linku.getTitle())));
             }
         }
 

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -28,7 +28,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.umc.linkyou.support.fixture.AlarmFixture.*;
@@ -306,6 +305,7 @@ class AlarmServiceTest {
         @DisplayName("알림이 저장되고 PersonalAlarmEvent가 발행된다")
         void 알림발송_성공() {
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user())));
             given(alarmRepository.save(any())).willReturn(alarm(AlarmType.LINK_SUMMARY_COMPLETE));
 
             alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
@@ -321,11 +321,12 @@ class AlarmServiceTest {
         void 폴더삭제알림_본문전체일치() {
             ArgumentCaptor<Alarm> alarmCaptor = ArgumentCaptor.forClass(Alarm.class);
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user())));
             given(alarmRepository.save(alarmCaptor.capture())).willAnswer(inv -> inv.getArgument(0));
 
             alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
                     AlarmType.FOLDER_DELETED, 300L,
-                    Map.of("nickname", "주인", "folderName", "어학")));
+                    new AlarmPayload.NicknameAndFolder("주인", "어학")));
 
             assertThat(alarmCaptor.getValue().getBody())
                     .isEqualTo("주인님이 '어학' 폴더를 삭제해 더 이상 접근할 수 없어요");
@@ -336,6 +337,7 @@ class AlarmServiceTest {
         void 큐레이션알림_닉네임포함() {
             ArgumentCaptor<Alarm> alarmCaptor = ArgumentCaptor.forClass(Alarm.class);
             given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(defaultSetting(user())));
             given(alarmRepository.save(alarmCaptor.capture())).willAnswer(inv -> inv.getArgument(0));
 
             alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
@@ -356,6 +358,97 @@ class AlarmServiceTest {
                     .isInstanceOf(GeneralException.class)
                     .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
                             .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("해당 타입의 알림 설정이 꺼져 있으면 발송하지 않는다")
+        void 설정꺼짐_발송스킵() {
+            Users user = user();
+            AlarmSetting setting = defaultSetting(user);
+            setting.updateLink(false);
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.of(setting));
+
+            alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                    AlarmType.LINK_SUMMARY_COMPLETE, 1L, new AlarmPayload.LinkTitle("제목")));
+
+            verify(alarmRepository, never()).save(any());
+            verify(userAlarmRepository, never()).save(any());
+            verify(eventPublisher, never()).publishEvent((Object) any());
+        }
+
+        @Test
+        @DisplayName("알림 설정이 초기화되지 않은 유저면 발송하지 않는다")
+        void 설정미초기화_발송스킵() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(alarmSettingRepository.findByUserId(USER_ID)).willReturn(Optional.empty());
+
+            alarmService.sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                    AlarmType.LINK_SUMMARY_COMPLETE, 1L, new AlarmPayload.LinkTitle("제목")));
+
+            verify(alarmRepository, never()).save(any());
+            verify(userAlarmRepository, never()).save(any());
+            verify(eventPublisher, never()).publishEvent((Object) any());
+        }
+    }
+
+    @Nested
+    @DisplayName("일괄 알림 발송 (sendAlarmBulk)")
+    class SendAlarmBulk {
+
+        private static final Long MEMBER_A = 2L;
+        private static final Long MEMBER_B = 3L;
+        private static final Long MEMBER_C = 4L;
+        private static final Long TARGET_ID = 300L;
+
+        private final AlarmPayload payload = new AlarmPayload.NicknameAndFolder("주인", "어학");
+
+        private Users userWith(Long id) {
+            return Users.builder().id(id).nickName("u" + id).build();
+        }
+
+        @Test
+        @DisplayName("설정 켜진 유저에게만 Alarm 1건 + UserAlarm N건을 배치 저장하고 이벤트를 발행한다")
+        void 설정켜진유저만_배치발송() {
+            AlarmSetting sA = defaultSetting(userWith(MEMBER_A));
+            AlarmSetting sB = defaultSetting(userWith(MEMBER_B));
+            sB.updateFolder(false); // OFF
+            AlarmSetting sC = defaultSetting(userWith(MEMBER_C));
+
+            List<Long> ids = List.of(MEMBER_A, MEMBER_B, MEMBER_C);
+            given(alarmSettingRepository.findAllByUserIdIn(ids)).willReturn(List.of(sA, sB, sC));
+            given(alarmRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+            given(userRepository.getReferenceById(anyLong())).willAnswer(inv -> userWith(inv.getArgument(0)));
+
+            alarmService.sendAlarmBulk(ids, AlarmType.FOLDER_DELETED, TARGET_ID, payload);
+
+            verify(alarmRepository, times(1)).save(any());
+            ArgumentCaptor<List<UserAlarm>> captor = ArgumentCaptor.forClass(List.class);
+            verify(userAlarmRepository).saveAll(captor.capture());
+            assertThat(captor.getValue()).hasSize(2); // A, C 만
+            verify(eventPublisher, times(2)).publishEvent((Object) any());
+        }
+
+        @Test
+        @DisplayName("전원 설정이 꺼져 있으면 아무것도 저장·발행하지 않는다")
+        void 전원꺼짐_스킵() {
+            AlarmSetting sA = defaultSetting(userWith(MEMBER_A));
+            sA.updateFolder(false);
+            given(alarmSettingRepository.findAllByUserIdIn(List.of(MEMBER_A))).willReturn(List.of(sA));
+
+            alarmService.sendAlarmBulk(List.of(MEMBER_A), AlarmType.FOLDER_DELETED, TARGET_ID, payload);
+
+            verify(alarmRepository, never()).save(any());
+            verify(userAlarmRepository, never()).saveAll(any());
+            verify(eventPublisher, never()).publishEvent((Object) any());
+        }
+
+        @Test
+        @DisplayName("userIds가 비어 있으면 설정 조회도 하지 않는다")
+        void 빈리스트_스킵() {
+            alarmService.sendAlarmBulk(List.of(), AlarmType.FOLDER_DELETED, TARGET_ID, payload);
+
+            verifyNoInteractions(alarmSettingRepository, alarmRepository, userAlarmRepository, eventPublisher);
         }
     }
 
@@ -433,6 +526,46 @@ class AlarmServiceTest {
 
             assertThatThrownBy(() ->
                     alarmService.viewAlarmList(USER_ID, AlarmSettingType.ALL, null, 10))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+        }
+    }
+
+    @Nested
+    @DisplayName("읽지 않은 알림 존재 여부 조회 (hasUnreadAlarm)")
+    class HasUnreadAlarm {
+
+        @Test
+        @DisplayName("읽지 않은 알림이 있으면 hasUnread=true를 반환한다")
+        void 읽지않은알림_있음() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(eq(USER_ID), any()))
+                    .willReturn(true);
+
+            AlarmResponseDTO.UnreadAlarmExistsDTO result = alarmService.hasUnreadAlarm(USER_ID);
+
+            assertThat(result.hasUnread()).isTrue();
+        }
+
+        @Test
+        @DisplayName("읽지 않은 알림이 없으면 hasUnread=false를 반환한다")
+        void 읽지않은알림_없음() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
+            given(userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(eq(USER_ID), any()))
+                    .willReturn(false);
+
+            AlarmResponseDTO.UnreadAlarmExistsDTO result = alarmService.hasUnreadAlarm(USER_ID);
+
+            assertThat(result.hasUnread()).isFalse();
+        }
+
+        @Test
+        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
+        void 유저없음_예외() {
+            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> alarmService.hasUnreadAlarm(USER_ID))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
                             .isEqualTo(UserErrorStatus._USER_NOT_FOUND));

--- a/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/AlarmServiceTest.java
@@ -539,7 +539,6 @@ class AlarmServiceTest {
         @Test
         @DisplayName("읽지 않은 알림이 있으면 hasUnread=true를 반환한다")
         void 읽지않은알림_있음() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
             given(userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(eq(USER_ID), any()))
                     .willReturn(true);
 
@@ -551,24 +550,12 @@ class AlarmServiceTest {
         @Test
         @DisplayName("읽지 않은 알림이 없으면 hasUnread=false를 반환한다")
         void 읽지않은알림_없음() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.of(user()));
             given(userAlarmRepository.existsByUser_IdAndIsReadFalseAndCreatedAtAfter(eq(USER_ID), any()))
                     .willReturn(false);
 
             AlarmResponseDTO.UnreadAlarmExistsDTO result = alarmService.hasUnreadAlarm(USER_ID);
 
             assertThat(result.hasUnread()).isFalse();
-        }
-
-        @Test
-        @DisplayName("유저가 없으면 _USER_NOT_FOUND를 던진다")
-        void 유저없음_예외() {
-            given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> alarmService.hasUnreadAlarm(USER_ID))
-                    .isInstanceOf(GeneralException.class)
-                    .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
-                            .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
         }
     }
 

--- a/src/test/java/com/umc/linkyou/service/alarm/listener/FolderDeletedAlarmEventListenerTest.java
+++ b/src/test/java/com/umc/linkyou/service/alarm/listener/FolderDeletedAlarmEventListenerTest.java
@@ -1,32 +1,22 @@
 package com.umc.linkyou.service.alarm.listener;
 
-import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
-import com.umc.linkyou.apiPayload.exception.GeneralException;
-import com.umc.linkyou.domain.AlarmSetting;
-import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.enums.AlarmType;
-import com.umc.linkyou.domain.enums.PermissionType;
-import com.umc.linkyou.repository.AlarmSettingRepository;
 import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.service.alarm.event.FolderDeletedAlarmEvent;
-import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Map;
 
-import static com.umc.linkyou.support.fixture.AlarmFixture.defaultSetting;
 import static com.umc.linkyou.support.fixture.FolderFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,82 +24,42 @@ import static org.mockito.Mockito.*;
 class FolderDeletedAlarmEventListenerTest {
     @InjectMocks private FolderDeletedAlarmEventListener listener;
 
-    @Mock private AlarmSettingRepository alarmSettingRepository;
     @Mock private AlarmService alarmService;
 
-    private static final Long MEMBER_ON = 2L;
-    private static final Long MEMBER_OFF = 3L;
-    private static final Long MEMBER_NO_SETTING = 4L;
-    private static final Long MEMBER_FAILS = 5L;
+    private static final Long MEMBER_A = 2L;
+    private static final Long MEMBER_B = 3L;
+    private static final Long MEMBER_C = 4L;
 
     @Nested
     @DisplayName("handle")
     class Handle {
         @Test
-        @DisplayName("폴더 알림이 켜진 멤버에게만 sendAlarm을 호출한다")
-        void 폴더알림켜진멤버만_발송() {
-            Users onUser = participant(MEMBER_ON, PermissionType.VIEWER).getUser();
-            Users offUser = participant(MEMBER_OFF, PermissionType.WRITER).getUser();
-
-            AlarmSetting onSetting = defaultSetting(onUser);
-            AlarmSetting offSetting = defaultSetting(offUser);
-            offSetting.updateFolder(false);
-
-            given(alarmSettingRepository.findAllByUserIdIn(List.of(MEMBER_ON, MEMBER_OFF, MEMBER_NO_SETTING)))
-                    .willReturn(List.of(onSetting, offSetting));
-
+        @DisplayName("멤버ids/타입/targetId/payload로 sendAlarmBulk를 한 번 호출한다")
+        void bulk_한번호출() {
+            List<Long> members = List.of(MEMBER_A, MEMBER_B, MEMBER_C);
             FolderDeletedAlarmEvent event = new FolderDeletedAlarmEvent(
-                    FOLDER_ID, List.of(MEMBER_ON, MEMBER_OFF, MEMBER_NO_SETTING), owner().getNickName(), folder().getFolderName());
+                    FOLDER_ID, members, owner().getNickName(), folder().getFolderName());
 
             listener.handle(event);
 
-            verify(alarmService, times(1)).sendAlarm(eq(MEMBER_ON), any());
-            verify(alarmService, never()).sendAlarm(eq(MEMBER_OFF), any());
-            verify(alarmService, never()).sendAlarm(eq(MEMBER_NO_SETTING), any());
+            verify(alarmService).sendAlarmBulk(
+                    members,
+                    AlarmType.FOLDER_DELETED,
+                    FOLDER_ID,
+                    new AlarmPayload.NicknameAndFolder(owner().getNickName(), folder().getFolderName()));
         }
 
         @Test
-        @DisplayName("sendAlarm 호출 시 닉네임과 폴더명이 values에 정확히 담긴다")
-        void sendAlarm_values_정확히전달() {
-            Users onUser = participant(MEMBER_ON, PermissionType.VIEWER).getUser();
-            given(alarmSettingRepository.findAllByUserIdIn(List.of(MEMBER_ON)))
-                    .willReturn(List.of(defaultSetting(onUser)));
+        @DisplayName("sendAlarmBulk 예외는 async uncaught 핸들러로 전파된다 (리스너에서 삼키지 않음)")
+        void 예외_전파() {
+            doThrow(new RuntimeException("boom"))
+                    .when(alarmService).sendAlarmBulk(any(), any(), any(), any());
 
             FolderDeletedAlarmEvent event = new FolderDeletedAlarmEvent(
-                    FOLDER_ID, List.of(MEMBER_ON), owner().getNickName(), folder().getFolderName());
+                    FOLDER_ID, List.of(MEMBER_A), owner().getNickName(), folder().getFolderName());
 
-            listener.handle(event);
-
-            ArgumentCaptor<AlarmRequestDTO.AlarmSendRequestDTO> captor = ArgumentCaptor.forClass(AlarmRequestDTO.AlarmSendRequestDTO.class);
-            verify(alarmService).sendAlarm(eq(MEMBER_ON), captor.capture());
-
-            AlarmRequestDTO.AlarmSendRequestDTO requestDTO = captor.getValue();
-            assertThat(requestDTO.type()).isEqualTo(AlarmType.FOLDER_DELETED);
-            assertThat(requestDTO.targetId()).isEqualTo(FOLDER_ID);
-            assertThat(requestDTO.values()).isEqualTo(Map.of("nickname", owner().getNickName(), "folderName", folder().getFolderName()));
-        }
-
-        @Test
-        @DisplayName("한 멤버 발송에서 예외가 발생해도 나머지 멤버는 계속 발송된다")
-        void 한멤버예외_나머지계속발송() {
-            Users failingUser = participant(MEMBER_FAILS, PermissionType.VIEWER).getUser();
-            Users succeedingUser = participant(MEMBER_ON, PermissionType.VIEWER).getUser();
-
-            AlarmSetting failingSetting = defaultSetting(failingUser);
-            AlarmSetting succeedingSetting = defaultSetting(succeedingUser);
-
-            given(alarmSettingRepository.findAllByUserIdIn(List.of(MEMBER_FAILS, MEMBER_ON)))
-                    .willReturn(List.of(failingSetting, succeedingSetting));
-            doThrow(new GeneralException(UserErrorStatus._USER_NOT_FOUND))
-                    .when(alarmService).sendAlarm(eq(MEMBER_FAILS), any());
-
-            FolderDeletedAlarmEvent event = new FolderDeletedAlarmEvent(
-                    FOLDER_ID, List.of(MEMBER_FAILS, MEMBER_ON), owner().getNickName(), folder().getFolderName());
-
-            listener.handle(event);
-
-            verify(alarmService).sendAlarm(eq(MEMBER_FAILS), any());
-            verify(alarmService).sendAlarm(eq(MEMBER_ON), any());
+            assertThatThrownBy(() -> listener.handle(event))
+                    .isInstanceOf(RuntimeException.class);
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)
#364 

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement


### 2️⃣ Functional Requirement
- 알림 설정 AlarmService에서 일괄 관리(설정 조회가 흩어짐 방지)
- 알림 Placeholder, payload 관리 - 매직 스트링 흩어짐 방지
- 링크 요약 알림 연결
- 폴더 알림 연결 부분 수정
- 알림 새로운 타입 추가(공유 폴더 알림)
- 읽은 알림 존재 여부 조회 API 구현

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 읽지 않은 알림이 있는지 확인하는 조회 기능이 추가되었습니다.
  * AI 요약 완료, 공유 폴더 초대, 폴더 삭제 등 새로운 알림이 지원됩니다.
  * 알림 내용에 제목, 닉네임, 폴더명 등을 반영할 수 있게 되었습니다.

* **Bug Fixes**
  * 알림 전송 방식이 개선되어 대량 발송 시에도 더 안정적으로 처리됩니다.
  * 알림 설정이 반영된 수신자에게만 알림이 전달되도록 동작이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->