### PR TITLE
!!hotfix/#403 tightday err

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
@@ -16,7 +16,7 @@ public class AiArticleConverter {
                 .build();
     }
 
-    // tags/title은 지연 로딩 컬렉션(linku.getLinkuKeywords())과 usersLinku 우선순위 결정이 필요해
+    // tags/title/imgUrl은 지연 로딩 컬렉션(linku.getLinkuKeywords())과 usersLinku 우선순위 결정이 필요해
     // 트랜잭션을 쥔 서비스 레이어에서 계산해 넘겨받는다 (LinkuService/LinkuCreateService/FolderServiceImpl과
     // 동일한 패턴). 컨버터는 순수 조립만 담당한다.
     public static AiArticleResponseDTO.AiArticleResultDTO toDto(
@@ -24,7 +24,8 @@ public class AiArticleConverter {
             Linku linku,
             UsersLinku usersLinku,
             String tags,
-            String title
+            String title,
+            String imgUrl
     ) {
         Emotion emotion = usersLinku != null ? usersLinku.getEmotion() : null;
         return new AiArticleResponseDTO.AiArticleResultDTO(
@@ -34,7 +35,7 @@ public class AiArticleConverter {
                 emotion != null ? emotion.getName() : null,
                 linku.getCategory() != null ? linku.getCategory().getCategoryName() : null,
                 entity.getSummary(),
-                linku.getImgUrl(),
+                imgUrl,
                 usersLinku != null ? usersLinku.getMemo() : null,
                 tags,
                 title

--- a/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
@@ -16,29 +16,34 @@ public class AiArticleConverter {
                 .build();
     }
 
-    // tags/title/imgUrl은 지연 로딩 컬렉션(linku.getLinkuKeywords())과 usersLinku 우선순위 결정이 필요해
-    // 트랜잭션을 쥔 서비스 레이어에서 계산해 넘겨받는다 (LinkuService/LinkuCreateService/FolderServiceImpl과
-    // 동일한 패턴). 컨버터는 순수 조립만 담당한다.
+    // tags는 지연 로딩 컬렉션(linku.getLinkuKeywords())을 순회해야 해서 트랜잭션을 쥔 서비스
+    // 레이어에서 계산해 넘겨받는다 (LinkuService/LinkuCreateService/FolderServiceImpl과 동일한 패턴).
+    // title/imgUrl은 단순 필드 우선순위 결정(usersLinku 우선, 없으면 linku)이라 지연 로딩과 무관하므로
+    // LinkuConverter와 동일하게 컨버터가 직접 계산한다.
     public static AiArticleResponseDTO.AiArticleResultDTO toDto(
             AiArticle entity,
             Linku linku,
             UsersLinku usersLinku,
-            String tags,
-            String title,
-            String imgUrl
+            String tags
     ) {
         Emotion emotion = usersLinku != null ? usersLinku.getEmotion() : null;
-        return new AiArticleResponseDTO.AiArticleResultDTO(
-                entity.getId(),
-                linku.getLinkuId(),
-                emotion != null ? emotion.getEmotionId() : null,
-                emotion != null ? emotion.getName() : null,
-                linku.getCategory() != null ? linku.getCategory().getCategoryName() : null,
-                entity.getSummary(),
-                imgUrl,
-                usersLinku != null ? usersLinku.getMemo() : null,
-                tags,
-                title
-        );
+        String title = (usersLinku != null && usersLinku.getTitle() != null)
+                ? usersLinku.getTitle()
+                : linku.getTitle();
+        String imgUrl = (usersLinku != null && usersLinku.getImageUrl() != null)
+                ? usersLinku.getImageUrl()
+                : linku.getImgUrl();
+        return AiArticleResponseDTO.AiArticleResultDTO.builder()
+                .id(entity.getId())
+                .linkuId(linku.getLinkuId())
+                .emotionId(emotion != null ? emotion.getEmotionId() : null)
+                .emotionName(emotion != null ? emotion.getName() : null)
+                .categoryName(linku.getCategory() != null ? linku.getCategory().getCategoryName() : null)
+                .summary(entity.getSummary())
+                .imgUrl(imgUrl)
+                .memo(usersLinku != null ? usersLinku.getMemo() : null)
+                .tags(tags)
+                .title(title)
+                .build();
     }
 }

--- a/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
@@ -188,4 +188,20 @@ public class LinkuConverter {
                 .build();
     } //리스트로 반환할때 쓰이는 것
 
+    // 마이페이지 AI 요약 링크 목록용 - toLinkuSimpleDTO와 동일한 title/linkuImageUrl 우선순위 패턴
+    // (usersLinku 우선, 없으면 linku)을 사용한다.
+    public static LinkuResponseDTO.AiArticleSummaryDTO toAiArticleSummaryDTO(UsersLinku usersLinku) {
+        Linku linku = usersLinku.getLinku();
+        Domain domain = linku.getDomain();
+        return LinkuResponseDTO.AiArticleSummaryDTO.builder()
+                .linkuId(linku.getLinkuId())
+                .linku(linku.getLinkuUrl())
+                .emotionId(usersLinku.getEmotion() != null ? usersLinku.getEmotion().getEmotionId() : null)
+                .domain(domain != null ? domain.getName() : null)
+                .domainImageUrl(domain != null ? domain.getImageUrl() : null)
+                .title(usersLinku.getTitle() != null ? usersLinku.getTitle() : linku.getTitle())
+                .linkuImageUrl(usersLinku.getImageUrl() != null ? usersLinku.getImageUrl() : linku.getImgUrl())
+                .build();
+    }
+
 }

--- a/src/main/java/com/umc/linkyou/service/AiArticleService.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleService.java
@@ -6,10 +6,10 @@ import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.AiArticleConverter;
+import com.umc.linkyou.converter.LinkuConverter;
 import com.umc.linkyou.domain.AiArticle;
 import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.Linku;
-import com.umc.linkyou.domain.classification.Domain;
 import com.umc.linkyou.domain.enums.AlarmType;
 import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
@@ -77,7 +77,7 @@ public class AiArticleService {
         alarmService.sendAlarm(userId, new AlarmRequestDTO.AlarmSendRequestDTO(
                 AlarmType.LINK_SUMMARY_COMPLETE, linkuId, new AlarmPayload.LinkTitle(linkTitle)));
 
-        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), linkTitle, resolveImageUrl(linku, usersLinku));
+        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku));
     }
 
     @Transactional
@@ -94,7 +94,7 @@ public class AiArticleService {
         }
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AiArticleResponseDTO.AiArticleResultDTO showAiArticle(Long linkuId, Long userId) {
         Linku linku = linkuRepository.findById(linkuId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
@@ -102,14 +102,21 @@ public class AiArticleService {
                 .orElseThrow(() -> new GeneralException(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND));
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        // 동일 (user, linku) 조합으로 저장된 UsersLinku가 여러 건일 수 있어 최신 1건을 사용한다.
+        // 동일 (user, linku) 조합으로 저장된 UsersLinku가 여러 건일 수 있다. 응답에는 최신 1건을 대표로
+        // 쓰되, "AI 요약 있음" 표시는 본인이 저장한 모든 건에 동일하게 남긴다 (saveAiArticle과 동일한 패턴).
         // 요청 유저가 이 linku를 저장한 적이 없으면(=UsersLinku 없음) 소유권이 없는 것이므로 예외를 던진다.
         // (다른 유저가 먼저 요약을 만들어둔 linkuId를 알기만 하면 조회되는 것을 막기 위함)
-        UsersLinku usersLinku = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(userId, linkuId).stream()
+        List<UsersLinku> usersLinkus = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(userId, linkuId);
+        UsersLinku usersLinku = usersLinkus.stream()
                 .max(Comparator.comparing(UsersLinku::getCreatedAt))
                 .orElseThrow(() -> new GeneralException(LinkuErrorStatus._USER_LINKU_NOT_FOUND));
 
-        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), resolveTitle(linku, usersLinku), resolveImageUrl(linku, usersLinku));
+        // 다른 유저가 먼저 만들어둔 요약이라도, 본인이 직접 조회한 시점부터는 본인 소유 UsersLinku에도
+        // "AI 요약 있음"으로 남긴다 (본인이 요청/조회한 적 없는데 true로 보이는 문제를 막기 위해 저장
+        // 시점에는 더 이상 자동으로 표시하지 않으므로, 대신 실제 조회 시점에 표시한다).
+        usersLinkus.forEach(ul -> ul.markAiExist(true));
+
+        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku));
     }
 
     // AI 요약 호출과 별개로, 링크 저장 시 이미 분류되어 저장된 키워드를 그대로 태그로 사용한다
@@ -120,18 +127,12 @@ public class AiArticleService {
                 .collect(Collectors.joining(", "));
     }
 
+    // 알림 페이로드에 넣을 제목 계산용. DTO의 title은 AiArticleConverter.toDto가 동일한
+    // 우선순위(usersLinku 우선, 없으면 linku)로 자체 계산하므로 여기서는 알림 발송에만 쓰인다.
     private String resolveTitle(Linku linku, UsersLinku usersLinku) {
         return (usersLinku != null && usersLinku.getTitle() != null)
                 ? usersLinku.getTitle()
                 : linku.getTitle();
-    }
-
-    // usersLinku에 사용자가 업로드한 이미지가 있으면 그걸 우선 쓰고, 없으면 linku에 캐싱된
-    // 크롤링 썸네일로 폴백한다 (LinkuConverter의 linkuImageUrl 처리와 동일한 패턴).
-    private String resolveImageUrl(Linku linku, UsersLinku usersLinku) {
-        return (usersLinku != null && usersLinku.getImageUrl() != null)
-                ? usersLinku.getImageUrl()
-                : linku.getImgUrl();
     }
 
     @Transactional(readOnly = true)
@@ -146,19 +147,7 @@ public class AiArticleService {
                 : null;
 
         List<LinkuResponseDTO.AiArticleSummaryDTO> linkuResultDTOs = resultList.stream()
-                .map(ul -> {
-                    Linku l = ul.getLinku();
-                    Domain domain = l.getDomain();
-                    return LinkuResponseDTO.AiArticleSummaryDTO.builder()
-                            .linkuId(l.getLinkuId())
-                            .linku(l.getLinkuUrl())
-                            .emotionId(ul.getEmotion() != null ? ul.getEmotion().getEmotionId() : null)
-                            .domain(domain != null ? domain.getName() : null)
-                            .domainImageUrl(domain != null ? domain.getImageUrl() : null)
-                            .title(ul.getTitle() != null ? ul.getTitle() : l.getTitle())
-                            .linkuImageUrl(ul.getImageUrl() != null ? ul.getImageUrl() : l.getImgUrl())
-                            .build();
-                })
+                .map(LinkuConverter::toAiArticleSummaryDTO)
                 .collect(Collectors.toList());
 
         return LinkuResponseDTO.LinkuSliceResultDTO.builder()

--- a/src/main/java/com/umc/linkyou/service/AiArticleService.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleService.java
@@ -77,7 +77,7 @@ public class AiArticleService {
         alarmService.sendAlarm(userId, new AlarmRequestDTO.AlarmSendRequestDTO(
                 AlarmType.LINK_SUMMARY_COMPLETE, linkuId, new AlarmPayload.LinkTitle(linkTitle)));
 
-        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), linkTitle);
+        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), linkTitle, resolveImageUrl(linku, usersLinku));
     }
 
     @Transactional
@@ -109,7 +109,7 @@ public class AiArticleService {
                 .max(Comparator.comparing(UsersLinku::getCreatedAt))
                 .orElseThrow(() -> new GeneralException(LinkuErrorStatus._USER_LINKU_NOT_FOUND));
 
-        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), resolveTitle(linku, usersLinku));
+        return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku), resolveTitle(linku, usersLinku), resolveImageUrl(linku, usersLinku));
     }
 
     // AI 요약 호출과 별개로, 링크 저장 시 이미 분류되어 저장된 키워드를 그대로 태그로 사용한다
@@ -124,6 +124,14 @@ public class AiArticleService {
         return (usersLinku != null && usersLinku.getTitle() != null)
                 ? usersLinku.getTitle()
                 : linku.getTitle();
+    }
+
+    // usersLinku에 사용자가 업로드한 이미지가 있으면 그걸 우선 쓰고, 없으면 linku에 캐싱된
+    // 크롤링 썸네일로 폴백한다 (LinkuConverter의 linkuImageUrl 처리와 동일한 패턴).
+    private String resolveImageUrl(Linku linku, UsersLinku usersLinku) {
+        return (usersLinku != null && usersLinku.getImageUrl() != null)
+                ? usersLinku.getImageUrl()
+                : linku.getImgUrl();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuCreateService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuCreateService.java
@@ -31,7 +31,6 @@ import com.umc.linkyou.service.folder.FolderService;
 import com.umc.linkyou.service.Linku.LinkuUpsertService;
 import com.umc.linkyou.infra.parser.TitleDomainParser;
 import com.umc.linkyou.service.keyword.KeywordService;
-import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.repository.classification.CategoryRepository;
 import com.umc.linkyou.repository.classification.SituationRepository;
 import com.umc.linkyou.repository.classification.domainRepository.DomainRepository;
@@ -70,7 +69,6 @@ public class LinkuCreateService {
     private final KeywordService keywordService;
     private final LinkuUpsertService linkuUpsertService;
     private final SafeUrlFetcher safeUrlFetcher;
-    private final AiArticleRepository aiArticleRepository;
     private final UserProfileRefreshQueueRepository userProfileRefreshQueueRepository;
     // 크롤링/AI분석/이미지 업로드 등 블로킹 외부 I/O를 @Transactional 메서드 밖에서 수행하기 위해
     // (커넥션을 그 시간만큼 붙들고 있지 않도록) DB 쓰기 구간만 프로그래밍 방식으로 트랜잭션에 넣는다.
@@ -330,10 +328,14 @@ public class LinkuCreateService {
                                        String memo, String imageUrl, String title,
                                        boolean emotionAi, boolean situationAi) {
         UsersLinku usersLinku = LinkuConverter.toUsersLinku(user, linku, emotion, situation, memo, imageUrl, title, emotionAi, situationAi);
-        // 이미 이 링크(linku)에 대한 AI 요약이 존재한다면(과거에 본인 또는 다른 유저가 요청해 만들어졌을 수 있음),
-        // 새로 생기는 저장 건도 처음부터 "AI 요약 있음"으로 표시한다. 그렇지 않으면 동일 링크를 재저장할 때마다
-        // 새 UsersLinku 행은 기본값(false)으로 생성되어, 이미 요약이 있는데도 "요약 없음"으로 보이는 문제가 생긴다.
-        if (aiArticleRepository.findByLinku(linku).isPresent()) {
+        // "본인"이 과거에 이 링크(linku)를 저장하면서 AI 요약을 직접 요청/조회한 적이 있다면, 이번에
+        // 새로 생기는 저장 건도 처음부터 "AI 요약 있음"으로 표시한다 (동일 유저가 같은 링크를 여러 번
+        // 저장해도 이미 자신이 확인한 요약이 "요약 없음"으로 보이면 안 되기 때문).
+        // 단, 다른 유저가 먼저 이 링크를 요약해뒀을 뿐 본인은 요청/조회한 적이 없다면 true로 표시하지 않는다.
+        boolean userAlreadyHasAiArticle = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(user.getId(), linku.getLinkuId())
+                .stream()
+                .anyMatch(ul -> Boolean.TRUE.equals(ul.getAiExist()));
+        if (userAlreadyHasAiArticle) {
             usersLinku.markAiExist(true);
         }
         UsersLinku saved = usersLinkuRepository.save(usersLinku);

--- a/src/main/java/com/umc/linkyou/service/users/UserService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserService.java
@@ -385,6 +385,9 @@ public class UserService {
         // purposes를 보낸 경우에만 전체 교체 (미포함 시 기존 목적 유지)
         if (request.getPurposes() != null) {
             usersPurposeRepository.deleteAllByUser(user);
+            // delete를 즉시 flush하지 않으면 insert가 flush 순서상 delete보다 먼저 나가
+            // 겹치는 값이 있을 때 uk_users_purposes_user_purpose 유니크 제약 위반(409)이 발생함
+            usersPurposeRepository.flush();
             usersPurposeRepository.saveAll(
                     UserConverter.toUsersPurposes(user, resolvePurposes(request.getPurposes())));
         }
@@ -392,6 +395,8 @@ public class UserService {
         // interests를 보낸 경우에만 전체 교체 (미포함 시 기존 관심사 유지)
         if (request.getInterests() != null) {
             usersInterestRepository.deleteAllByUser(user);
+            // 위와 동일한 이유로 flush 필요 (uk_users_interests_user_interest 위반 방지)
+            usersInterestRepository.flush();
             usersInterestRepository.saveAll(
                     UserConverter.toUsersInterests(user, resolveInterests(request.getInterests())));
         }

--- a/src/main/java/com/umc/linkyou/web/dto/AiArticleResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/AiArticleResponseDTO.java
@@ -1,16 +1,23 @@
 package com.umc.linkyou.web.dto;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
 public class AiArticleResponseDTO {
-    public record AiArticleResultDTO(
-            Long id,
-            Long linkuId,
-            Long emotionId,
-            String emotionName,
-            String categoryName,
-            String summary,
-            String imgUrl,
-            String memo,
-            String tags,
-            String title
-    ) {}
+    @Getter
+    @Setter
+    @Builder
+    public static class AiArticleResultDTO {
+        private Long id;
+        private Long linkuId;
+        private Long emotionId;
+        private String emotionName;
+        private String categoryName;
+        private String summary;
+        private String imgUrl;
+        private String memo;
+        private String tags;
+        private String title;
+    }
 }

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -395,7 +395,11 @@ class AiArticleServiceTest {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
                 UsersLinku older = buildUsersLinku(linku, user);
+                org.springframework.test.util.ReflectionTestUtils.setField(
+                        older, "createdAt", java.time.LocalDateTime.now().minusDays(1));
                 UsersLinku newer = buildUsersLinku(linku, user);
+                org.springframework.test.util.ReflectionTestUtils.setField(
+                        newer, "createdAt", java.time.LocalDateTime.now());
                 AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -328,6 +328,9 @@ class AiArticleServiceTest {
 
                 verify(aiArticleAnalyzer, never()).analyzeByUrl(any());
                 verify(aiArticleRepository, never()).save(any());
+                // 요약 생성을 직접 요청한 게 아니라 이미 있는 요약을 조회(showAiArticle)한 경우에도
+                // 본인이 실제로 확인한 것이므로 aiExist는 true로 표시되어야 한다.
+                assertTrue(usersLinku.getAiExist());
             }
 
             @Test
@@ -353,6 +356,78 @@ class AiArticleServiceTest {
 
                 verify(aiArticleAnalyzer).analyzeByUrl(any());
                 assertEquals(SUMMARY, articleWithNullSummary.getSummary());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("showAiArticle() - AI 요약 조회")
+    class ShowAiArticle {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("다른 유저가 먼저 만들어둔 요약이라도 본인이 조회하면 본인 소유 UsersLinku의 aiExist가 true로 표시된다")
+            void 다른_유저가_만든_요약이라도_본인이_조회하면_aiExist가_true로_표시된다() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                // 저장 시점에는 본인이 요청/조회한 적이 없어 aiExist=false였던 상태 (다른 유저가 먼저 요약함)
+                UsersLinku usersLinku = buildUsersLinku(linku, user);
+                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
+
+                assertFalse(usersLinku.getAiExist());
+
+                aiArticleService.showAiArticle(LINKU_ID, USER_ID);
+
+                assertTrue(usersLinku.getAiExist());
+            }
+
+            @Test
+            @DisplayName("동일 (user, linku)로 저장된 UsersLinku가 여러 건이면 조회 시 전부 aiExist가 true로 표시된다")
+            void 여러건이면_조회시_전부_aiExist가_true로_표시된다() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                UsersLinku older = buildUsersLinku(linku, user);
+                UsersLinku newer = buildUsersLinku(linku, user);
+                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(older, newer));
+
+                aiArticleService.showAiArticle(LINKU_ID, USER_ID);
+
+                assertTrue(older.getAiExist());
+                assertTrue(newer.getAiExist());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("요청 유저가 이 linku를 저장한 적이 없으면 예외가 발생한다")
+            void 소유권_없으면_예외가_발생한다() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of());
+
+                assertThrows(GeneralException.class,
+                        () -> aiArticleService.showAiArticle(LINKU_ID, USER_ID));
             }
         }
     }

--- a/src/test/java/com/umc/linkyou/service/Linku/LinkuCreateServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/Linku/LinkuCreateServiceTest.java
@@ -247,13 +247,14 @@ class LinkuCreateServiceTest {
     class CreateUsersLinkuAiExistInheritance {
 
         @Test
-        @DisplayName("이미_AI_요약이_존재하는_링크를_재저장하면_새_UsersLinku도_aiExist가_true로_생성된다")
-        void 이미_AI_요약이_존재하는_링크를_재저장하면_새_UsersLinku도_aiExist가_true로_생성된다() {
+        @DisplayName("본인이_이전에_같은_링크를_저장하며_AI_요약을_확인한_적_있으면_새_UsersLinku도_aiExist가_true로_생성된다")
+        void 본인이_이전에_같은_링크를_저장하며_AI_요약을_확인한_적_있으면_새_UsersLinku도_aiExist가_true로_생성된다() {
             Linku linku = LinkuFixture.linku(null);
-            com.umc.linkyou.domain.AiArticle existingArticle = com.umc.linkyou.domain.AiArticle.builder()
-                    .id(1L).linku(linku).summary("이미 존재하는 요약").build();
+            UsersLinku previousSave = UsersLinku.builder()
+                    .user(LinkuFixture.user()).linku(linku).aiExist(true).build();
 
-            given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
+            given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(LinkuFixture.USER_ID, linku.getLinkuId()))
+                    .willReturn(List.of(previousSave));
             given(usersLinkuRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
             UsersLinku result = linkuCreateService.createUsersLinku(
@@ -264,11 +265,28 @@ class LinkuCreateServiceTest {
         }
 
         @Test
-        @DisplayName("아직_AI_요약이_없는_링크를_저장하면_UsersLinku는_aiExist가_false로_생성된다")
-        void 아직_AI_요약이_없는_링크를_저장하면_UsersLinku는_aiExist가_false로_생성된다() {
+        @DisplayName("본인의_이전_저장_이력이_없으면_UsersLinku는_aiExist가_false로_생성된다")
+        void 본인의_이전_저장_이력이_없으면_UsersLinku는_aiExist가_false로_생성된다() {
             Linku linku = LinkuFixture.linku(null);
 
-            given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
+            given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(LinkuFixture.USER_ID, linku.getLinkuId()))
+                    .willReturn(List.of());
+            given(usersLinkuRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            UsersLinku result = linkuCreateService.createUsersLinku(
+                    LinkuFixture.user(), linku, LinkuFixture.emotion(), LinkuFixture.situation(),
+                    null, null, "1번째 저장", true, true);
+
+            assertFalse(result.getAiExist());
+        }
+
+        @Test
+        @DisplayName("다른_유저가_이미_이_링크를_요약해뒀어도_본인이_요청_조회한_적_없으면_aiExist가_false로_생성된다")
+        void 다른_유저가_이미_이_링크를_요약해뒀어도_본인이_요청_조회한_적_없으면_aiExist가_false로_생성된다() {
+            Linku linku = LinkuFixture.linku(null);
+            // 다른 유저가 저장하며 이미 AI 요약을 확인해둔 상태 - 본인의 이력이 아니므로 조회 대상이 아니다.
+            given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(LinkuFixture.USER_ID, linku.getLinkuId()))
+                    .willReturn(List.of());
             given(usersLinkuRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
 
             UsersLinku result = linkuCreateService.createUsersLinku(


### PR DESCRIPTION
## 🔗 관련 이슈
#403

## 📌 작업 내용

### 1️⃣ Non-Functional Requirement
- `AiArticleResponseDTO.AiArticleResultDTO`를 `@Builder` 기반 클래스로 변경해 DTO 컨벤션 통일
- `AiArticleConverter.toDto()`에서 title/imgUrl 우선순위 계산 의무를 컨버터로 이관 (서비스 중복 로직 제거)
- `AiArticleService.getMyAiArticlesByCategory()`를 `LinkuConverter` 사용으로 리팩토링, 사용하지 않는 import 정리

### 2️⃣ Functional Requirement
- `LinkuCreateService.createUsersLinku()`의 `aiExist` 판단 기준을 **전역 AI 요약 존재** → **본인의 과거 `aiExist=true` 이력**으로 변경 [[docs.spring](https://docs.spring.io/spring-data/jpa/reference/jpa/transactions.html)](https://docs.spring.io/spring-data/jpa/reference/jpa/transactions.html)
- `AiArticleService.showAiArticle()`에서 사용자가 캐시된 요약을 조회하면 본인의 `UsersLinku` 전체에 `aiExist=true`를 표시하는 로직 추가 [[docs.spring](https://docs.spring.io/spring-data/jpa/reference/jpa/transactions.html)](https://docs.spring.io/spring-data/jpa/reference/jpa/transactions.html)
- `showAiArticle()`는 엔티티 변경이 필요하므로 `@Transactional(readOnly = true)` 제거 [perfectacle.github](https://perfectacle.github.io/2021/08/08/readonly-transaction-doesnt-make-entity-snapshot/)

## 🧪 테스트 결과
- `LinkuCreateServiceTest`: 다른 사용자의 요약이 존재해도 본인 미조회 시 `aiExist=false` 유지 검증
- `AiArticleServiceTest`의 `ShowAiArticle` 섹션: 본인이 직접 조회 후 `aiExist=true` 반영 검증

## 📎 참고 사항
- 핵심: **AI 요약 보유 여부를 사용자의 실제 접근 이력으로만 판단** (다른 사용자의 요약은 내 `aiExist`에 영향 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * AI 요약 결과의 제목과 이미지가 사용자별 설정을 우선해 표시됩니다.
  * 마이페이지의 AI 요약 링크 목록에서 사용자별 제목, 이미지, 감정 정보가 올바르게 반영됩니다.
  * AI 요약 조회 후 해당 사용자와 링크에 요약 완료 상태가 자동으로 표시됩니다.
  * 링크를 다시 저장할 때 사용자별 AI 요약 조회 이력이 정확히 유지됩니다.

* **버그 수정**
  * 다른 사용자가 생성한 요약이 내 링크의 요약 완료 상태로 잘못 표시되는 문제를 수정했습니다.
  * 동일한 링크를 여러 번 저장한 경우에도 요약 상태가 일관되게 반영됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->