### PR TITLE
fix: 온보딩 추가 사항 입력 시 토큰 발급 오류 수정

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/UserConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/UserConverter.java
@@ -33,13 +33,6 @@ public class UserConverter {
                 .build();
     }
 
-    public static UserResponseDTO.JoinResultDTO toJoinResultDTO(Users users) {
-        return UserResponseDTO.JoinResultDTO.builder()
-                .userId(users.getId())
-                .createdAt(users.getCreatedAt())
-                .build();
-    }
-
     public static UserResponseDTO.JoinResultDTO toJoinResultDTO(
             Users users, String accessToken, String refreshToken) {
         return UserResponseDTO.JoinResultDTO.builder()

--- a/src/main/java/com/umc/linkyou/jwt/TokenIssueService.java
+++ b/src/main/java/com/umc/linkyou/jwt/TokenIssueService.java
@@ -3,6 +3,7 @@ package com.umc.linkyou.jwt;
 import com.umc.linkyou.config.properties.JwtProperties;
 import com.umc.linkyou.domain.enums.DeviceType;
 import com.umc.linkyou.domain.enums.Role;
+import com.umc.linkyou.domain.enums.UserStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,10 +18,12 @@ public class TokenIssueService {
     private final RefreshTokenManager refreshTokenManager;
     private final JwtProperties jwtProperties;
 
+    // 액세스 토큰 발급 (리프레시 토큰은 DB에 저장되어야 하므로, 별도 메서드에서 발급)
     public String issueAccessToken(Long userId, String email, String provider, Role role) {
         return jwtTokenProvider.createAccessToken(userId, email, provider, role);
     }
 
+    // 리프레시 토큰은 DB에 저장되어야 하므로, 발급 시 DB에 저장하는 로직을 포함
     public IssuedTokenPair issueTokenPair(
             Long userId,
             String email,
@@ -44,6 +47,26 @@ public class TokenIssueService {
         );
 
         return new IssuedTokenPair(accessToken, refreshToken);
+    }
+
+    /**
+     * 유저 상태에 따라 발급 범위를 결정
+     * TEMP(온보딩 미완료): 세션이 오래 유지되지 않도록 access token만 발급
+     * 그 외의 경우 : access + refresh 토큰 쌍 발급
+     */
+    public IssuedTokenPair issueForStatus(
+            Long userId,
+            String email,
+            String provider,
+            Role role,
+            UserStatus status,
+            String deviceId,
+            DeviceType deviceType
+    ) {
+        if (status == UserStatus.TEMP) {
+            return new IssuedTokenPair(issueAccessToken(userId, email, provider, role), null);
+        }
+        return issueTokenPair(userId, email, provider, role, deviceId, deviceType);
     }
 
     public record IssuedTokenPair(String accessToken, String refreshToken) {

--- a/src/main/java/com/umc/linkyou/service/users/UserLoginService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserLoginService.java
@@ -34,50 +34,22 @@ public class UserLoginService {
     ) {
         userStatusValidator.validateLoginAllowed(user);
 
-        if (user.getStatus() == UserStatus.TEMP) {
-            return MobileLoginResponse.builder()
-                    .userId(user.getId())
-                    .accessToken(issueTempAccessToken(user, resolvedEmail, provider))
-                    .refreshToken(null)
-                    .status(UserStatus.TEMP)
-                    .build();
-        }
-
         TokenIssueService.IssuedTokenPair tokenPair =
-                issueActiveTokenPair(user, resolvedEmail, provider, deviceId, deviceType);
+                tokenIssueService.issueForStatus(
+                        user.getId(),
+                        resolvedEmail,
+                        provider.name(),
+                        user.getRole(),
+                        user.getStatus(),
+                        deviceId,
+                        deviceType
+                );
 
         return MobileLoginResponse.builder()
                 .userId(user.getId())
                 .accessToken(tokenPair.accessToken())
                 .refreshToken(tokenPair.refreshToken())
-                .status(UserStatus.ACTIVE)
+                .status(user.getStatus())
                 .build();
-    }
-
-
-    private String issueTempAccessToken(Users user, String resolvedEmail, Provider provider) {
-        return tokenIssueService.issueAccessToken(
-                user.getId(),
-                resolvedEmail,
-                provider.name(),
-                user.getRole()
-        );
-    }
-
-    private TokenIssueService.IssuedTokenPair issueActiveTokenPair(
-            Users user,
-            String resolvedEmail,
-            Provider provider,
-            String deviceId,
-            DeviceType deviceType
-    ) {
-        return tokenIssueService.issueTokenPair(
-                user.getId(),
-                resolvedEmail,
-                provider.name(),
-                user.getRole(),
-                deviceId,
-                deviceType
-        );
     }
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -225,7 +225,8 @@ public class UserService {
     }
 
     @Transactional
-    public Users socialCompleteProfile(Long userId, UserRequestDTO.SocialCompleteDTO request) {
+    public UserResponseDTO.JoinResultDTO socialCompleteProfile(
+            Long userId, String providerStr, UserRequestDTO.SocialCompleteDTO request) {
         Users user =
                 userRepository
                         .findById(userId)
@@ -262,7 +263,25 @@ public class UserService {
         Users savedUser = userRepository.save(user);
         initUserFolders(savedUser);
 
-        return savedUser;
+        // 6. ACTIVE 전환 완료 시점에 정식 토큰 쌍 발급
+        Provider provider = Provider.valueOf(providerStr);
+        String email =
+                authAccountRepository
+                        .findEmailByUserIdAndProvider(savedUser.getId(), provider)
+                        .orElseThrow(() -> new UserHandler(UserErrorStatus._USER_NOT_FOUND));
+
+        TokenIssueService.IssuedTokenPair tokenPair =
+                tokenIssueService.issueForStatus(
+                        savedUser.getId(),
+                        email,
+                        providerStr,
+                        savedUser.getRole(),
+                        savedUser.getStatus(),
+                        request.getDeviceId(),
+                        request.getDeviceType());
+
+        return UserConverter.toJoinResultDTO(
+                savedUser, tokenPair.accessToken(), tokenPair.refreshToken());
     }
 
     public UserResponseDTO.TokenPair reissueRefreshToken(

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -72,7 +72,8 @@ public interface UserApi {
             summary = "소셜 프로필 완성",
             description = """
                     소셜 로그인 직후 TEMP 상태인 사용자의 필수 추가 정보를 입력받습니다.
-                    - 닉네임, 성별, 직업, 목적, 관심사를 입력받아 계정을 ACTIVE 상태로 전환합니다.
+                    - 닉네임, 성별, 직업, 목적, 관심사, deviceId, deviceType을 입력받아 계정을 ACTIVE 상태로 전환합니다.
+                    - 완료 시 정식 액세스/리프레시 토큰을 발급합니다.
                     - 최초 1회만 호출 가능하며, 이미 ACTIVE인 경우 에러를 반환합니다.
                     """
     )

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -49,8 +49,9 @@ public class UserController implements UserApi {
 
     @Override
     public ApiResponse<UserResponseDTO.JoinResultDTO> completeSocialProfile(UserRequestDTO.SocialCompleteDTO request, @CurrentUser CustomUserDetails userDetails) {
-        Users updatedUser = userService.socialCompleteProfile(userDetails.getUserId(), request);
-        return ApiResponse.onSuccess(UserSuccessStatus.SOCIAL_PROFILE_COMPLETED, UserConverter.toJoinResultDTO(updatedUser));
+        UserResponseDTO.JoinResultDTO result =
+                userService.socialCompleteProfile(userDetails.getUserId(), userDetails.getProvider(), request);
+        return ApiResponse.onSuccess(UserSuccessStatus.SOCIAL_PROFILE_COMPLETED, result);
     }
 
     @Override

--- a/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
@@ -111,6 +111,14 @@ public class UserRequestDTO {
         @Schema(description = "약관 동의 맵", example = "{\"TERMS_OF_USE\": true, \"PRIVACY_POLICY\": true, \"MARKETING\": false}")
         @NotEmpty(message = "약관 동의 정보는 필수입니다.")
         private  Map<TermsType, Boolean> termsMap;
+
+        @Schema(example = "ios-iphone-16-pro")
+        @NotBlank(message = "deviceId는 필수입니다.")
+        private String deviceId;
+
+        @Schema(example = "PHONE")
+        @NotNull(message = "deviceType은 필수입니다.")
+        private DeviceType deviceType;
     }
 
     /**

--- a/src/test/java/com/umc/linkyou/integration/UserRegistrationIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/UserRegistrationIntegrationTest.java
@@ -142,13 +142,16 @@ public class UserRegistrationIntegrationTest {
                         testJob.getId(),
                         List.of("WORK"),
                         List.of("ART"),
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        "test-device-2",
+                        DeviceType.PHONE);
 
         // 3. 예외 발생 검증
         com.umc.linkyou.apiPayload.exception.handler.UserHandler exception =
                 assertThrows(
                         com.umc.linkyou.apiPayload.exception.handler.UserHandler.class,
-                        () -> userService.socialCompleteProfile(activeUser.getId(), completeReq));
+                        () -> userService.socialCompleteProfile(
+                                activeUser.getId(), "GENERAL", completeReq));
 
         // getCode() 메서드를 통해 에러 코드 검증
         assertEquals(UserErrorStatus._DUPLICATE_JOIN_REQUEST, exception.getCode());

--- a/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
@@ -150,7 +150,7 @@ class UserServiceImplTest {
         class Success {
 
             @Test
-            @DisplayName("성공 - TEMP 상태 유저가 프로필 완성 시 ACTIVE 상태로 변경된다")
+            @DisplayName("성공 - TEMP 상태 유저가 프로필 완성 시 ACTIVE 상태로 변경되고 정식 토큰이 발급된다")
             void social_complete_success() {
                 // given
                 Users tempUser = Users.builder().id(1L).status(UserStatus.TEMP).build();
@@ -162,7 +162,9 @@ class UserServiceImplTest {
                                 1L,
                                 new ArrayList<>(),
                                 new ArrayList<>(),
-                                Collections.emptyMap());
+                                Collections.emptyMap(),
+                                "test-device",
+                                DeviceType.PHONE);
 
                 when(userRepository.findById(eq(tempUser.getId())))
                         .thenReturn(Optional.of(tempUser));
@@ -174,13 +176,29 @@ class UserServiceImplTest {
                 when(categoryRepository.findAll()).thenReturn(new ArrayList<>());
                 when(usersCategoryColorRepository.saveAll(anyList()))
                         .thenAnswer(invocation -> invocation.getArgument(0));
+                when(authAccountRepository.findEmailByUserIdAndProvider(eq(1L), eq(Provider.KAKAO)))
+                        .thenReturn(Optional.of("kakao@example.com"));
+                when(tokenIssueService.issueForStatus(
+                                eq(1L),
+                                eq("kakao@example.com"),
+                                eq("KAKAO"),
+                                any(),
+                                eq(UserStatus.ACTIVE),
+                                eq("test-device"),
+                                eq(DeviceType.PHONE)))
+                        .thenReturn(
+                                new TokenIssueService.IssuedTokenPair(
+                                        "accessToken", "refreshToken"));
 
                 // when
-                Users result = userService.socialCompleteProfile(tempUser.getId(), request);
+                UserResponseDTO.JoinResultDTO result =
+                        userService.socialCompleteProfile(tempUser.getId(), "KAKAO", request);
 
                 // then
-                assertEquals(UserStatus.ACTIVE, result.getStatus());
-                assertEquals("완성닉네임", result.getNickName());
+                assertEquals(UserStatus.ACTIVE, tempUser.getStatus());
+                assertEquals("완성닉네임", tempUser.getNickName());
+                assertEquals("accessToken", result.getTokenResponse().getAccessToken());
+                assertEquals("refreshToken", result.getTokenResponse().getRefreshToken());
                 verify(termsAgreementService).upsertTerms(any(Users.class), any());
             }
         }

--- a/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
 import com.umc.linkyou.config.common.WebConfig;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.DeviceType;
 import com.umc.linkyou.domain.enums.Gender;
 import com.umc.linkyou.domain.enums.TermsType;
 import com.umc.linkyou.domain.enums.UserStatus;
@@ -97,16 +98,18 @@ class UserControllerTest {
                         1L,
                         List.of("STUDY"),
                         List.of("DESIGN"),
-                        Map.of(TermsType.TERMS_OF_USE, true)
+                        Map.of(TermsType.TERMS_OF_USE, true),
+                        "ios-iphone-16-pro",
+                        DeviceType.PHONE
                 );
 
-                Users mockUser = Users.builder()
-                        .id(2L)
-                        .status(UserStatus.ACTIVE)
+                UserResponseDTO.JoinResultDTO mockResult = UserResponseDTO.JoinResultDTO.builder()
+                        .userId(2L)
+                        .createdAt(LocalDateTime.now())
+                        .tokenResponse(new UserResponseDTO.TokenPair("mockAccess", "mockRefresh"))
                         .build();
-                ReflectionTestUtils.setField(mockUser, "createdAt", LocalDateTime.now());
 
-                given(userService.socialCompleteProfile(any(), any())).willReturn(mockUser);
+                given(userService.socialCompleteProfile(any(), any(), any())).willReturn(mockResult);
 
                 mockMvc.perform(patch("/api/v1/users/social/complete")
                                 .contentType(MediaType.APPLICATION_JSON)
@@ -130,7 +133,9 @@ class UserControllerTest {
                         1L,
                         List.of("STUDY"),
                         List.of("DESIGN"),
-                        Map.of(TermsType.MARKETING, true)
+                        Map.of(TermsType.MARKETING, true),
+                        "ios-iphone-16-pro",
+                        DeviceType.PHONE
                 );
 
                 mockMvc.perform(patch("/api/v1/users/social/complete")


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
- 프로젝트 설계 또는 구조 개선  
- 코드 컨벤션 또는 개발 표준 적용  

### 2️⃣ Functional Requirement
- 소셜 로그인 직후 TEMP 상태 유저가 `/users/social/complete`로 프로필을 완성해도 정식 액세스/리프레시 토큰이 발급되지 않아, 온보딩 완료 후에도 클라이언트가 자동 로그인이 안 되는 문제를 수정했습니다. 
- TEMP/ACTIVE 상태별 토큰 발급 분기 로직을 `TokenIssueService`로 통합해 중복을 제거했습니다.

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 소셜 프로필 완료 시 디바이스 ID와 디바이스 유형을 입력할 수 있습니다.
  * 프로필 완료 후 정식 액세스 토큰과 리프레시 토큰을 발급합니다.
  * 임시 계정은 액세스 토큰만 발급되며, 계정 상태에 맞는 인증 정보가 제공됩니다.

* **문서**
  * 소셜 프로필 완료 API 안내에 디바이스 정보와 토큰 발급 내용이 반영되었습니다.

* **테스트**
  * 프로필 완료, 토큰 발급, 디바이스 정보 검증 시나리오가 보강되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->