### PR TITLE
fix: #370 카테고리 수정 추가

### DIFF
--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.service.Linku;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
@@ -210,6 +211,26 @@ public class LinkuService {
             linkuModified = true;
         }
 
+        // 5-1. 카테고리(중분류) 변경
+        //      Linku는 동일 URL을 저장한 모든 유저가 공유하는 엔티티이므로 category 자체를 바꾸지 않고,
+        //      이 유저 소유의 해당 카테고리 중분류(루트) 폴더로 LinkuFolder 매핑만 이동한다.
+        LinkuFolder linkuFolder = linkuFolderRepository
+                .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId())
+                .orElse(null);
+
+        if (dto.getCategoryId() != null) {
+            Category newCategory = categoryRepository.findById(dto.getCategoryId())
+                    .orElseThrow(() -> new GeneralException(CategoryErrorStatus._CATEGORY_NOT_FOUND));
+            Folder targetFolder = usersFolderRepository.findFolderByUserIdAndCategory(userId, newCategory)
+                    .orElseThrow(() -> new GeneralException(FolderErrorStatus._FOLDER_NOT_FOUND));
+
+            if (linkuFolder == null) {
+                throw new GeneralException(LinkuErrorStatus._USER_LINKU_NOT_FOUND);
+            }
+            linkuFolder.updateFolder(targetFolder);
+            linkuFolderRepository.save(linkuFolder);
+        }
+
         // 6. 제목(title) 변경 (개인화: 공용 Linku가 아닌 이 유저의 UsersLinku.title만 변경)
         if (dto.getTitle() != null) {
             usersLinku.updateTitle(dto.getTitle());
@@ -229,11 +250,10 @@ public class LinkuService {
         if (linkuModified) linkuRepository.save(linku);
         if (usersLinkuModified) usersLinkuRepository.save(usersLinku);
 
-        // 8. 최신 폴더 매핑 정보, 카테고리, 도메인 등 다시 조회해 응답 준비
-        LinkuFolder linkuFolder = linkuFolderRepository
-                .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId())
-                .orElse(null);
-        Category category = linku.getCategory();
+        // 8. 카테고리, 도메인 등 응답 준비
+        //    categoryId는 공유 Linku가 아니라 이 유저가 속한 폴더(중분류) 기준으로 내려준다.
+        //    (폴더 매핑이 없는 예외적인 경우에만 공유 Linku의 category로 대체)
+        Category category = linkuFolder != null ? linkuFolder.getFolder().getCategory() : linku.getCategory();
         Domain domain = linku.getDomain();
 
         // 9. DTO 변환해 반환 (모든 정보 최신상태로 응답)

--- a/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
@@ -85,14 +86,20 @@ public interface LinkuApi {
     @Operation(
             summary = "링크 수정",
             description = """
-                    기존 링크의 정보(메모, 감정, 상황, 도메인, 제목, 대표 이미지)를 수정합니다. 모든 필드는 선택이며, 보낸 필드만 변경됩니다.
+                    기존 링크의 정보(메모, 감정, 상황, 도메인, 카테고리, 제목, 대표 이미지)를 수정합니다. 모든 필드는 선택이며, 보낸 필드만 변경됩니다.
 
                     - **image** (선택): 새 이미지를 첨부하면 기존에 등록돼 있던 이미지(있는 경우)는 S3에서 삭제되고 새 이미지로 교체됩니다. 첨부하지 않으면 기존 이미지가 그대로 유지됩니다.
+                    - **categoryId** (선택): 카테고리를 변경하면 링크(Linku)의 공유 카테고리 자체는 바뀌지 않고, 내 폴더 중 해당 카테고리의 중분류(루트) 폴더로 이 링크가 이동합니다. 소분류로는 이동하지 않습니다.
                     - URL 자체는 이 API로 변경할 수 없습니다.
-                    - 폴더 이동은 이 API로 처리하지 않고 별도의 링크 폴더 이동 API(`PATCH /linku/{linkuId}/folder`)를 사용해야 합니다.
+                    - 소분류 폴더로의 이동은 이 API로 처리하지 않고 별도의 링크 폴더 이동 API(`PATCH /linku/{linkuId}/folder`)를 사용해야 합니다.
                     """
     )
-    @ApiErrorCode(linkuErrorStatus = {LinkuErrorStatus._LINKU_NOT_FOUND, LinkuErrorStatus._USER_LINKU_NOT_FOUND}, errorStatus = {ErrorStatus._DOMAIN_NOT_FOUND})
+    @ApiErrorCode(
+            linkuErrorStatus = {LinkuErrorStatus._LINKU_NOT_FOUND, LinkuErrorStatus._USER_LINKU_NOT_FOUND},
+            errorStatus = {ErrorStatus._DOMAIN_NOT_FOUND},
+            categoryErrorStatus = {CategoryErrorStatus._CATEGORY_NOT_FOUND},
+            folderErrorStatus = {FolderErrorStatus._FOLDER_NOT_FOUND}
+    )
     @PatchMapping(value = "/{linkuId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ApiResponse<LinkuResponseDTO.LinkuResultDTO> updateLinku(
             @CurrentUser CustomUserDetails userDetails,
@@ -101,6 +108,7 @@ public interface LinkuApi {
             @RequestParam(required = false) Long emotionId,
             @RequestParam(required = false) Long situationId,
             @RequestParam(required = false) Long domainId,
+            @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) MultipartFile image
     );

--- a/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
@@ -67,6 +67,7 @@ public class LinkuController implements LinkuApi {
             @RequestParam(required = false) Long emotionId,
             @RequestParam(required = false) Long situationId,
             @RequestParam(required = false) Long domainId,
+            @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) String title,
             @RequestParam(required = false) MultipartFile image) {
         LinkuRequestDTO.LinkuUpdateDTO updateDTO = LinkuRequestDTO.LinkuUpdateDTO.builder()
@@ -74,6 +75,7 @@ public class LinkuController implements LinkuApi {
                 .emotionId(emotionId)
                 .situationId(situationId)
                 .domainId(domainId)
+                .categoryId(categoryId)
                 .title(title)
                 .image(image)
                 .build();

--- a/src/main/java/com/umc/linkyou/web/dto/linku/LinkuRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/linku/LinkuRequestDTO.java
@@ -46,6 +46,9 @@ public class LinkuRequestDTO {
         @Schema(example = "1", description = "도메인(domain) ID")
         private Long domainId;
 
+        @Schema(example = "5", description = "변경할 카테고리 ID. 내 폴더 중 해당 카테고리의 중분류(루트) 폴더로 링크가 이동합니다.")
+        private Long categoryId;
+
         @Schema(example = "수정된 제목", description = "링크의 제목(TITLE)")
         private String title;
 

--- a/src/test/java/com/umc/linkyou/service/Linku/LinkuServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/Linku/LinkuServiceTest.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.service.Linku;
 
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
@@ -490,6 +491,181 @@ class LinkuServiceTest {
                 // then
                 assertEquals("https://cdn.example.com/old.jpg", usersLinku.getImageUrl());
                 verify(awsS3Service, never()).replaceFile(any(), any(), any());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("updateLinku() - 카테고리(중분류) 변경")
+    class UpdateLinkuCategory {
+
+        private static final Long NEW_CATEGORY_ID = 5L;
+
+        private Category newCategory() {
+            return Category.builder()
+                    .categoryId(NEW_CATEGORY_ID)
+                    .categoryName("여행")
+                    .build();
+        }
+
+        private Folder newRootFolder(Category category) {
+            return Folder.builder()
+                    .folderId(40L)
+                    .folderName("여행")
+                    .category(category)
+                    .build();
+        }
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("categoryId 제공 시 내 소유 중분류 폴더로 LinkuFolder 매핑이 이동하고, 공용 Linku는 변경되지 않는다")
+            void categoryId_제공_시_내_중분류_폴더로_매핑이_이동한다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                Linku linku = usersLinku.getLinku();
+                Category newCategory = newCategory();
+                Folder oldFolder = LinkuFixture.folder();
+                Folder targetFolder = newRootFolder(newCategory);
+                LinkuFolder linkuFolder = LinkuFolder.builder()
+                        .linkuFolderId(2000L)
+                        .folder(oldFolder)
+                        .usersLinku(usersLinku)
+                        .build();
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.of(linkuFolder));
+                given(categoryRepository.findById(NEW_CATEGORY_ID)).willReturn(Optional.of(newCategory));
+                given(usersFolderRepository.findFolderByUserIdAndCategory(USER_ID, newCategory))
+                        .willReturn(Optional.of(targetFolder));
+
+                // when
+                LinkuResponseDTO.LinkuResultDTO result = linkuService.updateLinku(USER_ID, 100L,
+                        LinkuRequestDTO.LinkuUpdateDTO.builder().categoryId(NEW_CATEGORY_ID).build());
+
+                // then: LinkuFolder의 folder만 교체되고 저장됨. 공유 Linku 엔티티는 건드리지 않음
+                assertEquals(targetFolder, linkuFolder.getFolder());
+                verify(linkuFolderRepository).save(linkuFolder);
+                verify(linkuRepository, never()).save(any());
+                assertNotEquals(NEW_CATEGORY_ID, linku.getCategory().getCategoryId());
+
+                // then: 응답은 새로 이동한 폴더 기준 정보를 반영
+                assertEquals(NEW_CATEGORY_ID, result.getCategoryId());
+                assertEquals("여행", result.getFolderName());
+            }
+
+            @Test
+            @DisplayName("categoryId 미제공 시 폴더 매핑은 변경되지 않는다")
+            void categoryId_미제공_시_폴더_매핑_변경없다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                Folder oldFolder = LinkuFixture.folder();
+                LinkuFolder linkuFolder = LinkuFolder.builder()
+                        .folder(oldFolder)
+                        .usersLinku(usersLinku)
+                        .build();
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.of(linkuFolder));
+
+                // when
+                linkuService.updateLinku(USER_ID, 100L,
+                        LinkuRequestDTO.LinkuUpdateDTO.builder().memo("메모만 변경").build());
+
+                // then
+                assertEquals(oldFolder, linkuFolder.getFolder());
+                verify(linkuFolderRepository, never()).save(any());
+                verify(categoryRepository, never()).findById(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("존재하지 않는 categoryId면 예외가 발생한다")
+            void 존재하지_않는_categoryId면_예외가_발생한다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                LinkuFolder linkuFolder = LinkuFolder.builder()
+                        .folder(LinkuFixture.folder())
+                        .usersLinku(usersLinku)
+                        .build();
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.of(linkuFolder));
+                given(categoryRepository.findById(999L)).willReturn(Optional.empty());
+
+                // when & then
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> linkuService.updateLinku(USER_ID, 100L,
+                                LinkuRequestDTO.LinkuUpdateDTO.builder().categoryId(999L).build()));
+                assertEquals(CategoryErrorStatus._CATEGORY_NOT_FOUND, ex.getCode());
+                verify(linkuFolderRepository, never()).save(any());
+            }
+
+            @Test
+            @DisplayName("해당 카테고리의 내 소유 중분류 폴더가 없으면 예외가 발생한다")
+            void 카테고리에_해당하는_내_폴더가_없으면_예외가_발생한다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                Category newCategory = newCategory();
+                LinkuFolder linkuFolder = LinkuFolder.builder()
+                        .folder(LinkuFixture.folder())
+                        .usersLinku(usersLinku)
+                        .build();
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.of(linkuFolder));
+                given(categoryRepository.findById(NEW_CATEGORY_ID)).willReturn(Optional.of(newCategory));
+                given(usersFolderRepository.findFolderByUserIdAndCategory(USER_ID, newCategory))
+                        .willReturn(Optional.empty());
+
+                // when & then
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> linkuService.updateLinku(USER_ID, 100L,
+                                LinkuRequestDTO.LinkuUpdateDTO.builder().categoryId(NEW_CATEGORY_ID).build()));
+                assertEquals(FolderErrorStatus._FOLDER_NOT_FOUND, ex.getCode());
+                verify(linkuFolderRepository, never()).save(any());
+            }
+
+            @Test
+            @DisplayName("이 사용자의 링크-폴더 매핑이 없으면 예외가 발생한다")
+            void 링크_폴더_매핑이_없으면_예외가_발생한다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                Category newCategory = newCategory();
+                Folder targetFolder = newRootFolder(newCategory);
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.empty());
+                given(categoryRepository.findById(NEW_CATEGORY_ID)).willReturn(Optional.of(newCategory));
+                given(usersFolderRepository.findFolderByUserIdAndCategory(USER_ID, newCategory))
+                        .willReturn(Optional.of(targetFolder));
+
+                // when & then
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> linkuService.updateLinku(USER_ID, 100L,
+                                LinkuRequestDTO.LinkuUpdateDTO.builder().categoryId(NEW_CATEGORY_ID).build()));
+                assertEquals(LinkuErrorStatus._USER_LINKU_NOT_FOUND, ex.getCode());
             }
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
> #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 링크 수정 시 카테고리를 선택적으로 변경할 수 있습니다.
  - 카테고리 변경 시 사용자의 폴더 매핑이 해당 카테고리의 루트 폴더로 이동합니다.
  - 공유 링크의 기본 카테고리는 유지됩니다.

- **버그 수정**
  - 링크 수정 후 응답에 표시되는 카테고리가 사용자의 최신 폴더 매핑을 기준으로 정확히 반영됩니다.
  - 존재하지 않는 카테고리나 폴더 지정 시 적절한 오류가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->