### PR TITLE
fix: 회원 탈퇴 복구를 전용 AccessToken으로만 가능하도록 제한

### DIFF
--- a/src/main/java/com/umc/linkyou/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/linkyou/jwt/JwtAuthenticationFilter.java
@@ -24,6 +24,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
     private final AccessTokenBlackListManager accessTokenBlackListManager;
 
+    private static final String RECOVERY_ENDPOINT = "/api/v1/users/recover";
+
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,
@@ -38,6 +40,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (accessTokenBlackListManager.isBlacklisted(token)) {
             throw new JwtException("Blacklisted access token");
+        }
+
+        if (jwtTokenProvider.isRecoveryToken(token) && !RECOVERY_ENDPOINT.equals(request.getRequestURI())) {
+            throw new JwtException("복구 전용 토큰은 회원 복구 API에서만 사용할 수 있습니다.");
         }
 
         Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/com/umc/linkyou/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/umc/linkyou/jwt/JwtTokenProvider.java
@@ -64,6 +64,28 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    private static final String RECOVERY_PURPOSE = "RECOVER";
+    private static final long RECOVERY_TOKEN_EXPIRATION_MS = 10 * 60 * 1000L; // 10분
+
+    // 탈퇴 유예 기간 복구 전용 토큰 — 회원 복구 API 외 다른 엔드포인트에는 사용할 수 없음
+    public String createRecoveryToken(Long userId, String subject, String provider, Role role) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .claim("userId", userId)
+                .claim("provider", provider)
+                .claim("role", role.getAuthority())
+                .claim("purpose", RECOVERY_PURPOSE)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + RECOVERY_TOKEN_EXPIRATION_MS))
+                .signWith(accessKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean isRecoveryToken(String token) {
+        Claims claims = validateAndParseAccess(token).getBody();
+        return RECOVERY_PURPOSE.equals(claims.get("purpose", String.class));
+    }
+
     // 클레임 기반으로 Authentication 구성 — DB 조회 없음
     public Authentication getAuthentication(String token) {
         Claims claims = validateAndParseAccess(token).getBody();

--- a/src/main/java/com/umc/linkyou/jwt/TokenIssueService.java
+++ b/src/main/java/com/umc/linkyou/jwt/TokenIssueService.java
@@ -23,6 +23,11 @@ public class TokenIssueService {
         return jwtTokenProvider.createAccessToken(userId, email, provider, role);
     }
 
+    // 탈퇴 유예 기간 복구 전용 토큰, TTL 10분으로 일반 로그인에는 사용 불가능
+    public String issueRecoveryToken(Long userId, String email, String provider, Role role) {
+        return jwtTokenProvider.createRecoveryToken(userId, email, provider, role);
+    }
+
     // 리프레시 토큰은 DB에 저장되어야 하므로, 발급 시 DB에 저장하는 로직을 포함
     public IssuedTokenPair issueTokenPair(
             Long userId,

--- a/src/main/java/com/umc/linkyou/oauth2/mobile/dto/MobileLoginResponse.java
+++ b/src/main/java/com/umc/linkyou/oauth2/mobile/dto/MobileLoginResponse.java
@@ -4,11 +4,14 @@ import com.umc.linkyou.domain.enums.UserStatus;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 public class MobileLoginResponse {
     private Long userId;
     private String accessToken;
-    private String refreshToken;   // TEMP 유저는 null
-    private UserStatus status;     // ACTIVE or TEMP
+    private String refreshToken;   // TEMP/탈퇴 유예(INACTIVE) 유저는 null
+    private UserStatus status;     // ACTIVE, TEMP, INACTIVE(탈퇴 유예 - 복구 필요)
+    private LocalDateTime inactiveDate; // INACTIVE(탈퇴 유예)일 때만 값이 있음
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserLoginService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserLoginService.java
@@ -32,6 +32,19 @@ public class UserLoginService {
             String deviceId,
             DeviceType deviceType
     ) {
+        if (userStatusValidator.isWithinWithdrawGracePeriod(user)) {
+            // 탈퇴 유예중인 사용자는 복구 토큰만 발급하고, refresh token은 발급하지 않음
+            String recoveryToken =
+                    tokenIssueService.issueRecoveryToken(
+                            user.getId(), resolvedEmail, provider.name(), user.getRole());
+            return MobileLoginResponse.builder()
+                    .userId(user.getId())
+                    .accessToken(recoveryToken)
+                    .refreshToken(null)
+                    .status(user.getStatus())
+                    .inactiveDate(user.getInactiveDate())
+                    .build();
+        }
         userStatusValidator.validateLoginAllowed(user);
 
         TokenIssueService.IssuedTokenPair tokenPair =

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -188,7 +188,6 @@ public class UserService {
                         .orElseThrow(() -> new UserHandler(UserErrorStatus._LOGIN_FAILED));
 
         Long userId = user.getId();
-        userStatusValidator.validateLoginAllowed(user);
         // 소셜 전용 계정 차단 (GENERAL AuthAccount 없음)
         boolean hasGeneralAccount =
                 authAccountRepository.existsByUserIdAndProvider(user.getId(), Provider.GENERAL);
@@ -207,6 +206,15 @@ public class UserService {
                         .findByUserIdAndProvider(userId, Provider.GENERAL)
                         .map(AuthAccount::getEmail)
                         .orElseThrow(() -> new UserHandler(UserErrorStatus._USER_NOT_FOUND));
+
+        // 비밀번호 검증을 통과한 뒤에만 탈퇴 유예 상태를 판단(무자격 상태 노출 방지)
+        if (userStatusValidator.isWithinWithdrawGracePeriod(user)) {
+            String recoveryToken =
+                    tokenIssueService.issueRecoveryToken(
+                            user.getId(), email, Provider.GENERAL.name(), user.getRole());
+            return UserConverter.toLoginResultDTO(user, recoveryToken, null);
+        }
+        userStatusValidator.validateLoginAllowed(user);
 
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/umc/linkyou/service/users/UserStatusValidator.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserStatusValidator.java
@@ -6,12 +6,27 @@ import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.UserStatus;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 @Component
 public class UserStatusValidator {
+
+    // 탈퇴 유예 기간
+    public static final int WITHDRAW_GRACE_PERIOD_DAYS = 14;
 
     public void validateLoginAllowed(Users user) {
         if (user.getStatus() == UserStatus.INACTIVE) {
             throw new GeneralException(UserErrorStatus._USER_INACTIVE);
         }
+    }
+
+    // 탈퇴 유예 기간 이내의 INACTIVE 유저인지 (복구 가능 여부)
+    public boolean isWithinWithdrawGracePeriod(Users user) {
+        if (user.getStatus() != UserStatus.INACTIVE || user.getInactiveDate() == null) {
+            return false;
+        }
+        return ChronoUnit.DAYS.between(user.getInactiveDate(), LocalDateTime.now())
+                <= WITHDRAW_GRACE_PERIOD_DAYS;
     }
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -18,7 +18,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
-import java.time.temporal.ChronoUnit;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,6 +29,7 @@ public class UserWithdrawService{
     private final UserRepository userRepository;
     private final RefreshTokenManager refreshTokenManager;
     private final AuthAccountRepository authAccountRepository;
+    private final UserStatusValidator userStatusValidator;
 
     // 탈퇴 유예 기간
     private static final int GRACE_PERIOD_DAYS = 14;
@@ -57,9 +57,8 @@ public class UserWithdrawService{
         if (user.getStatus() != UserStatus.INACTIVE) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST); // 이미 활성 상태인 경우
         }
-        // 2. inactiveDate가 null이거나 14일이 경과했는지 확인
-        LocalDateTime inactiveDate = user.getInactiveDate();
-        if (inactiveDate == null || ChronoUnit.DAYS.between(inactiveDate, LocalDateTime.now()) > GRACE_PERIOD_DAYS) {
+        // 2. 유예 기간(14일) 이내인지 확인
+        if (!userStatusValidator.isWithinWithdrawGracePeriod(user)) {
             throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
         // 상태 및 탈퇴 관련 필드 초기화

--- a/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
@@ -8,6 +8,7 @@ import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
+import com.umc.linkyou.service.users.UserStatusValidator;
 import com.umc.linkyou.service.users.UserWithdrawService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,6 +35,7 @@ public class UserWithdrawServiceTest {
     private UserRepository userRepository;
     @Mock private RefreshTokenManager refreshTokenManager;
     @Mock private AuthAccountRepository authAccountRepository;
+    @Mock private UserStatusValidator userStatusValidator;
 
     @InjectMocks
     private UserWithdrawService userWithdrawService;
@@ -55,6 +57,7 @@ public class UserWithdrawServiceTest {
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
+            given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
 
             // when
             Users result = userWithdrawService.recoverUser(userId);
@@ -78,6 +81,7 @@ public class UserWithdrawServiceTest {
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
+            given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
 
             // when
             Users result = userWithdrawService.recoverUser(userId);
@@ -99,6 +103,7 @@ public class UserWithdrawServiceTest {
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
+            given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
 
             // when
             Users result = userWithdrawService.recoverUser(userId);
@@ -138,6 +143,29 @@ public class UserWithdrawServiceTest {
                     .build();
 
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+            // when & then
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(e -> {
+                        GeneralException ex = (GeneralException) e;
+                        assertThat(ex.getCode()).isEqualTo(ErrorStatus._BAD_REQUEST);
+                    });
+        }
+
+        @Test
+        @DisplayName("탈퇴 유예 기간(14일)이 지난 경우 BAD_REQUEST 예외가 발생한다")
+        void 유예기간_경과_예외() {
+            // given
+            Long userId = 4L;
+            Users user = Users.builder()
+                    .id(userId)
+                    .status(UserStatus.INACTIVE)
+                    .build();
+            user.withdraw("테스트 탈퇴", LocalDateTime.now().minusDays(15));
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(false);
 
             // when & then
             assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))

--- a/src/test/java/com/umc/linkyou/service/users/UserLoginServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserLoginServiceTest.java
@@ -1,0 +1,123 @@
+package com.umc.linkyou.service.users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.DeviceType;
+import com.umc.linkyou.domain.enums.Provider;
+import com.umc.linkyou.domain.enums.Role;
+import com.umc.linkyou.domain.enums.UserStatus;
+import com.umc.linkyou.jwt.TokenIssueService;
+import com.umc.linkyou.oauth2.mobile.dto.MobileLoginResponse;
+
+@ExtendWith(MockitoExtension.class)
+class UserLoginServiceTest {
+
+    @InjectMocks private UserLoginService userLoginService;
+
+    @Mock private UserStatusValidator userStatusValidator;
+    @Mock private TokenIssueService tokenIssueService;
+
+    @Nested
+    @DisplayName("handleSocialLogin")
+    class HandleSocialLogin {
+
+        @Test
+        @DisplayName("성공 - ACTIVE 유저는 access+refresh 토큰 쌍을 받는다")
+        void ACTIVE_유저는_토큰_쌍을_받는다() {
+            // given
+            Users user =
+                    Users.builder().id(1L).role(Role.USER).status(UserStatus.ACTIVE).build();
+            when(userStatusValidator.isWithinWithdrawGracePeriod(user)).thenReturn(false);
+            when(tokenIssueService.issueForStatus(
+                            eq(1L), eq("kakao@example.com"), eq("KAKAO"), eq(Role.USER),
+                            eq(UserStatus.ACTIVE), eq("device-1"), eq(DeviceType.PHONE)))
+                    .thenReturn(new TokenIssueService.IssuedTokenPair("access", "refresh"));
+
+            // when
+            MobileLoginResponse result =
+                    userLoginService.handleSocialLogin(
+                            user, "kakao@example.com", Provider.KAKAO, "device-1", DeviceType.PHONE);
+
+            // then
+            assertEquals("access", result.getAccessToken());
+            assertEquals("refresh", result.getRefreshToken());
+            assertEquals(UserStatus.ACTIVE, result.getStatus());
+            verify(userStatusValidator).validateLoginAllowed(user);
+        }
+
+        @Test
+        @DisplayName("성공 - 탈퇴 유예 기간 이내인 유저는 복구 전용 토큰만 받는다")
+        void 유예_기간_이내인_유저는_복구_전용_토큰만_받는다() {
+            // given
+            Users user =
+                    Users.builder().id(2L).role(Role.USER).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트 탈퇴", LocalDateTime.now().minusDays(3));
+
+            when(userStatusValidator.isWithinWithdrawGracePeriod(user)).thenReturn(true);
+            when(tokenIssueService.issueRecoveryToken(2L, "kakao@example.com", "KAKAO", Role.USER))
+                    .thenReturn("recoveryToken");
+
+            // when
+            MobileLoginResponse result =
+                    userLoginService.handleSocialLogin(
+                            user, "kakao@example.com", Provider.KAKAO, "device-1", DeviceType.PHONE);
+
+            // then
+            assertEquals("recoveryToken", result.getAccessToken());
+            assertNull(result.getRefreshToken());
+            assertEquals(UserStatus.INACTIVE, result.getStatus());
+            assertEquals(user.getInactiveDate(), result.getInactiveDate());
+            verify(userStatusValidator, never()).validateLoginAllowed(any());
+            verify(tokenIssueService, never())
+                    .issueForStatus(any(), any(), any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("실패 - 탈퇴 유예 기간이 지난 유저는 로그인이 차단된다")
+        void 유예_기간이_지난_유저는_로그인이_차단된다() {
+            // given
+            Users user =
+                    Users.builder().id(3L).role(Role.USER).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트 탈퇴", LocalDateTime.now().minusDays(20));
+
+            when(userStatusValidator.isWithinWithdrawGracePeriod(user)).thenReturn(false);
+            doThrow(new GeneralException(UserErrorStatus._USER_INACTIVE))
+                    .when(userStatusValidator)
+                    .validateLoginAllowed(user);
+
+            // when & then
+            GeneralException ex =
+                    assertThrows(
+                            GeneralException.class,
+                            () ->
+                                    userLoginService.handleSocialLogin(
+                                            user,
+                                            "kakao@example.com",
+                                            Provider.KAKAO,
+                                            "device-1",
+                                            DeviceType.PHONE));
+            assertEquals(UserErrorStatus._USER_INACTIVE, ex.getCode());
+        }
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserServiceImplTest.java
@@ -2,6 +2,8 @@ package com.umc.linkyou.service.users;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -273,6 +275,154 @@ class UserServiceImplTest {
                                 eq(Role.USER),
                                 eq(request.deviceId()),
                                 eq(request.deviceType()));
+            }
+
+            @Test
+            @DisplayName("성공 - 탈퇴 유예 기간 이내인 유저는 복구 전용 토큰만 발급받는다")
+            void 탈퇴_유예_기간_이내인_유저는_복구_전용_토큰만_발급받는다() {
+                // given
+                UserRequestDTO.LoginRequestDTO request =
+                        new UserRequestDTO.LoginRequestDTO(
+                                "inactive@example.com",
+                                "password123",
+                                "ios-iphone-16-pro",
+                                DeviceType.PHONE);
+
+                Users user =
+                        Users.builder()
+                                .id(2L)
+                                .role(Role.USER)
+                                .status(UserStatus.INACTIVE)
+                                .password("encodedPassword")
+                                .build();
+                user.withdraw("테스트 탈퇴", java.time.LocalDateTime.now().minusDays(3));
+
+                AuthAccount authAccount =
+                        AuthAccount.builder().user(user).email("inactive@example.com").build();
+
+                when(authAccountRepository.findUserByEmailAndProvider(
+                                eq(request.email()), eq(Provider.GENERAL)))
+                        .thenReturn(Optional.of(user));
+                when(authAccountRepository.existsByUserIdAndProvider(
+                                anyLong(), eq(Provider.GENERAL)))
+                        .thenReturn(true);
+                when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+                when(authAccountRepository.findByUserIdAndProvider(anyLong(), eq(Provider.GENERAL)))
+                        .thenReturn(Optional.of(authAccount));
+                when(userStatusValidator.isWithinWithdrawGracePeriod(user)).thenReturn(true);
+                when(tokenIssueService.issueRecoveryToken(
+                                eq(user.getId()),
+                                eq("inactive@example.com"),
+                                eq(Provider.GENERAL.name()),
+                                eq(Role.USER)))
+                        .thenReturn("recoveryToken");
+
+                // when
+                UserResponseDTO.LoginResultDTO result = userService.loginUser(request);
+
+                // then
+                assertEquals("recoveryToken", result.getAccessToken());
+                assertNull(result.getRefreshToken());
+                assertEquals(UserStatus.INACTIVE, result.getStatus());
+                verify(tokenIssueService, never())
+                        .issueTokenPair(any(), any(), any(), any(), any(), any());
+                verify(userStatusValidator, never()).validateLoginAllowed(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("실패 - 탈퇴 유예 기간이어도 비밀번호가 틀리면 로그인에 실패한다")
+            void 유예_기간이어도_비밀번호가_틀리면_로그인에_실패한다() {
+                // given
+                UserRequestDTO.LoginRequestDTO request =
+                        new UserRequestDTO.LoginRequestDTO(
+                                "inactive@example.com",
+                                "wrongPassword",
+                                "ios-iphone-16-pro",
+                                DeviceType.PHONE);
+
+                Users user =
+                        Users.builder()
+                                .id(2L)
+                                .role(Role.USER)
+                                .status(UserStatus.INACTIVE)
+                                .password("encodedPassword")
+                                .build();
+                user.withdraw("테스트 탈퇴", java.time.LocalDateTime.now().minusDays(3));
+
+                when(authAccountRepository.findUserByEmailAndProvider(
+                                eq(request.email()), eq(Provider.GENERAL)))
+                        .thenReturn(Optional.of(user));
+                when(authAccountRepository.existsByUserIdAndProvider(
+                                anyLong(), eq(Provider.GENERAL)))
+                        .thenReturn(true);
+                when(passwordEncoder.matches(anyString(), anyString())).thenReturn(false);
+
+                // when & then
+                com.umc.linkyou.apiPayload.exception.handler.UserHandler ex =
+                        assertThrows(
+                                com.umc.linkyou.apiPayload.exception.handler.UserHandler.class,
+                                () -> userService.loginUser(request));
+                assertEquals(
+                        com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus._LOGIN_FAILED,
+                        ex.getCode());
+                verify(userStatusValidator, never()).isWithinWithdrawGracePeriod(any());
+                verify(tokenIssueService, never())
+                        .issueRecoveryToken(any(), any(), any(), any());
+            }
+
+            @Test
+            @DisplayName("실패 - 탈퇴 유예 기간이 지난 유저는 로그인이 차단된다")
+            void 유예_기간이_지난_유저는_로그인이_차단된다() {
+                // given
+                UserRequestDTO.LoginRequestDTO request =
+                        new UserRequestDTO.LoginRequestDTO(
+                                "inactive@example.com",
+                                "password123",
+                                "ios-iphone-16-pro",
+                                DeviceType.PHONE);
+
+                Users user =
+                        Users.builder()
+                                .id(2L)
+                                .role(Role.USER)
+                                .status(UserStatus.INACTIVE)
+                                .password("encodedPassword")
+                                .build();
+                user.withdraw("테스트 탈퇴", java.time.LocalDateTime.now().minusDays(20));
+
+                AuthAccount authAccount =
+                        AuthAccount.builder().user(user).email("inactive@example.com").build();
+
+                when(authAccountRepository.findUserByEmailAndProvider(
+                                eq(request.email()), eq(Provider.GENERAL)))
+                        .thenReturn(Optional.of(user));
+                when(authAccountRepository.existsByUserIdAndProvider(
+                                anyLong(), eq(Provider.GENERAL)))
+                        .thenReturn(true);
+                when(passwordEncoder.matches(anyString(), anyString())).thenReturn(true);
+                when(authAccountRepository.findByUserIdAndProvider(anyLong(), eq(Provider.GENERAL)))
+                        .thenReturn(Optional.of(authAccount));
+                when(userStatusValidator.isWithinWithdrawGracePeriod(user)).thenReturn(false);
+                doThrow(
+                                new com.umc.linkyou.apiPayload.exception.GeneralException(
+                                        com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus
+                                                ._USER_INACTIVE))
+                        .when(userStatusValidator)
+                        .validateLoginAllowed(user);
+
+                // when & then
+                com.umc.linkyou.apiPayload.exception.GeneralException ex =
+                        assertThrows(
+                                com.umc.linkyou.apiPayload.exception.GeneralException.class,
+                                () -> userService.loginUser(request));
+                assertEquals(
+                        com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus._USER_INACTIVE,
+                        ex.getCode());
             }
         }
     }

--- a/src/test/java/com/umc/linkyou/service/users/UserStatusValidatorTest.java
+++ b/src/test/java/com/umc/linkyou/service/users/UserStatusValidatorTest.java
@@ -1,0 +1,104 @@
+package com.umc.linkyou.service.users;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.UserStatus;
+
+class UserStatusValidatorTest {
+
+    private final UserStatusValidator validator = new UserStatusValidator();
+
+    @Nested
+    @DisplayName("validateLoginAllowed")
+    class ValidateLoginAllowed {
+
+        @Test
+        @DisplayName("INACTIVE 유저는 로그인이 차단된다")
+        void INACTIVE_유저는_로그인이_차단된다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+
+            GeneralException ex =
+                    org.junit.jupiter.api.Assertions.assertThrows(
+                            GeneralException.class, () -> validator.validateLoginAllowed(user));
+            assertEquals(UserErrorStatus._USER_INACTIVE, ex.getCode());
+        }
+
+        @Test
+        @DisplayName("ACTIVE 유저는 로그인이 허용된다")
+        void ACTIVE_유저는_로그인이_허용된다() {
+            Users user = Users.builder().id(1L).status(UserStatus.ACTIVE).build();
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+                    () -> validator.validateLoginAllowed(user));
+        }
+
+        @Test
+        @DisplayName("TEMP 유저는 로그인이 허용된다")
+        void TEMP_유저는_로그인이_허용된다() {
+            Users user = Users.builder().id(1L).status(UserStatus.TEMP).build();
+            org.junit.jupiter.api.Assertions.assertDoesNotThrow(
+                    () -> validator.validateLoginAllowed(user));
+        }
+    }
+
+    @Nested
+    @DisplayName("isWithinWithdrawGracePeriod")
+    class IsWithinWithdrawGracePeriod {
+
+        @Test
+        @DisplayName("ACTIVE 유저는 유예 대상이 아니다")
+        void ACTIVE_유저는_유예_대상이_아니다() {
+            Users user = Users.builder().id(1L).status(UserStatus.ACTIVE).build();
+            assertFalse(validator.isWithinWithdrawGracePeriod(user));
+        }
+
+        @Test
+        @DisplayName("INACTIVE지만 inactiveDate가 없으면 유예 대상이 아니다")
+        void inactiveDate가_없으면_유예_대상이_아니다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+            assertFalse(validator.isWithinWithdrawGracePeriod(user));
+        }
+
+        @Test
+        @DisplayName("탈퇴 후 7일이면 유예 기간 이내다")
+        void 탈퇴_후_7일이면_유예_기간_이내다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트", LocalDateTime.now().minusDays(7));
+            assertTrue(validator.isWithinWithdrawGracePeriod(user));
+        }
+
+        @Test
+        @DisplayName("탈퇴 직후(1분 이내)에도 유예 기간 이내다")
+        void 탈퇴_직후에도_유예_기간_이내다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트", LocalDateTime.now().minusMinutes(1));
+            assertTrue(validator.isWithinWithdrawGracePeriod(user));
+        }
+
+        @Test
+        @DisplayName("탈퇴 후 정확히 13일 23시간이면 유예 기간 이내다 (경계값)")
+        void 유예기간_경계값에서는_이내로_판단한다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트", LocalDateTime.now().minusDays(13).minusHours(23));
+            assertTrue(validator.isWithinWithdrawGracePeriod(user));
+        }
+
+        @Test
+        @DisplayName("탈퇴 후 15일이 지나면 유예 기간이 지난 것으로 판단한다")
+        void 탈퇴_후_15일이_지나면_유예_기간이_지난_것으로_판단한다() {
+            Users user = Users.builder().id(1L).status(UserStatus.INACTIVE).build();
+            user.withdraw("테스트", LocalDateTime.now().minusDays(15));
+            assertFalse(validator.isWithinWithdrawGracePeriod(user));
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용

회원 탈퇴 복구를 전용 AccessToken으로만 가능하도록 제한했습니다. 해당 토큰으로 로그인 및 다른 API 호출 시 401 예외처리됩니다.

### 1️⃣ Non-Functional Requirement
- 프로젝트 설계 또는 구조 개선  
- 코드 컨벤션 또는 개발 표준 적용  

### 2️⃣ Functional Requirement
 
- 회원 탈퇴 후 14일 유예 기간 동안 계정을 복구할 수 있어야 하는데, 지금까지는 탈퇴 즉시 refresh token이 전부 삭제되고 재로그인도 막혀 있어서, 탈퇴 시점에 들고 있던 access token(TTL 24시간)이 만료되면 그 이후로는 `/users/recover`를 호출할 방법이 없었습니다. 
정책상 14일 유예인데 실질적으로는 24시간 안에만 복구 가능했었기 때문에, INACTIVE한 유저에게도 accessToken을 발급하도록 했습니다. 
- 유예 기간 이내의 INACTIVE 유저가 로그인을 시도하면, 일반 로그인 대신 복구 전용 토큰(refresh 없음, TTL 10분, `purpose=RECOVER` 클레임 포함)을 발급합니다. 이 토큰은 `/users/recover` 이외의 엔드포인트에는 사용할 수 없도록 필터에서 차단합니다.

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 탈퇴 후 14일 이내 사용자가 로그인하면 계정 복구 전용 토큰을 발급합니다.
  - 복구 응답에 탈퇴일과 계정 상태 정보를 표시합니다.
  - 복구 토큰은 제한된 복구 기능에서만 사용할 수 있으며 10분 후 만료됩니다.

- **개선 사항**
  - 유예 기간이 지난 탈퇴 계정은 기존과 같이 로그인이 제한됩니다.
  - 잘못된 비밀번호 입력 시 복구 절차가 진행되지 않습니다.

- **테스트**
  - 계정 복구, 유예 기간 경계, 만료 계정 및 인증 실패 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->