### PR TITLE
feat: #405 초대장 응답에서 baseurl 삭제

### DIFF
--- a/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/ShareFolderController.java
@@ -13,7 +13,6 @@ import com.umc.linkyou.web.dto.folder.share.ShareFolderResponseDTO;
 import com.umc.linkyou.web.dto.folder.share.ViewerResponseDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,13 +23,10 @@ public class ShareFolderController implements ShareFolderApi {
 
     private final ShareFolderService shareFolderService;
 
-    @Value("${app.deeplink.base-url}")
-    private String deeplinkBaseUrl;
-
     @Override
     public ApiResponse<String> createInviteLink(@CurrentUser CustomUserDetails userDetails, @PathVariable Long folderId) {
         String token = shareFolderService.createInviteLink(userDetails.getUserId(), folderId);
-        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_CREATED, deeplinkBaseUrl + "/open?action=share&folderId=" + token);
+        return ApiResponse.onSuccess(FolderSuccessStatus.FOLDER_INVITE_LINK_CREATED, token);
     }
 
     @Override


### PR DESCRIPTION
## 🔗 관련 이슈
closes #405

---

## 📌 작업 내용
폴더 초대장 발급 API의 응답에서 초대 링크 전체가 아닌 토큰만 전달하도록 응답을 변경합니다.

### 1️⃣ Non-Functional Requirement
- 딥링크 조립에 쓰이던 `@Value("${app.deeplink.base-url}")` 환경설정 의존성을 컨트롤러에서 제거

### 2️⃣ Functional Requirement
- 폴더 초대장 발급 API(`POST /v1/share-folders/{folderId}/invite-link`)의 응답을 `deeplinkBaseUrl + "/open?action=share&folderId=" + token` 전체 URL에서 **토큰 값만** 반환하도록 변경

---

## 🧪 테스트 결과
<img width="308" height="106" alt="image" src="https://github.com/user-attachments/assets/779f3b25-4b22-47a4-b372-27cd6612553b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 초대 링크 생성 결과가 전체 URL 대신 생성된 초대 토큰으로 반환되도록 변경되었습니다.
  * 초대 링크 처리 시 불필요한 URL 설정 의존성이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->