### PR TITLE
fix: #259 폴더 다중 계층 생성 제약 추가, #348 DTO 변환 로직 Converter 분리

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/FolderErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/folder/FolderErrorStatus.java
@@ -12,6 +12,7 @@ public enum FolderErrorStatus implements BaseErrorCode {
 
     // 400 Bad Request
     _FOLDER_INVALID_CURSOR(HttpStatus.BAD_REQUEST, "FOLDER4001", "유효하지 않은 커서 값입니다."),
+    _FOLDER_MAX_DEPTH_EXCEEDED(HttpStatus.BAD_REQUEST, "FOLDER4002", "소분류 폴더 하위에는 폴더를 생성할 수 없습니다."),
 
     // 403 Forbidden
     _FOLDER_CREATE_FORBIDDEN(HttpStatus.FORBIDDEN, "FOLDER4031", "해당하는 폴더를 생성할 권한이 없습니다."),

--- a/src/main/java/com/umc/linkyou/converter/FolderConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/FolderConverter.java
@@ -12,22 +12,6 @@ import java.util.Map;
 
 public class FolderConverter {
 
-    public static FolderResponseDTO toFolderResponseDTO(Folder folder) {
-        if (folder == null) {
-            return null;
-        }
-        Category category = folder.getCategory();
-        return FolderResponseDTO.builder()
-                .folderId(folder.getFolderId())
-                .folderName(folder.getFolderName())
-                .categoryId(category != null ? category.getCategoryId() : null)
-                .categoryName(category != null ? category.getCategoryName() : null)
-                .parentFolderId(folder.getParentFolder() != null ? folder.getParentFolder().getFolderId() : null)
-                .createdAt(folder.getCreatedAt())
-                .updatedAt(folder.getUpdatedAt())
-                .build();
-    }
-
     public static FolderResponseDTO toFolderResponseDTO(Folder folder, Boolean isBookmarked) {
         if (folder == null) {
             return null;
@@ -63,11 +47,11 @@ public class FolderConverter {
                 .build();
     }
 
-    public static UsersFolder toUsersFolder(Users user, Folder folder) {
+    public static UsersFolder toUsersFolder(Users user, Folder folder, PermissionType permissionType) {
         return UsersFolder.builder()
                 .user(user)
                 .folder(folder)
-                .permissionType(PermissionType.OWNER)
+                .permissionType(permissionType)
                 .isBookmarked(false)
                 .build();
     }

--- a/src/main/java/com/umc/linkyou/converter/InvitationConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/InvitationConverter.java
@@ -1,0 +1,14 @@
+package com.umc.linkyou.converter;
+
+import com.umc.linkyou.domain.folder.FolderShareLink;
+import com.umc.linkyou.web.dto.folder.share.InvitationInfoResponseDTO;
+
+public class InvitationConverter {
+
+    public static InvitationInfoResponseDTO toInvitationInfoResponseDTO(FolderShareLink link) {
+        return InvitationInfoResponseDTO.builder()
+                .folderName(link.getFolder().getFolderName())
+                .ownerName(link.getCreator().getNickName())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/linkyou/converter/ShareFolderConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/ShareFolderConverter.java
@@ -1,4 +1,38 @@
 package com.umc.linkyou.converter;
 
+import com.umc.linkyou.domain.folder.Folder;
+import com.umc.linkyou.domain.mapping.folder.UsersFolder;
+import com.umc.linkyou.web.dto.folder.share.MySharedFolderResponseDTO;
+import com.umc.linkyou.web.dto.folder.share.ShareFolderResponseDTO;
+import com.umc.linkyou.web.dto.folder.share.ViewerResponseDTO;
+
+import java.time.LocalDateTime;
+
 public class ShareFolderConverter {
+
+    public static ShareFolderResponseDTO toShareFolderResponseDTO(
+            Long folderId, Long userId, String permission, LocalDateTime sharedAt) {
+        return ShareFolderResponseDTO.builder()
+                .folderId(folderId)
+                .userId(userId)
+                .permission(permission)
+                .sharedAt(sharedAt.toString())
+                .build();
+    }
+
+    public static ViewerResponseDTO toViewerResponseDTO(UsersFolder usersFolder) {
+        ViewerResponseDTO dto = new ViewerResponseDTO();
+        dto.setUserId(usersFolder.getUser().getId());
+        dto.setUserName(usersFolder.getUser().getNickName());
+        dto.setPermission(usersFolder.getPermissionType().name());
+        return dto;
+    }
+
+    public static MySharedFolderResponseDTO toMySharedFolderResponseDTO(Folder folder, int memberCount) {
+        return MySharedFolderResponseDTO.builder()
+                .folderId(folder.getFolderId())
+                .folderName(folder.getFolderName())
+                .memberCount(memberCount)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
@@ -91,16 +91,7 @@ public class FolderServiceImpl implements FolderService {
                 .isBookmarked(false)
                 .build());
 
-        return FolderResponseDTO.builder()
-                .folderId(folder.getFolderId())
-                .folderName(folder.getFolderName())
-                .isBookmarked(false)
-                .categoryId(parent.getCategory().getCategoryId())
-                .categoryName(parent.getCategory().getCategoryName())
-                .parentFolderId(parent.getFolderId())
-                .createdAt(folder.getCreatedAt())
-                .updatedAt(folder.getUpdatedAt())
-                .build();
+        return FolderConverter.toFolderResponseDTO(folder, false);
     }
 
     // 폴더 이름 수정
@@ -206,14 +197,9 @@ public class FolderServiceImpl implements FolderService {
                         .collect(Collectors.toList())
                 : null;
 
-        Category category = folder.getCategory();
-        return FolderTreeResponseDTO.builder()
-                .folderId(folder.getFolderId())
-                .folderName(folder.getFolderName())
-                .isBookmarked(bookmarkMap.getOrDefault(folder.getFolderId(), false))
-                .categoryId(category != null ? category.getCategoryId() : null)
-                .children(childDTOs)
-                .build();
+        FolderTreeResponseDTO dto = FolderConverter.toFolderTreeDTO(folder, bookmarkMap);
+        dto.setChildren(childDTOs);
+        return dto;
     }
 
     // 중분류 폴더 목록 조회

--- a/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
@@ -52,6 +52,11 @@ public class FolderServiceImpl implements FolderService {
             throw new GeneralException(FolderErrorStatus._FOLDER_PARENT_NOT_FOUND);
         }
 
+        // 부모 폴더에 대한 생성 권한 확인
+        if (!usersFolderRepository.existsFolderOwnerOrWriter(userId, parentFolderId)) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_CREATE_FORBIDDEN);
+        }
+
         // 폴더는 중분류-소분류 2단계까지만 허용 (부모가 이미 소분류면 생성 불가)
         if (parent.getParentFolder() != null) {
             throw new GeneralException(FolderErrorStatus._FOLDER_MAX_DEPTH_EXCEEDED);

--- a/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/FolderServiceImpl.java
@@ -6,7 +6,6 @@ import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Linku;
-import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.mapping.LinkuFolder;
 import com.umc.linkyou.domain.mapping.UsersLinku;
@@ -51,6 +50,11 @@ public class FolderServiceImpl implements FolderService {
         // 부모 폴더 존재 확인
         if (parent == null) {
             throw new GeneralException(FolderErrorStatus._FOLDER_PARENT_NOT_FOUND);
+        }
+
+        // 폴더는 중분류-소분류 2단계까지만 허용 (부모가 이미 소분류면 생성 불가)
+        if (parent.getParentFolder() != null) {
+            throw new GeneralException(FolderErrorStatus._FOLDER_MAX_DEPTH_EXCEEDED);
         }
 
         // 부모 폴더에 대한 생성 권한 확인 (소유자 또는 편집자만 가능)
@@ -265,6 +269,11 @@ public class FolderServiceImpl implements FolderService {
     @Transactional
     public BookmarkUpdateResponseDTO updateBookmark(Long userId, Long folderId, Boolean isBookmarked) {
         UsersFolder usersFolder = usersFolderRepository.findByUserIdAndFolderId(userId, folderId).orElseThrow(() -> new GeneralException(ErrorStatus._FOLDER_BOOKMARK_NOT_FOUND));
+
+        // 공유 해제 등으로 권한이 회수(NONE)된 관계는 존재하지 않는 것과 동일하게 처리
+        if (usersFolder.getPermissionType() == PermissionType.NONE) {
+            throw new GeneralException(ErrorStatus._FOLDER_BOOKMARK_NOT_FOUND);
+        }
 
         usersFolder.updateBookmark(isBookmarked);
 

--- a/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/InvitationServiceImpl.java
@@ -3,11 +3,12 @@ package com.umc.linkyou.service.folder.share;
 import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.converter.FolderConverter;
+import com.umc.linkyou.converter.InvitationConverter;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.enums.PermissionType;
 import com.umc.linkyou.domain.folder.FolderShareLink;
-import com.umc.linkyou.domain.mapping.folder.UsersFolder;
 import com.umc.linkyou.repository.FolderShareLinkRepository;
 import com.umc.linkyou.repository.usersFolderRepository.UsersFolderRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
@@ -34,10 +35,7 @@ public class InvitationServiceImpl implements InvitationService {
             throw new GeneralException(InvitationErrorStatus.INVITATION_EXPIRED);
         }
 
-        return InvitationInfoResponseDTO.builder()
-                .folderName(link.getFolder().getFolderName())
-                .ownerName(link.getCreator().getNickName())
-                .build();
+        return InvitationConverter.toInvitationInfoResponseDTO(link);
     }
 
     // 초대 수락
@@ -67,14 +65,7 @@ public class InvitationServiceImpl implements InvitationService {
         }
 
         // 멤버 추가
-        UsersFolder newMember = UsersFolder.builder()
-                .user(user)
-                .folder(folder)
-                .permissionType(PermissionType.VIEWER)
-                .isBookmarked(false)
-                .build();
-
-        usersFolderRepository.save(newMember);
+        usersFolderRepository.save(FolderConverter.toUsersFolder(user, folder, PermissionType.VIEWER));
 
         return folder.getFolderId();
     }

--- a/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/folder/share/ShareFolderServiceImpl.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.apiPayload.code.status.folder.InvitationErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.ShareFolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.converter.ShareFolderConverter;
 import com.umc.linkyou.domain.enums.PermissionType;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.folder.FolderShareLink;
@@ -126,13 +127,7 @@ public class ShareFolderServiceImpl implements ShareFolderService {
         List<UsersFolder> participants = usersFolderRepository.findAllParticipantsByFolderId(folderId);
 
         return participants.stream()
-                .map(uf -> {
-                    ViewerResponseDTO dto = new ViewerResponseDTO();
-                    dto.setUserId(uf.getUser().getId());
-                    dto.setUserName(uf.getUser().getNickName());
-                    dto.setPermission(uf.getPermissionType().name());
-                    return dto;
-                })
+                .map(ShareFolderConverter::toViewerResponseDTO)
                 .toList();
     }
 
@@ -177,12 +172,8 @@ public class ShareFolderServiceImpl implements ShareFolderService {
             .ifPresent(setting -> eventPublisher.publishEvent(
                     new FolderPermissionChangedAlarmEvent(memberId, folderId, folderName)));
 
-        return ShareFolderResponseDTO.builder()
-                .folderId(folderId)
-                .userId(usersFolder.getUser().getId())
-                .permission(permission.name())
-                .sharedAt(usersFolder.getUpdatedAt().toString())
-                .build();
+        return ShareFolderConverter.toShareFolderResponseDTO(
+                folderId, usersFolder.getUser().getId(), permission.name(), usersFolder.getUpdatedAt());
     }
 
     // 가장 오래 참여한 멤버에게 소유권 자동 위임 후 폴더 나가기
@@ -208,12 +199,8 @@ public class ShareFolderServiceImpl implements ShareFolderService {
         ownerUF.updatePermission(PermissionType.NONE);
         usersFolderRepository.saveAll(List.of(newOwnerUF, ownerUF));
 
-        return ShareFolderResponseDTO.builder()
-                .folderId(folderId)
-                .userId(newOwnerUF.getUser().getId())
-                .permission(PermissionType.OWNER.name())
-                .sharedAt(LocalDateTime.now().toString())
-                .build();
+        return ShareFolderConverter.toShareFolderResponseDTO(
+                folderId, newOwnerUF.getUser().getId(), PermissionType.OWNER.name(), LocalDateTime.now());
     }
 
     // 내가 공유한(소유자인) 폴더 목록 조회
@@ -231,11 +218,8 @@ public class ShareFolderServiceImpl implements ShareFolderService {
                 .collect(Collectors.groupingBy(uf -> uf.getFolder().getFolderId(), Collectors.counting()));
 
         return folders.stream()
-                .map(folder -> MySharedFolderResponseDTO.builder()
-                        .folderId(folder.getFolderId())
-                        .folderName(folder.getFolderName())
-                        .memberCount(memberCountByFolderId.getOrDefault(folder.getFolderId(), 0L).intValue())
-                        .build())
+                .map(folder -> ShareFolderConverter.toMySharedFolderResponseDTO(
+                        folder, memberCountByFolderId.getOrDefault(folder.getFolderId(), 0L).intValue()))
                 .toList();
     }
 
@@ -265,11 +249,6 @@ public class ShareFolderServiceImpl implements ShareFolderService {
 
         usersFolderRepository.saveAll(mappings);
 
-        return ShareFolderResponseDTO.builder()
-                .folderId(folderId)
-                .userId(ownerId)
-                .permission("PRIVATE")
-                .sharedAt(LocalDateTime.now().toString())
-                .build();
+        return ShareFolderConverter.toShareFolderResponseDTO(folderId, ownerId, "PRIVATE", LocalDateTime.now());
     }
 }

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.handler.UserHandler;
+import com.umc.linkyou.converter.FolderConverter;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.*;
 import com.umc.linkyou.domain.classification.Category;
@@ -26,7 +27,6 @@ import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.domain.folder.Fcolor;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.mapping.folder.UsersCategoryColor;
-import com.umc.linkyou.domain.mapping.folder.UsersFolder;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
@@ -445,13 +445,7 @@ public class UserService {
 
         for (Category category : categories) {
             // 중분류 폴더 생성
-            Folder subFolder =
-                    folderRepository.save(
-                            Folder.builder()
-                                    .folderName(category.getCategoryName())
-                                    .category(category)
-                                    .parentFolder(null)
-                                    .build());
+            Folder subFolder = folderRepository.save(FolderConverter.toFolder(category));
 
             // 기본 카테고리 색상 설정
             Fcolor defaultColor = category.getFcolor();
@@ -463,13 +457,7 @@ public class UserService {
                             .build());
 
             // UsersFolder 매핑
-            usersFolderRepository.save(
-                    UsersFolder.builder()
-                            .user(user)
-                            .folder(subFolder)
-                            .permissionType(PermissionType.OWNER)
-                            .isBookmarked(false)
-                            .build());
+            usersFolderRepository.save(FolderConverter.toUsersFolder(user, subFolder, PermissionType.OWNER));
         }
         usersCategoryColorRepository.saveAll(userColors);
     }

--- a/src/main/java/com/umc/linkyou/web/api/FolderApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/FolderApi.java
@@ -20,7 +20,7 @@ import java.util.List;
 public interface FolderApi {
 
     @Operation(summary = "소분류 폴더 생성", description = "중분류 폴더 하위에 소분류 폴더를 생성합니다.")
-    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_PARENT_NOT_FOUND, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN, FolderErrorStatus._FOLDER_NAME_CONFLICT, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
+    @ApiErrorCode(folderErrorStatus = {FolderErrorStatus._FOLDER_PARENT_NOT_FOUND, FolderErrorStatus._FOLDER_MAX_DEPTH_EXCEEDED, FolderErrorStatus._FOLDER_CREATE_FORBIDDEN, FolderErrorStatus._FOLDER_NAME_CONFLICT, FolderErrorStatus._FOLDER_CREATE_DUPLICATE})
     @PostMapping("/{parentFolderId}/subfolders")
     ApiResponse<FolderResponseDTO> createFolder(
             @CurrentUser CustomUserDetails userDetails,


### PR DESCRIPTION
## 🔗 관련 이슈
closes #259 #348 

---

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- 폴더/공유폴더/초대 관련 응답 DTO 변환 로직을 `Converter`로 분리

### 2️⃣ Functional Requirement
- 폴더는 중분류-소분류 2단계까지만 생성 가능하도록 제약 추가
- 공유 해제 등으로 권한이 `NONE`으로 회수된 폴더에 북마크 업데이트 요청이 오면 `_FOLDER_BOOKMARK_NOT_FOUND` 처리하도록 수정

---

## 🧪 테스트 결과
로컬 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 폴더를 중분류와 소분류의 2단계까지만 생성할 수 있도록 제한했습니다.
  * 폴더 공유 및 초대 관련 응답 정보가 제공됩니다.
  * 폴더 목록과 공유 폴더에 북마크 및 권한 정보가 표시됩니다.

* **오류 수정**
  * 소분류 폴더 아래에 추가 폴더를 생성할 때 명확한 오류 메시지를 제공합니다.
  * 북마크가 없는 폴더의 토글 동작을 올바르게 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->