### PR TITLE
Feat/#353 tag count to percent

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/exception/ExceptionAdvice.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import java.util.LinkedHashMap;
@@ -54,6 +55,15 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         log.error("[Method Argument Not Valid] Errors: {}", errors, e);
         return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, CommonErrorStatus._BAD_REQUEST, request, errors);
     }
+
+    @ExceptionHandler
+    public ResponseEntity<Object> handleTypeMismatch(MethodArgumentTypeMismatchException e, WebRequest request) {
+        Map<String, String> errors = Map.of(e.getName(), "형식이 올바르지 않습니다.");
+
+        log.error("[Method Argument Type Mismatch] Parameter: {}, Value: {}", e.getName(), e.getValue(), e);
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, CommonErrorStatus._BAD_REQUEST, request, errors);
+    }
+
     @ExceptionHandler
     public ResponseEntity<Object> exception(Exception e, WebRequest request) {
         log.error("[Unhandled Exception] {}", e.getMessage(), e);

--- a/src/main/java/com/umc/linkyou/config/common/WebConfig.java
+++ b/src/main/java/com/umc/linkyou/config/common/WebConfig.java
@@ -7,10 +7,13 @@ import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.validation.annotation.ApiV2;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @Configuration
@@ -22,6 +25,16 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(currentUserArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new Converter<String, YearMonth>() {
+            @Override
+            public YearMonth convert(String source) {
+                return YearMonth.parse(source);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
@@ -44,7 +44,6 @@ public interface UsersLinkuRepository  extends JpaRepository<UsersLinku, Long>, 
 
     List<UsersLinku> findByUser_IdAndLastViewedAtIsNull(Long userId);
 
-}
     // 해당 기간 유저가 저장한 링크의 감정별 저장 횟수
     @Query("""
             SELECT ul.emotion.emotionId, COUNT(ul)
@@ -71,5 +70,4 @@ public interface UsersLinkuRepository  extends JpaRepository<UsersLinku, Long>, 
             @Param("userId") Long userId,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end);
-
 }

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
@@ -45,3 +45,31 @@ public interface UsersLinkuRepository  extends JpaRepository<UsersLinku, Long>, 
     List<UsersLinku> findByUser_IdAndLastViewedAtIsNull(Long userId);
 
 }
+    // 해당 기간 유저가 저장한 링크의 감정별 저장 횟수
+    @Query("""
+            SELECT ul.emotion.emotionId, COUNT(ul)
+            FROM UsersLinku ul
+            WHERE ul.user.id = :userId
+            AND ul.createdAt >= :start AND ul.createdAt < :end
+            GROUP BY ul.emotion.emotionId
+            """)
+    List<Object[]> countByEmotionForUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+
+    // 해당 기간 유저가 저장한 링크의 상황별 저장 횟수
+    @Query("""
+            SELECT ul.situation.id, COUNT(ul)
+            FROM UsersLinku ul
+            WHERE ul.user.id = :userId
+            AND ul.situation IS NOT NULL
+            AND ul.createdAt >= :start AND ul.createdAt < :end
+            GROUP BY ul.situation.id
+            """)
+    List<Object[]> countBySituationForUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end);
+
+}

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
@@ -3,6 +3,7 @@ package com.umc.linkyou.repository.UserLinkuRepository;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.repository.dto.TagCountRow;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -46,28 +47,28 @@ public interface UsersLinkuRepository  extends JpaRepository<UsersLinku, Long>, 
 
     // 해당 기간 유저가 저장한 링크의 감정별 저장 횟수
     @Query("""
-            SELECT ul.emotion.emotionId, COUNT(ul)
+            SELECT new com.umc.linkyou.repository.dto.TagCountRow(ul.emotion.emotionId, COUNT(ul))
             FROM UsersLinku ul
             WHERE ul.user.id = :userId
             AND ul.emotion IS NOT NULL
             AND ul.createdAt >= :start AND ul.createdAt < :end
             GROUP BY ul.emotion.emotionId
             """)
-    List<Object[]> countByEmotionForUserAndPeriod(
+    List<TagCountRow> countByEmotionForUserAndPeriod(
             @Param("userId") Long userId,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end);
 
     // 해당 기간 유저가 저장한 링크의 상황별 저장 횟수
     @Query("""
-            SELECT ul.situation.id, COUNT(ul)
+            SELECT new com.umc.linkyou.repository.dto.TagCountRow(ul.situation.id, COUNT(ul))
             FROM UsersLinku ul
             WHERE ul.user.id = :userId
             AND ul.situation IS NOT NULL
             AND ul.createdAt >= :start AND ul.createdAt < :end
             GROUP BY ul.situation.id
             """)
-    List<Object[]> countBySituationForUserAndPeriod(
+    List<TagCountRow> countBySituationForUserAndPeriod(
             @Param("userId") Long userId,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end);

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepository.java
@@ -49,6 +49,7 @@ public interface UsersLinkuRepository  extends JpaRepository<UsersLinku, Long>, 
             SELECT ul.emotion.emotionId, COUNT(ul)
             FROM UsersLinku ul
             WHERE ul.user.id = :userId
+            AND ul.emotion IS NOT NULL
             AND ul.createdAt >= :start AND ul.createdAt < :end
             GROUP BY ul.emotion.emotionId
             """)

--- a/src/main/java/com/umc/linkyou/repository/dto/KeywordCountRow.java
+++ b/src/main/java/com/umc/linkyou/repository/dto/KeywordCountRow.java
@@ -1,0 +1,3 @@
+package com.umc.linkyou.repository.dto;
+
+public record KeywordCountRow(String name, Long count) {}

--- a/src/main/java/com/umc/linkyou/repository/dto/TagCountRow.java
+++ b/src/main/java/com/umc/linkyou/repository/dto/TagCountRow.java
@@ -1,0 +1,3 @@
+package com.umc.linkyou.repository.dto;
+
+public record TagCountRow(Long refId, Long count) {}

--- a/src/main/java/com/umc/linkyou/repository/keywordRepository/KeywordMonthlyCountRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/keywordRepository/KeywordMonthlyCountRepository.java
@@ -2,7 +2,6 @@ package com.umc.linkyou.repository.keywordRepository;
 
 import com.umc.linkyou.domain.enums.KeywordType;
 import com.umc.linkyou.domain.log.KeywordMonthlyCount;
-import com.umc.linkyou.service.keyword.KeywordStatRow;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -40,7 +39,7 @@ public interface KeywordMonthlyCountRepository extends JpaRepository<KeywordMont
             @Param("baseMonth") String baseMonth,
             Pageable pageable);
 
-    // 큐레이션 상세: 해당 월 top 감정
+    // 큐레이션 상세: 해당 월 top 감정 or 상황
     @Query("""
             SELECT k
             FROM KeywordMonthlyCount k
@@ -55,15 +54,4 @@ public interface KeywordMonthlyCountRepository extends JpaRepository<KeywordMont
             @Param("type") KeywordType type,
             Pageable pageable);
 
-    // 같은 직업 유저들의 키워드 합산 상위 N건
-    @Query("""
-            SELECT new com.umc.linkyou.service.keyword.KeywordStatRow(k.type, k.refId, SUM(k.count))
-            FROM KeywordMonthlyCount k
-            WHERE k.user.job.id = :jobId
-            GROUP BY k.type, k.refId
-            ORDER BY SUM(k.count) DESC
-            """)
-    List<KeywordStatRow> findTopKeywordByJobId(
-            @Param("jobId") Long jobId,
-            Pageable pageable);
 }

--- a/src/main/java/com/umc/linkyou/repository/mapping/LinkuKeywordRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/mapping/LinkuKeywordRepository.java
@@ -3,6 +3,7 @@ package com.umc.linkyou.repository.mapping;
 import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.mapping.LinkuKeyword;
+import com.umc.linkyou.repository.dto.KeywordCountRow;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,7 +19,7 @@ public interface LinkuKeywordRepository extends JpaRepository<LinkuKeyword, Long
 
     // 해당 월에 같은 직업 유저들이 저장한 링크의 키워드별 등장 횟수 상위 N건
     @Query("""
-            SELECT k.name, COUNT(ul)
+            SELECT new com.umc.linkyou.repository.dto.KeywordCountRow(k.name, COUNT(ul))
             FROM LinkuKeyword lk
             JOIN lk.keyword k
             JOIN lk.linku l
@@ -28,7 +29,7 @@ public interface LinkuKeywordRepository extends JpaRepository<LinkuKeyword, Long
             GROUP BY k.name
             ORDER BY COUNT(ul) DESC
             """)
-    List<Object[]> findTopKeywordNamesByJobIdAndPeriod(
+    List<KeywordCountRow> findTopKeywordNamesByJobIdAndPeriod(
             @Param("jobId") Long jobId,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end,

--- a/src/main/java/com/umc/linkyou/repository/mapping/LinkuKeywordRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/mapping/LinkuKeywordRepository.java
@@ -3,10 +3,34 @@ package com.umc.linkyou.repository.mapping;
 import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.mapping.LinkuKeyword;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface LinkuKeywordRepository extends JpaRepository<LinkuKeyword, Long> {
     boolean existsByLinkuAndKeyword(Linku linku, Keyword keyword);
+
+    // 해당 월에 같은 직업 유저들이 저장한 링크의 키워드별 등장 횟수 상위 N건
+    @Query("""
+            SELECT k.name, COUNT(ul)
+            FROM LinkuKeyword lk
+            JOIN lk.keyword k
+            JOIN lk.linku l
+            JOIN l.usersLinku ul
+            WHERE ul.user.job.id = :jobId
+            AND ul.createdAt >= :start AND ul.createdAt < :end
+            GROUP BY k.name
+            ORDER BY COUNT(ul) DESC
+            """)
+    List<Object[]> findTopKeywordNamesByJobIdAndPeriod(
+            @Param("jobId") Long jobId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            Pageable pageable);
 }

--- a/src/main/java/com/umc/linkyou/service/common/TagNameResolver.java
+++ b/src/main/java/com/umc/linkyou/service/common/TagNameResolver.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class KeywordNameResolver {
+public class TagNameResolver {
 
     private final EmotionMapper emotionMapper;
     private final SituationRepository situationRepository;

--- a/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
@@ -5,7 +5,7 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.repository.keywordRepository.KeywordMonthlyCountRepository;
-import com.umc.linkyou.service.common.KeywordNameResolver;
+import com.umc.linkyou.service.common.TagNameResolver;
 import com.umc.linkyou.service.curation.ment.CurationMentMaterializer;
 import com.umc.linkyou.service.curation.utils.ThumbnailUrlProvider;
 import com.umc.linkyou.service.curation.recommend.external.ExternalRecommendMaterializer;
@@ -46,7 +46,7 @@ public class CurationServiceImpl implements CurationService {
     private final InternalRecommendMaterializer internalRecommendMaterializer;
     private final CurationMentMaterializer curationMentMaterializer;
     private final KeywordMonthlyCountRepository keywordMonthlyCountRepository;
-    private final KeywordNameResolver keywordNameResolver;
+    private final TagNameResolver tagNameResolver;
 
     // 단일 유저의 특정 월 큐레이션 생성
     @Override
@@ -158,7 +158,7 @@ public class CurationServiceImpl implements CurationService {
         List<String> tagNames = keywordMonthlyCountRepository
                 .findTopByUserIdAndBaseMonth(userId, baseMonth, PageRequest.of(0, 3))
                 .stream()
-                .map(kmc -> keywordNameResolver.resolve(kmc.getType(), kmc.getRefId()))
+                .map(kmc -> tagNameResolver.resolve(kmc.getType(), kmc.getRefId()))
                 .toList();
 
         return CurationDetailResponse.builder()

--- a/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationServiceImpl.java
@@ -4,8 +4,6 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
-import com.umc.linkyou.repository.keywordRepository.KeywordMonthlyCountRepository;
-import com.umc.linkyou.service.common.TagNameResolver;
 import com.umc.linkyou.service.curation.ment.CurationMentMaterializer;
 import com.umc.linkyou.service.curation.utils.ThumbnailUrlProvider;
 import com.umc.linkyou.service.curation.recommend.external.ExternalRecommendMaterializer;
@@ -24,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import com.umc.linkyou.web.dto.curation.CurationListResponse;
-import org.springframework.data.domain.PageRequest;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,8 +42,6 @@ public class CurationServiceImpl implements CurationService {
     private final ExternalRecommendMaterializer externalRecommendMaterializer;
     private final InternalRecommendMaterializer internalRecommendMaterializer;
     private final CurationMentMaterializer curationMentMaterializer;
-    private final KeywordMonthlyCountRepository keywordMonthlyCountRepository;
-    private final TagNameResolver tagNameResolver;
 
     // 단일 유저의 특정 월 큐레이션 생성
     @Override
@@ -152,19 +147,9 @@ public class CurationServiceImpl implements CurationService {
             throw new GeneralException(CurationErrorStatus._CURATION_FORBIDDEN);
         }
 
-        String baseMonth = curation.getBaseMonth();
-
-        // 상위 태그 3개 조회
-        List<String> tagNames = keywordMonthlyCountRepository
-                .findTopByUserIdAndBaseMonth(userId, baseMonth, PageRequest.of(0, 3))
-                .stream()
-                .map(kmc -> tagNameResolver.resolve(kmc.getType(), kmc.getRefId()))
-                .toList();
-
         return CurationDetailResponse.builder()
                 .curationId(curation.getCurationId())
                 .month(curation.getBaseMonth())
-                .topTags(tagNames)
                 .headerMent(curation.getHeaderMent())
                 .footerMent(curation.getFooterMent())
                 .mentReady(curation.getHeaderMent() != null && !curation.getHeaderMent().isBlank()

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
@@ -1,14 +1,12 @@
 package com.umc.linkyou.service.keyword;
 
 import com.umc.linkyou.domain.Linku;
-import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
 
 import java.util.List;
 
 public interface KeywordService {
-    List<KeywordRankResponse> getMyTopKeywords(Long userId, String month, int limit);
-
-    List<KeywordRankResponse> getJobTopKeywords(Long userId, int limit);
-
     void saveKeywords(Linku linku, String rawKeywords);
+
+    List<JobKeywordRankResponse> getJobTopKeywords(Long userId, String month, int limit);
 }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
@@ -3,10 +3,11 @@ package com.umc.linkyou.service.keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
 
+import java.time.YearMonth;
 import java.util.List;
 
 public interface KeywordService {
     void saveKeywords(Linku linku, String rawKeywords);
 
-    List<JobKeywordRankResponse> getJobTopKeywords(Long userId, String month, int limit);
+    List<JobKeywordRankResponse> getJobTopKeywords(Long userId, YearMonth month, int limit);
 }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
@@ -62,8 +62,8 @@ public class KeywordServiceImpl implements KeywordService {
                 .findTopKeywordNamesByJobIdAndPeriod(user.getJob().getId(), start, end, PageRequest.of(0, limit))
                 .stream()
                 .map(row -> JobKeywordRankResponse.builder()
-                        .name((String) row[0])
-                        .count((Long) row[1])
+                        .name(row.name())
+                        .count(row.count())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
@@ -47,7 +47,7 @@ public class KeywordServiceImpl implements KeywordService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<JobKeywordRankResponse> getJobTopKeywords(Long userId, String month, int limit) {
+    public List<JobKeywordRankResponse> getJobTopKeywords(Long userId, YearMonth month, int limit) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
 
@@ -55,9 +55,8 @@ public class KeywordServiceImpl implements KeywordService {
             throw new GeneralException(UserErrorStatus._JOB_NOT_SET);
         }
 
-        YearMonth ym = YearMonth.parse(month);
-        LocalDateTime start = ym.atDay(1).atStartOfDay();
-        LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end = month.plusMonths(1).atDay(1).atStartOfDay();
 
         return linkuKeywordRepository
                 .findTopKeywordNamesByJobIdAndPeriod(user.getJob().getId(), start, end, PageRequest.of(0, limit))

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
@@ -1,69 +1,30 @@
 package com.umc.linkyou.service.keyword;
 
-import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.mapping.LinkuKeyword;
-import com.umc.linkyou.repository.keywordRepository.KeywordMonthlyCountRepository;
-import com.umc.linkyou.repository.keywordRepository.KeywordRepository;
 import com.umc.linkyou.repository.mapping.LinkuKeywordRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
-import com.umc.linkyou.service.common.KeywordNameResolver;
-import com.umc.linkyou.service.keyword.KeywordUpsertService;
-import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class KeywordServiceImpl implements KeywordService {
 
-    private final UserRepository userRepository;
-    private final KeywordMonthlyCountRepository keywordMonthlyCountRepository;
-    private final KeywordNameResolver keywordNameResolver;
-    private final KeywordRepository keywordRepository;
     private final LinkuKeywordRepository linkuKeywordRepository;
     private final KeywordUpsertService keywordUpsertService;
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<KeywordRankResponse> getMyTopKeywords(Long userId, String month, int limit) {
-        return keywordMonthlyCountRepository
-                .findTopByUserIdAndBaseMonth(userId, month, PageRequest.of(0, limit))
-                .stream()
-                .map(k -> KeywordRankResponse.builder()
-                        .name(keywordNameResolver.resolve(k.getType(), k.getRefId()))
-                        .count(k.getCount())
-                        .build())
-                .toList();
-    }
-
-    @Override
-    @Transactional(readOnly = true)
-    public List<KeywordRankResponse> getJobTopKeywords(Long userId, int limit) {
-        Users user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-
-        if (user.getJob() == null) {
-            throw new GeneralException(UserErrorStatus._JOB_NOT_SET);
-        }
-
-        return keywordMonthlyCountRepository
-                .findTopKeywordByJobId(user.getJob().getId(), PageRequest.of(0, limit))
-                .stream()
-                .map(row -> KeywordRankResponse.builder()
-                        .name(keywordNameResolver.resolve(row.type(), row.refId()))
-                        .count(row.totalCount())
-                        .build())
-                .toList();
-    }
+    private final UserRepository userRepository;
 
     @Override
     @Transactional
@@ -82,5 +43,29 @@ public class KeywordServiceImpl implements KeywordService {
                 );
             }
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<JobKeywordRankResponse> getJobTopKeywords(Long userId, String month, int limit) {
+        Users user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+
+        if (user.getJob() == null) {
+            throw new GeneralException(UserErrorStatus._JOB_NOT_SET);
+        }
+
+        YearMonth ym = YearMonth.parse(month);
+        LocalDateTime start = ym.atDay(1).atStartOfDay();
+        LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+
+        return linkuKeywordRepository
+                .findTopKeywordNamesByJobIdAndPeriod(user.getJob().getId(), start, end, PageRequest.of(0, limit))
+                .stream()
+                .map(row -> JobKeywordRankResponse.builder()
+                        .name((String) row[0])
+                        .count((Long) row[1])
+                        .build())
+                .toList();
     }
 }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordStatRow.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordStatRow.java
@@ -1,5 +1,0 @@
-package com.umc.linkyou.service.keyword;
-
-import com.umc.linkyou.domain.enums.KeywordType;
-
-public record KeywordStatRow(KeywordType type, Long refId, Long totalCount) {}

--- a/src/main/java/com/umc/linkyou/service/tag/TagService.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagService.java
@@ -2,8 +2,9 @@ package com.umc.linkyou.service.tag;
 
 import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
 
+import java.time.YearMonth;
 import java.util.List;
 
 public interface TagService {
-    List<MyTagRankResponse> getMyTopTags(Long userId, String month, int limit);
+    List<MyTagRankResponse> getMyTopTags(Long userId, YearMonth month, int limit);
 }

--- a/src/main/java/com/umc/linkyou/service/tag/TagService.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagService.java
@@ -1,0 +1,9 @@
+package com.umc.linkyou.service.tag;
+
+import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
+
+import java.util.List;
+
+public interface TagService {
+    List<MyTagRankResponse> getMyTopTags(Long userId, String month, int limit);
+}

--- a/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
@@ -37,11 +37,11 @@ public class TagServiceImpl implements TagService {
 
         List<TagStatRow> emotionCounts = usersLinkuRepository
                 .countByEmotionForUserAndPeriod(userId, start, end).stream()
-                .map(row -> new TagStatRow(KeywordType.EMOTION, (Long) row[0], (Long) row[1]))
+                .map(row -> new TagStatRow(KeywordType.EMOTION, row.refId(), row.count()))
                 .toList();
         List<TagStatRow> situationCounts = usersLinkuRepository
                 .countBySituationForUserAndPeriod(userId, start, end).stream()
-                .map(row -> new TagStatRow(KeywordType.SITUATION, (Long) row[0], (Long) row[1]))
+                .map(row -> new TagStatRow(KeywordType.SITUATION, row.refId(), row.count()))
                 .toList();
 
         long total = Stream.concat(emotionCounts.stream(), situationCounts.stream())

--- a/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
@@ -32,9 +32,8 @@ public class TagServiceImpl implements TagService {
             throw new GeneralException(UserErrorStatus._USER_NOT_FOUND);
         }
 
-        YearMonth ym = YearMonth.parse(month);
-        LocalDateTime start = ym.atDay(1).atStartOfDay();
-        LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime start = month.atDay(1).atStartOfDay();
+        LocalDateTime end = month.plusMonths(1).atDay(1).atStartOfDay();
 
         List<TagStatRow> emotionCounts = usersLinkuRepository
                 .countByEmotionForUserAndPeriod(userId, start, end).stream()

--- a/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
@@ -27,9 +27,10 @@ public class TagServiceImpl implements TagService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<MyTagRankResponse> getMyTopTags(Long userId, String month, int limit) {
-        userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+    public List<MyTagRankResponse> getMyTopTags(Long userId, YearMonth month, int limit) {
+        if (!userRepository.existsById(userId)) {
+            throw new GeneralException(UserErrorStatus._USER_NOT_FOUND);
+        }
 
         YearMonth ym = YearMonth.parse(month);
         LocalDateTime start = ym.atDay(1).atStartOfDay();

--- a/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagServiceImpl.java
@@ -1,0 +1,60 @@
+package com.umc.linkyou.service.tag;
+
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.enums.KeywordType;
+import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.common.TagNameResolver;
+import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+public class TagServiceImpl implements TagService {
+
+    private final UserRepository userRepository;
+    private final UsersLinkuRepository usersLinkuRepository;
+    private final TagNameResolver tagNameResolver;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MyTagRankResponse> getMyTopTags(Long userId, String month, int limit) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+
+        YearMonth ym = YearMonth.parse(month);
+        LocalDateTime start = ym.atDay(1).atStartOfDay();
+        LocalDateTime end = ym.plusMonths(1).atDay(1).atStartOfDay();
+
+        List<TagStatRow> emotionCounts = usersLinkuRepository
+                .countByEmotionForUserAndPeriod(userId, start, end).stream()
+                .map(row -> new TagStatRow(KeywordType.EMOTION, (Long) row[0], (Long) row[1]))
+                .toList();
+        List<TagStatRow> situationCounts = usersLinkuRepository
+                .countBySituationForUserAndPeriod(userId, start, end).stream()
+                .map(row -> new TagStatRow(KeywordType.SITUATION, (Long) row[0], (Long) row[1]))
+                .toList();
+
+        long total = Stream.concat(emotionCounts.stream(), situationCounts.stream())
+                .mapToLong(TagStatRow::totalCount)
+                .sum();
+
+        return Stream.concat(emotionCounts.stream(), situationCounts.stream())
+                .sorted(Comparator.comparingLong(TagStatRow::totalCount).reversed())
+                .limit(limit)
+                .map(row -> MyTagRankResponse.builder()
+                        .name(tagNameResolver.resolve(row.type(), row.refId()))
+                        .percent(total == 0 ? 0 : (int) Math.round(row.totalCount() * 100.0 / total))
+                        .build())
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/linkyou/service/tag/TagStatRow.java
+++ b/src/main/java/com/umc/linkyou/service/tag/TagStatRow.java
@@ -1,0 +1,5 @@
+package com.umc.linkyou.service.tag;
+
+import com.umc.linkyou.domain.enums.KeywordType;
+
+public record TagStatRow(KeywordType type, Long refId, Long totalCount) {}

--- a/src/main/java/com/umc/linkyou/web/api/CurationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/CurationApi.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "curation-controller", description = "큐레이션 관련 API")
+@Tag(name = "큐레이션 API", description = "큐레이션과 관련 된 API 입니다")
 @RequestMapping("/curations")
 public interface CurationApi {
 

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "folder-controller", description = "폴더 관련 API")
+@Tag(name = "폴더 API", description = "폴더와 관련 된 API 입니다")
 @RequestMapping("/folders")
 public interface FolderApi {
 

--- a/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/InvitationApi.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.*;
 
-@Tag(name = "invitation-controller", description = "초대 관련 API")
+@Tag(name = "초대장 API", description = "공유 폴더에 참가 가능한 초대장과 관련 된 API 입니다")
 @RequestMapping("/invitations")
 public interface InvitationApi {
 

--- a/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @Tag(name = "키워드 API", description = "링크 키워드 통계 관련 API")
@@ -24,7 +25,7 @@ public interface KeywordApi {
     @GetMapping("/job")
     ResponseEntity<ApiResponse<List<JobKeywordRankResponse>>> getJobTopKeywords(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
+            @RequestParam YearMonth month,
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit
     );
 }

--- a/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
@@ -5,7 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
-import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -15,24 +15,16 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "keyword-controller", description = "키워드 통계 관련 API")
+@Tag(name = "키워드 API", description = "링크 키워드 통계 관련 API")
 @RequestMapping("/keywords")
 public interface KeywordApi {
 
-    @Operation(summary = "내 월별 상위 키워드 조회")
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
-    @GetMapping("/my")
-    ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getMyTopKeywords(
-            @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
-            @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit
-    );
-
-    @Operation(summary = "같은 직업 유저들의 상위 키워드 조회")
+    @Operation(summary = "같은 직업 유저들이 해당 월에 저장한 링크의 상위 키워드 조회")
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND, UserErrorStatus._JOB_NOT_SET})
     @GetMapping("/job")
-    ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getJobTopKeywords(
+    ResponseEntity<ApiResponse<List<JobKeywordRankResponse>>> getJobTopKeywords(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "15") @Min(1) @Max(50) int limit
+            @RequestParam String month,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit
     );
 }

--- a/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/SharedFolderApi.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
-@Tag(name = "shared-folder-controller", description = "공유 받은 폴더 관련 API")
+@Tag(name = "공유 받은 폴더 API", description = "공유 받은 폴더 관련 API")
 @RequestMapping("/folders/shared")
 public interface SharedFolderApi {
 

--- a/src/main/java/com/umc/linkyou/web/api/TagApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/TagApi.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @Tag(name = "태그 API", description = "태그(감정·상황) 통계 관련 API")
@@ -24,7 +25,7 @@ public interface TagApi {
     @GetMapping("/my")
     ResponseEntity<ApiResponse<List<MyTagRankResponse>>> getMyTopTags(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
+            @RequestParam YearMonth month,
             @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit
     );
 }

--- a/src/main/java/com/umc/linkyou/web/api/TagApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/TagApi.java
@@ -1,0 +1,30 @@
+package com.umc.linkyou.web.api;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
+import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "태그 API", description = "태그(감정·상황) 통계 관련 API")
+@RequestMapping("/tags")
+public interface TagApi {
+
+    @Operation(summary = "내 월별 상위 태그 조회")
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @GetMapping("/my")
+    ResponseEntity<ApiResponse<List<MyTagRankResponse>>> getMyTopTags(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit
+    );
+}

--- a/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @ApiV1
@@ -26,7 +27,7 @@ public class KeywordController implements KeywordApi {
     @Override
     public ResponseEntity<ApiResponse<List<JobKeywordRankResponse>>> getJobTopKeywords(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
+            @RequestParam YearMonth month,
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit) {
         return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userDetails.getUserId(), month, limit)));
     }

--- a/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
@@ -6,7 +6,7 @@ import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.service.keyword.KeywordService;
 import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.api.KeywordApi;
-import com.umc.linkyou.web.dto.keyword.KeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -24,12 +24,10 @@ public class KeywordController implements KeywordApi {
     private final KeywordService keywordService;
 
     @Override
-    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getMyTopKeywords(@CurrentUser CustomUserDetails userDetails, @RequestParam String month, @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getMyTopKeywords(userDetails.getUserId(), month, limit)));
-    }
-
-    @Override
-    public ResponseEntity<ApiResponse<List<KeywordRankResponse>>> getJobTopKeywords(@CurrentUser CustomUserDetails userDetails, @RequestParam(defaultValue = "15") @Min(1) @Max(50) int limit) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userDetails.getUserId(), limit)));
+    public ResponseEntity<ApiResponse<List<JobKeywordRankResponse>>> getJobTopKeywords(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userDetails.getUserId(), month, limit)));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/controller/TagController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/TagController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.YearMonth;
 import java.util.List;
 
 @ApiV1
@@ -26,7 +27,7 @@ public class TagController implements TagApi {
     @Override
     public ResponseEntity<ApiResponse<List<MyTagRankResponse>>> getMyTopTags(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestParam String month,
+            @RequestParam YearMonth month,
             @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit) {
         return ResponseEntity.ok(ApiResponse.onSuccess(tagService.getMyTopTags(userDetails.getUserId(), month, limit)));
     }

--- a/src/main/java/com/umc/linkyou/web/controller/TagController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/TagController.java
@@ -1,0 +1,33 @@
+package com.umc.linkyou.web.controller;
+
+import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.jwt.CurrentUser;
+import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.service.tag.TagService;
+import com.umc.linkyou.validation.annotation.ApiV1;
+import com.umc.linkyou.web.api.TagApi;
+import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@ApiV1
+@Validated
+@RequiredArgsConstructor
+public class TagController implements TagApi {
+
+    private final TagService tagService;
+
+    @Override
+    public ResponseEntity<ApiResponse<List<MyTagRankResponse>>> getMyTopTags(
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam String month,
+            @RequestParam(defaultValue = "3") @Min(1) @Max(50) int limit) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(tagService.getMyTopTags(userDetails.getUserId(), month, limit)));
+    }
+}

--- a/src/main/java/com/umc/linkyou/web/dto/curation/CurationDetailResponse.java
+++ b/src/main/java/com/umc/linkyou/web/dto/curation/CurationDetailResponse.java
@@ -3,14 +3,11 @@ package com.umc.linkyou.web.dto.curation;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 @Builder
 public class CurationDetailResponse {
     private Long curationId;
     private String month;
-    private List<String> topTags;
     private String headerMent;
     private String footerMent;
     private boolean mentReady;

--- a/src/main/java/com/umc/linkyou/web/dto/keyword/JobKeywordRankResponse.java
+++ b/src/main/java/com/umc/linkyou/web/dto/keyword/JobKeywordRankResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class KeywordRankResponse {
+public class JobKeywordRankResponse {
     private String name;
     private long count;
 }

--- a/src/main/java/com/umc/linkyou/web/dto/tag/MyTagRankResponse.java
+++ b/src/main/java/com/umc/linkyou/web/dto/tag/MyTagRankResponse.java
@@ -1,0 +1,11 @@
+package com.umc.linkyou.web.dto.tag;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MyTagRankResponse {
+    private String name;
+    private int percent;
+}

--- a/src/test/java/com/umc/linkyou/service/curation/CurationServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/curation/CurationServiceTest.java
@@ -6,7 +6,6 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Curation;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.repository.curationRepository.CurationRepository;
-import com.umc.linkyou.repository.keywordRepository.KeywordMonthlyCountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.service.curation.utils.ThumbnailUrlProvider;
 import com.umc.linkyou.web.dto.curation.CurationDetailResponse;
@@ -39,7 +38,6 @@ class CurationServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private CurationRepository curationRepository;
     @Mock private ThumbnailUrlProvider thumbnailUrlProvider;
-    @Mock private KeywordMonthlyCountRepository keywordMonthlyCountRepository;
 
     @Nested
     @DisplayName("큐레이션 생성")
@@ -110,7 +108,6 @@ class CurationServiceTest {
 
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(curationRepository.findById(CURATION_ID)).willReturn(Optional.of(curation));
-                given(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonth(eq(USER_ID), eq(MONTH),any())).willReturn(List.of());
 
                 CurationDetailResponse result = curationService.getCurationDetail(USER_ID, CURATION_ID);
 

--- a/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.Job;
+import com.umc.linkyou.repository.dto.KeywordCountRow;
 import com.umc.linkyou.repository.mapping.LinkuKeywordRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
@@ -58,7 +59,7 @@ class KeywordServiceTest {
                 Users user = Users.builder().id(USER_ID).job(job).build();
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(linkuKeywordRepository.findTopKeywordNamesByJobIdAndPeriod(eq(JOB_ID), eq(MONTH_START), eq(MONTH_END), any()))
-                        .willReturn(List.<Object[]>of(new Object[]{"스프링", 15L}));
+                        .willReturn(List.of(new KeywordCountRow("스프링", 15L)));
 
                 List<JobKeywordRankResponse> result = keywordService.getJobTopKeywords(USER_ID, BASE_MONTH, 15);
 

--- a/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
@@ -1,0 +1,113 @@
+package com.umc.linkyou.service.keyword;
+
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.classification.Job;
+import com.umc.linkyou.repository.mapping.LinkuKeywordRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("KeywordService 단위 테스트")
+class KeywordServiceTest {
+
+    private static final long USER_ID = 48L;
+    private static final long UNKNOWN_USER_ID = 999L;
+    private static final long JOB_ID = 7L;
+    private static final String BASE_MONTH = "2026-03";
+    private static final LocalDateTime MONTH_START = YearMonth.parse(BASE_MONTH).atDay(1).atStartOfDay();
+    private static final LocalDateTime MONTH_END = YearMonth.parse(BASE_MONTH).plusMonths(1).atDay(1).atStartOfDay();
+
+    @InjectMocks private KeywordServiceImpl keywordService;
+
+    @Mock private LinkuKeywordRepository linkuKeywordRepository;
+    @Mock private KeywordUpsertService keywordUpsertService;
+    @Mock private UserRepository userRepository;
+
+    @Nested
+    @DisplayName("getJobTopKeywords")
+    class GetJobTopKeywords {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("직업이_설정된_유저_조회_시_같은_직업군이_해당_월에_저장한_링크의_상위_키워드를_반환한다")
+            void 직업이_설정된_유저_조회_시_같은_직업군이_해당_월에_저장한_링크의_상위_키워드를_반환한다() {
+                Job job = Job.builder().id(JOB_ID).name("개발자").build();
+                Users user = Users.builder().id(USER_ID).job(job).build();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(linkuKeywordRepository.findTopKeywordNamesByJobIdAndPeriod(eq(JOB_ID), eq(MONTH_START), eq(MONTH_END), any()))
+                        .willReturn(List.<Object[]>of(new Object[]{"스프링", 15L}));
+
+                List<JobKeywordRankResponse> result = keywordService.getJobTopKeywords(USER_ID, BASE_MONTH, 15);
+
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getName()).isEqualTo("스프링");
+                assertThat(result.get(0).getCount()).isEqualTo(15L);
+            }
+
+            @Test
+            @DisplayName("같은_직업군이_해당_월에_저장한_링크의_키워드_집계가_없을_시_빈_목록을_반환한다")
+            void 같은_직업군이_해당_월에_저장한_링크의_키워드_집계가_없을_시_빈_목록을_반환한다() {
+                Job job = Job.builder().id(JOB_ID).name("개발자").build();
+                Users user = Users.builder().id(USER_ID).job(job).build();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(linkuKeywordRepository.findTopKeywordNamesByJobIdAndPeriod(eq(JOB_ID), eq(MONTH_START), eq(MONTH_END), any()))
+                        .willReturn(List.of());
+
+                List<JobKeywordRankResponse> result = keywordService.getJobTopKeywords(USER_ID, BASE_MONTH, 15);
+
+                assertThat(result).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다")
+            void 존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다() {
+                given(userRepository.findById(UNKNOWN_USER_ID)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> keywordService.getJobTopKeywords(UNKNOWN_USER_ID, BASE_MONTH, 15))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+            }
+
+            @Test
+            @DisplayName("직업이_설정되지_않은_유저가_호출_시_JOB_NOT_SET_예외를_던진다")
+            void 직업이_설정되지_않은_유저가_호출_시_JOB_NOT_SET_예외를_던진다() {
+                given(userRepository.findById(USER_ID))
+                        .willReturn(Optional.of(Users.builder().id(USER_ID).job(null).build()));
+
+                assertThatThrownBy(() -> keywordService.getJobTopKeywords(USER_ID, BASE_MONTH, 15))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(UserErrorStatus._JOB_NOT_SET));
+            }
+        }
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/keyword/KeywordServiceTest.java
@@ -33,9 +33,9 @@ class KeywordServiceTest {
     private static final long USER_ID = 48L;
     private static final long UNKNOWN_USER_ID = 999L;
     private static final long JOB_ID = 7L;
-    private static final String BASE_MONTH = "2026-03";
-    private static final LocalDateTime MONTH_START = YearMonth.parse(BASE_MONTH).atDay(1).atStartOfDay();
-    private static final LocalDateTime MONTH_END = YearMonth.parse(BASE_MONTH).plusMonths(1).atDay(1).atStartOfDay();
+    private static final YearMonth BASE_MONTH = YearMonth.parse("2026-03");
+    private static final LocalDateTime MONTH_START = BASE_MONTH.atDay(1).atStartOfDay();
+    private static final LocalDateTime MONTH_END = BASE_MONTH.plusMonths(1).atDay(1).atStartOfDay();
 
     @InjectMocks private KeywordServiceImpl keywordService;
 

--- a/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.enums.KeywordType;
 import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
+import com.umc.linkyou.repository.dto.TagCountRow;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.service.common.TagNameResolver;
 import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
@@ -52,13 +53,13 @@ class TagServiceTest {
             void 이번_달_저장한_감정과_상황_카운트를_합산해_전체_합계_대비_퍼센트로_반환한다() {
                 given(userRepository.existsById(USER_ID)).willReturn(true);
                 given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
-                        .willReturn(List.<Object[]>of(
-                                new Object[]{1L, 5L},
-                                new Object[]{2L, 2L}
+                        .willReturn(List.of(
+                                new TagCountRow(1L, 5L),
+                                new TagCountRow(2L, 2L)
                         ));
                 given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
-                        .willReturn(List.<Object[]>of(
-                                new Object[]{10L, 3L}
+                        .willReturn(List.of(
+                                new TagCountRow(10L, 3L)
                         ));
                 given(tagNameResolver.resolve(KeywordType.EMOTION, 1L)).willReturn("즐거움");
                 given(tagNameResolver.resolve(KeywordType.SITUATION, 10L)).willReturn("출근길");
@@ -80,13 +81,13 @@ class TagServiceTest {
             void 종류가_limit보다_많을_시_상위_limit개만_반환한다() {
                 given(userRepository.existsById(USER_ID)).willReturn(true);
                 given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
-                        .willReturn(List.<Object[]>of(
-                                new Object[]{1L, 5L},
-                                new Object[]{2L, 2L}
+                        .willReturn(List.of(
+                                new TagCountRow(1L, 5L),
+                                new TagCountRow(2L, 2L)
                         ));
                 given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
-                        .willReturn(List.<Object[]>of(
-                                new Object[]{10L, 3L}
+                        .willReturn(List.of(
+                                new TagCountRow(10L, 3L)
                         ));
                 given(tagNameResolver.resolve(KeywordType.EMOTION, 1L)).willReturn("즐거움");
 

--- a/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
@@ -2,7 +2,6 @@ package com.umc.linkyou.service.tag;
 
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
-import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.KeywordType;
 import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
@@ -19,7 +18,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -31,9 +29,9 @@ class TagServiceTest {
 
     private static final long USER_ID = 48L;
     private static final long UNKNOWN_USER_ID = 999L;
-    private static final String BASE_MONTH = "2026-03";
-    private static final LocalDateTime MONTH_START = YearMonth.parse(BASE_MONTH).atDay(1).atStartOfDay();
-    private static final LocalDateTime MONTH_END = YearMonth.parse(BASE_MONTH).plusMonths(1).atDay(1).atStartOfDay();
+    private static final YearMonth BASE_MONTH = YearMonth.parse("2026-03");
+    private static final LocalDateTime MONTH_START = BASE_MONTH.atDay(1).atStartOfDay();
+    private static final LocalDateTime MONTH_END = BASE_MONTH.plusMonths(1).atDay(1).atStartOfDay();
 
     @InjectMocks private TagServiceImpl tagService;
 

--- a/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
@@ -52,7 +52,7 @@ class TagServiceTest {
             @Test
             @DisplayName("이번_달_저장한_감정과_상황_카운트를_합산해_전체_합계_대비_퍼센트로_반환한다")
             void 이번_달_저장한_감정과_상황_카운트를_합산해_전체_합계_대비_퍼센트로_반환한다() {
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(userRepository.existsById(USER_ID)).willReturn(true);
                 given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
                         .willReturn(List.<Object[]>of(
                                 new Object[]{1L, 5L},
@@ -80,7 +80,7 @@ class TagServiceTest {
             @Test
             @DisplayName("종류가_limit보다_많을_시_상위_limit개만_반환한다")
             void 종류가_limit보다_많을_시_상위_limit개만_반환한다() {
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(userRepository.existsById(USER_ID)).willReturn(true);
                 given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
                         .willReturn(List.<Object[]>of(
                                 new Object[]{1L, 5L},
@@ -102,7 +102,7 @@ class TagServiceTest {
             @Test
             @DisplayName("이번_달_저장한_기록이_없을_시_빈_목록을_반환한다")
             void 이번_달_저장한_기록이_없을_시_빈_목록을_반환한다() {
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(userRepository.existsById(USER_ID)).willReturn(true);
                 given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
                         .willReturn(List.of());
                 given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
@@ -121,7 +121,7 @@ class TagServiceTest {
             @Test
             @DisplayName("존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다")
             void 존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다() {
-                given(userRepository.findById(UNKNOWN_USER_ID)).willReturn(Optional.empty());
+                given(userRepository.existsById(UNKNOWN_USER_ID)).willReturn(false);
 
                 assertThatThrownBy(() -> tagService.getMyTopTags(UNKNOWN_USER_ID, BASE_MONTH, 3))
                         .isInstanceOf(GeneralException.class)

--- a/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/tag/TagServiceTest.java
@@ -1,0 +1,133 @@
+package com.umc.linkyou.service.tag;
+
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.KeywordType;
+import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
+import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.common.TagNameResolver;
+import com.umc.linkyou.web.dto.tag.MyTagRankResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagService 단위 테스트")
+class TagServiceTest {
+
+    private static final long USER_ID = 48L;
+    private static final long UNKNOWN_USER_ID = 999L;
+    private static final String BASE_MONTH = "2026-03";
+    private static final LocalDateTime MONTH_START = YearMonth.parse(BASE_MONTH).atDay(1).atStartOfDay();
+    private static final LocalDateTime MONTH_END = YearMonth.parse(BASE_MONTH).plusMonths(1).atDay(1).atStartOfDay();
+
+    @InjectMocks private TagServiceImpl tagService;
+
+    @Mock private UserRepository userRepository;
+    @Mock private UsersLinkuRepository usersLinkuRepository;
+    @Mock private TagNameResolver tagNameResolver;
+
+    @Nested
+    @DisplayName("getMyTopTags")
+    class GetMyTopTags {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("이번_달_저장한_감정과_상황_카운트를_합산해_전체_합계_대비_퍼센트로_반환한다")
+            void 이번_달_저장한_감정과_상황_카운트를_합산해_전체_합계_대비_퍼센트로_반환한다() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.<Object[]>of(
+                                new Object[]{1L, 5L},
+                                new Object[]{2L, 2L}
+                        ));
+                given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.<Object[]>of(
+                                new Object[]{10L, 3L}
+                        ));
+                given(tagNameResolver.resolve(KeywordType.EMOTION, 1L)).willReturn("즐거움");
+                given(tagNameResolver.resolve(KeywordType.SITUATION, 10L)).willReturn("출근길");
+                given(tagNameResolver.resolve(KeywordType.EMOTION, 2L)).willReturn("슬픔");
+
+                List<MyTagRankResponse> result = tagService.getMyTopTags(USER_ID, BASE_MONTH, 3);
+
+                assertThat(result).hasSize(3);
+                assertThat(result.get(0).getName()).isEqualTo("즐거움");
+                assertThat(result.get(0).getPercent()).isEqualTo(50);
+                assertThat(result.get(1).getName()).isEqualTo("출근길");
+                assertThat(result.get(1).getPercent()).isEqualTo(30);
+                assertThat(result.get(2).getName()).isEqualTo("슬픔");
+                assertThat(result.get(2).getPercent()).isEqualTo(20);
+            }
+
+            @Test
+            @DisplayName("종류가_limit보다_많을_시_상위_limit개만_반환한다")
+            void 종류가_limit보다_많을_시_상위_limit개만_반환한다() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.<Object[]>of(
+                                new Object[]{1L, 5L},
+                                new Object[]{2L, 2L}
+                        ));
+                given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.<Object[]>of(
+                                new Object[]{10L, 3L}
+                        ));
+                given(tagNameResolver.resolve(KeywordType.EMOTION, 1L)).willReturn("즐거움");
+
+                List<MyTagRankResponse> result = tagService.getMyTopTags(USER_ID, BASE_MONTH, 1);
+
+                assertThat(result).hasSize(1);
+                assertThat(result.get(0).getName()).isEqualTo("즐거움");
+                assertThat(result.get(0).getPercent()).isEqualTo(50);
+            }
+
+            @Test
+            @DisplayName("이번_달_저장한_기록이_없을_시_빈_목록을_반환한다")
+            void 이번_달_저장한_기록이_없을_시_빈_목록을_반환한다() {
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(Users.builder().id(USER_ID).build()));
+                given(usersLinkuRepository.countByEmotionForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.of());
+                given(usersLinkuRepository.countBySituationForUserAndPeriod(USER_ID, MONTH_START, MONTH_END))
+                        .willReturn(List.of());
+
+                List<MyTagRankResponse> result = tagService.getMyTopTags(USER_ID, BASE_MONTH, 3);
+
+                assertThat(result).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다")
+            void 존재하지_않는_userId로_호출_시_USER_NOT_FOUND_예외를_던진다() {
+                given(userRepository.findById(UNKNOWN_USER_ID)).willReturn(Optional.empty());
+
+                assertThatThrownBy(() -> tagService.getMyTopTags(UNKNOWN_USER_ID, BASE_MONTH, 3))
+                        .isInstanceOf(GeneralException.class)
+                        .satisfies(ex -> assertThat(((GeneralException) ex).getCode())
+                                .isEqualTo(UserErrorStatus._USER_NOT_FOUND));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> Close #353 

---

## 📌 작업 내용

  ### 1️⃣ Non-Functional Requirement
  - 폴더, 큐레이션 관련 Swagger `@Tag` 이름 한국어로 변경

  ### 2️⃣Functional Requirement
 #### 1. `/tags/my`  
  - 기존: `KeywordMonthlyCount`(홈 화면 AI 감정·상황 추천 조회 로그) 기반으로 `count` 그대로 반환
  - 변경: 유저가 그 달에 **저장한 링크**(`UsersLinku`)의 감정/상황을 직접 집계해 `percent`로 반환 
    - `percent = round(해당 태그 count / 그 달 전체 count 합 × 100)`

  #### 2. `/keywords/job`  
  - 기존: `KeywordMonthlyCount` 기반으로 감정/상황 랭킹 반환  
  - 변경: **같은 직업 유저들이 그 달에 저장한 링크의 키워드**(`LinkuKeyword`)를 집계하도록 변경 

---

## 🧪 테스트 결과
로컬 테스트 확인 완료

---

## 📎 참고 사항 (선택)
키워드로 혼합해 사용하고 있던 용어를 태그와 키워드로 분리했습니다.

> 키워드: 링크 생성에서 만들어지는 #해시태그 형식의 단어
> 태그: 상황/감정

키워드와 태그를 분리하는 과정에서 기존 키워드 기반 직업 랭킹이 #해시태그 키워드를 기반으로 해야 하는데 상황/감정 키워드를 기반으로 하고 있는 것을 발견해 키워드 기반으로 변경했습니다.

키워드 카운트 테이블은 정규화 과정을 거쳐 삭제 예정이라 네이밍 변경을 하지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 사용자 월간 상위 태그(감정·상황)를 비율과 함께 조회할 수 있습니다. (`/tags/my`)
- **변경 사항**
  - 키워드 개인 상위 조회 기능이 제거되었습니다.
  - 직업 기준 키워드 순위는 월 선택(YearMonth)과 기본 `limit=10`으로 제공되며 응답 형식이 변경되었습니다.
  - 큐레이션 상세 응답에서 `topTags`가 제거되고 `headerMent/footerMent/mentReady`로 제공됩니다.
- **문서화**
  - API 문서의 명칭/설명이 한국어 기준으로 정비되었습니다.
- **예외 처리**
  - 잘못된 파라미터 타입에 대한 400 응답이 추가되었습니다.
- **테스트**
  - 키워드/태그 관련 단위 테스트가 추가·보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->