### PR TITLE
fix: Docker Compose에 fcm 파일 마운트

### DIFF
--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -9,6 +9,7 @@ services:
       - "8080:8080"
     volumes:
       - /home/ubuntu/secrets/application-secret.properties:/app/config/application-secret.properties:ro
+      - /home/ubuntu/secrets/linku-firebase-adminsdk.json:/app/config/linku-firebase-adminsdk.json:ro
     environment:
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Seoul

--- a/src/main/java/com/umc/linkyou/service/alarm/FcmServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/alarm/FcmServiceImpl.java
@@ -125,7 +125,7 @@ public class FcmServiceImpl implements FcmPushSender, FcmSubscriber {
                 .setNotification(buildNotification(requestDTO))
                 .putData("title", requestDTO.getTitle())
                 .putData("body", requestDTO.getMessage())
-                .putData("type", requestDTO.getType().name())
+                .putData("type", requestDTO.getType().getResponseType().name())
                 .putData("targetId", requestDTO.getTargetId().toString());
         if (requestDTO.getAlarmId() != null) {
             builder.putData("alarmId", requestDTO.getAlarmId().toString());
@@ -143,7 +143,7 @@ public class FcmServiceImpl implements FcmPushSender, FcmSubscriber {
                 .setNotification(buildNotification(requestDTO))
                 .putData("title", requestDTO.getTitle())
                 .putData("body", requestDTO.getMessage())
-                .putData("type", requestDTO.getType().name())
+                .putData("type", requestDTO.getType().getResponseType().name())
                 .putData("targetId", requestDTO.getTargetId().toString())
                 .setToken(token)
                 .setAndroidConfig(AndroidConfig.builder()
@@ -159,7 +159,7 @@ public class FcmServiceImpl implements FcmPushSender, FcmSubscriber {
                 .setNotification(buildNotification(requestDTO))
                 .putData("title", requestDTO.getTitle())
                 .putData("body", requestDTO.getMessage())
-                .putData("type", requestDTO.getType().name())
+                .putData("type", requestDTO.getType().getResponseType().name())
                 .putData("targetId", requestDTO.getTargetId().toString());
         if (requestDTO.getAlarmId() != null) {
             builder.putData("alarmId", requestDTO.getAlarmId().toString());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -12,6 +12,10 @@ spring:
       - classpath:db/migration
       - classpath:db/seed
 
+fcm:
+  credentials:
+    path: file:/app/config/linku-firebase-adminsdk.json
+
 logging:
   level:
     root: INFO

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -8,6 +8,10 @@ spring:
     locations:
       - classpath:db/migration
 
+fcm:
+  credentials:
+    path: file:/app/config/linku-firebase-adminsdk.json
+
 springdoc:
   api-docs:
     enabled: false


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
- 프로젝트 설계 또는 구조 개선  
- 코드 컨벤션 또는 개발 표준 적용  

### 2️⃣ Functional Requirement

#### 요약
- prod/dev 모두 FCM 서비스 계정 credentials가 classpath 기본 경로만 바라보고 있어, 컨테이너에 마운트해둔 실제 파일 경로를 못 찾고 FCM이 조용히 비활성화되던 문제 수정
- push 데이터 payload의 type 필드가 세분화된 AlarmType이 아닌 ResponseType으로 되도록 수정
---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 개발 및 운영 환경에서 Firebase 알림 서비스가 인증 파일을 사용하도록 설정했습니다.

* **버그 수정**
  * 푸시 알림의 `type` 값이 클라이언트에서 사용하는 응답 유형 기준으로 전달되도록 개선했습니다.
  * 단일 알림, 다중 알림, 토픽 알림에 동일하게 적용됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->