### PR TITLE
feat: #403 회원 탈퇴시 토큰 만료

### DIFF
--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -70,9 +70,15 @@ public class UserWithdrawService{
         if (accessToken == null || accessToken.isBlank()) {
             return;
         }
-        long ttlMs = jwtTokenProvider.getRemainingExpiryMs(accessToken);
-        if (ttlMs > 0) {
-            accessTokenBlackListManager.addToBlacklist(accessToken, ttlMs);
+        // 만료/위조 등으로 파싱이 실패해도 탈퇴 자체는 계속 진행되어야 하므로
+        // 블랙리스트 등록 실패는 로그만 남기고 흐름을 막지 않는다.
+        try {
+            long ttlMs = jwtTokenProvider.getRemainingExpiryMs(accessToken);
+            if (ttlMs > 0) {
+                accessTokenBlackListManager.addToBlacklist(accessToken, ttlMs);
+            }
+        } catch (Exception e) {
+            log.warn("탈퇴 처리 중 액세스 토큰 블랙리스트 등록 실패 (탈퇴는 계속 진행됨)", e);
         }
     }
 

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -3,6 +3,8 @@ package com.umc.linkyou.service.users;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.jwt.AccessTokenBlackListManager;
+import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
 import com.umc.linkyou.domain.AuthAccount;
 import com.umc.linkyou.domain.Users;
@@ -30,19 +32,48 @@ public class UserWithdrawService{
     private final RefreshTokenManager refreshTokenManager;
     private final AuthAccountRepository authAccountRepository;
     private final UserStatusValidator userStatusValidator;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AccessTokenBlackListManager accessTokenBlackListManager;
 
     // 탈퇴 유예 기간
     private static final int GRACE_PERIOD_DAYS = 14;
 
+    /**
+     * 회원 탈퇴 (accessToken 미지정)
+     * 웹훅 등 현재 요청의 accessToken을 알 수 없는 내부 호출용.
+     */
     @Transactional
     public Users withdrawUser(Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO) {
+        return withdrawUser(userId, deleteReasonDTO, null);
+    }
+
+    /**
+     * 회원 탈퇴
+     * - Refresh Token 전체 삭제
+     * - 현재 요청의 Access Token을 블랙리스트에 등록하여 탈퇴 즉시 로그아웃 처리
+     */
+    @Transactional
+    public Users withdrawUser(
+            Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO, String accessToken) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        // 1. 토큰 즉시 무효화
+        // 1. 리프레시 토큰 즉시 무효화
         refreshTokenManager.deleteAllTokens(userId);
+        // 2. 현재 액세스 토큰 즉시 블랙리스트 등록 (탈퇴 즉시 로그아웃)
+        blacklistAccessToken(accessToken);
         user.withdraw(deleteReasonDTO.getReason(), LocalDateTime.now());
         userRepository.save(user);
         return user;
+    }
+
+    private void blacklistAccessToken(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            return;
+        }
+        long ttlMs = jwtTokenProvider.getRemainingExpiryMs(accessToken);
+        if (ttlMs > 0) {
+            accessTokenBlackListManager.addToBlacklist(accessToken, ttlMs);
+        }
     }
 
     /**

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -51,19 +51,55 @@ public class UserWithdrawService{
      * 회원 탈퇴
      * - Refresh Token 전체 삭제
      * - 현재 요청의 Access Token을 블랙리스트에 등록하여 탈퇴 즉시 로그아웃 처리
+     *
+     * Redis(RefreshToken 삭제/AccessToken 블랙리스트)는 @Transactional 롤백 대상이 아니므로,
+     * DB 커밋이 확정된 뒤(afterCommit)에만 반영한다. 이렇게 하면 DB 저장이 실패해 롤백되는 경우
+     * "DB는 ACTIVE인데 Redis만 로그아웃 처리된" 불일치가 생기지 않는다.
      */
     @Transactional
     public Users withdrawUser(
             Long userId, UserRequestDTO.DeleteReasonDTO deleteReasonDTO, String accessToken) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        // 1. 리프레시 토큰 즉시 무효화
-        refreshTokenManager.deleteAllTokens(userId);
-        // 2. 현재 액세스 토큰 즉시 블랙리스트 등록 (탈퇴 즉시 로그아웃)
-        blacklistAccessToken(accessToken);
+
         user.withdraw(deleteReasonDTO.getReason(), LocalDateTime.now());
         userRepository.save(user);
+
+        // DB 커밋 후에만 Redis 반영 (커밋 실패 시 Redis는 건드리지 않음)
+        runAfterCommit(() -> invalidateTokens(userId, accessToken));
+
         return user;
+    }
+
+    /**
+     * 트랜잭션 동기화가 활성 상태면 커밋 후에 실행되도록 등록하고,
+     * 활성 상태가 아니면(예: 순수 단위 테스트처럼 트랜잭션 밖에서 호출된 경우) 즉시 실행한다.
+     */
+    private void runAfterCommit(Runnable task) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    task.run();
+                }
+            });
+        } else {
+            task.run();
+        }
+    }
+
+    /**
+     * 리프레시 토큰 전체 삭제 + 현재 액세스 토큰 블랙리스트 등록.
+     * DB 트랜잭션 커밋 후에만 호출되므로, 여기서 실패해도 DB 상태를 되돌릴 수 없다.
+     * 따라서 예외를 던지지 않고 로그만 남긴다(재시도/보상 처리는 후속 개선 과제).
+     */
+    private void invalidateTokens(Long userId, String accessToken) {
+        try {
+            refreshTokenManager.deleteAllTokens(userId);
+        } catch (Exception e) {
+            log.warn("탈퇴 처리 중 리프레시 토큰 삭제 실패 (userId={})", userId, e);
+        }
+        blacklistAccessToken(accessToken);
     }
 
     private void blacklistAccessToken(String accessToken) {
@@ -121,11 +157,12 @@ public class UserWithdrawService{
         userRepository.deleteAll(toDelete);
 
         // 2. DB 커밋 후에만 Redis 토큰 삭제
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                for (Long userId : inactiveUserIds) {
+        runAfterCommit(() -> {
+            for (Long userId : inactiveUserIds) {
+                try {
                     refreshTokenManager.deleteAllTokens(userId);
+                } catch (Exception e) {
+                    log.warn("완전삭제 후 리프레시 토큰 삭제 실패 (userId={})", userId, e);
                 }
             }
         });
@@ -143,11 +180,17 @@ public class UserWithdrawService{
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
 
-        // 2. Redis 토큰 삭제
-        refreshTokenManager.deleteAllTokens(userId);
-
-        // 3. 부모 엔티티 삭제. 연관 데이터는 DB ON DELETE CASCADE가 정리합니다.
+        // 2. 부모 엔티티 삭제. 연관 데이터는 DB ON DELETE CASCADE가 정리합니다.
         userRepository.delete(user);
+
+        // 3. Redis 토큰 삭제는 DB 커밋 후에만 (삭제가 롤백되면 Redis는 건드리지 않음)
+        runAfterCommit(() -> {
+            try {
+                refreshTokenManager.deleteAllTokens(userId);
+            } catch (Exception e) {
+                log.warn("테스트 삭제 후 리프레시 토큰 삭제 실패 (userId={})", userId, e);
+            }
+        });
 
         log.info("🧪 테스트 삭제 완료: 사용자 ID {}", userId);
 

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -12,6 +12,7 @@ import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import com.umc.linkyou.jwt.CurrentUser;
 import org.springframework.web.bind.annotation.*;
@@ -67,6 +68,7 @@ public interface UserApi {
                     사용자 계정을 비활성화(INACTIVE) 처리합니다.
                     - 탈퇴 사유를 입력받아 저장합니다.
                     - 실제 데이터 삭제는 정책에 따라 유예 기간(예: 30일) 후에 진행됩니다.
+                    - 리프레시 토큰을 즉시 삭제하고, 현재 액세스 토큰을 블랙리스트에 등록하여 탈퇴 즉시 로그아웃 처리됩니다.
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
@@ -74,7 +76,8 @@ public interface UserApi {
     @PostMapping("/inactive")
     ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(
             @CurrentUser CustomUserDetails userDetails,
-            @RequestBody @Valid UserRequestDTO.DeleteReasonDTO deleteReasonDTO);
+            @RequestBody @Valid UserRequestDTO.DeleteReasonDTO deleteReasonDTO,
+            HttpServletRequest request);
 
     // 소셜 프로필 완성 temp -> active
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.user.UserSuccessStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
+import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.service.users.TermsAgreementService;
@@ -14,6 +15,7 @@ import com.umc.linkyou.web.api.UserApi;
 import com.umc.linkyou.web.dto.UserRequestDTO;
 import com.umc.linkyou.web.dto.UserResponseDTO;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
@@ -42,8 +44,9 @@ public class UserController implements UserApi {
     }
 
     @Override
-    public ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(@CurrentUser CustomUserDetails userDetails, UserRequestDTO.DeleteReasonDTO deleteReasonDTO) {
-        Users user = userWithdrawService.withdrawUser(userDetails.getUserId(), deleteReasonDTO);
+    public ApiResponse<UserResponseDTO.withDrawalResultDTO> withdrawMe(@CurrentUser CustomUserDetails userDetails, UserRequestDTO.DeleteReasonDTO deleteReasonDTO, HttpServletRequest request) {
+        String accessToken = JwtTokenProvider.resolveToken(request);
+        Users user = userWithdrawService.withdrawUser(userDetails.getUserId(), deleteReasonDTO, accessToken);
         return ApiResponse.onSuccess(UserSuccessStatus.USER_WITHDRAW_OK, UserConverter.toWithDrawalResultDTO(user));
     }
 

--- a/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
@@ -3,6 +3,8 @@ package com.umc.linkyou.service;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.jwt.AccessTokenBlackListManager;
+import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.UserStatus;
@@ -10,6 +12,7 @@ import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.service.users.UserStatusValidator;
 import com.umc.linkyou.service.users.UserWithdrawService;
+import com.umc.linkyou.web.dto.UserRequestDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -22,12 +25,15 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("UserWithdrawService - recoverUser 테스트")
+@DisplayName("UserWithdrawService - withdrawUser/recoverUser 테스트")
 public class UserWithdrawServiceTest {
 
 
@@ -36,9 +42,139 @@ public class UserWithdrawServiceTest {
     @Mock private RefreshTokenManager refreshTokenManager;
     @Mock private AuthAccountRepository authAccountRepository;
     @Mock private UserStatusValidator userStatusValidator;
+    @Mock private JwtTokenProvider jwtTokenProvider;
+    @Mock private AccessTokenBlackListManager accessTokenBlackListManager;
 
     @InjectMocks
     private UserWithdrawService userWithdrawService;
+
+    @Nested
+    @DisplayName("withdrawUser - 회원 탈퇴 테스트")
+    class Withdraw {
+
+        @Test
+        @DisplayName("accessToken이 주어지면 리프레시 토큰 삭제 + 액세스 토큰을 블랙리스트에 등록하고 즉시 로그아웃 처리한다")
+        void 탈퇴_성공_액세스토큰_블랙리스트등록() {
+            // given
+            Long userId = 10L;
+            String accessToken = "access-token-value";
+            long remainingTtlMs = 60_000L;
+
+            Users user = Users.builder().id(userId).status(UserStatus.ACTIVE).build();
+            UserRequestDTO.DeleteReasonDTO reasonDTO = new UserRequestDTO.DeleteReasonDTO();
+            reasonDTO.setReason("더 이상 사용하지 않음");
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+            given(jwtTokenProvider.getRemainingExpiryMs(accessToken)).willReturn(remainingTtlMs);
+
+            // when
+            Users result = userWithdrawService.withdrawUser(userId, reasonDTO, accessToken);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.INACTIVE);
+            assertThat(result.getDeleted_reason()).isEqualTo("더 이상 사용하지 않음");
+            then(refreshTokenManager).should(times(1)).deleteAllTokens(userId);
+            then(accessTokenBlackListManager)
+                    .should(times(1))
+                    .addToBlacklist(accessToken, remainingTtlMs);
+        }
+
+        @Test
+        @DisplayName("accessToken이 없으면(webhook 등 내부 호출) 블랙리스트 등록을 시도하지 않는다")
+        void 탈퇴_성공_액세스토큰_없음() {
+            // given
+            Long userId = 11L;
+            Users user = Users.builder().id(userId).status(UserStatus.ACTIVE).build();
+            UserRequestDTO.DeleteReasonDTO reasonDTO = new UserRequestDTO.DeleteReasonDTO();
+            reasonDTO.setReason("웹훅에 의한 탈퇴");
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+
+            // when : accessToken 없는 2-arg 오버로드 호출
+            Users result = userWithdrawService.withdrawUser(userId, reasonDTO);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.INACTIVE);
+            then(refreshTokenManager).should(times(1)).deleteAllTokens(userId);
+            then(jwtTokenProvider).should(never()).getRemainingExpiryMs(org.mockito.ArgumentMatchers.anyString());
+            then(accessTokenBlackListManager)
+                    .should(never())
+                    .addToBlacklist(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyLong());
+        }
+
+        @Test
+        @DisplayName("이미 만료된 accessToken(TTL 0 이하)은 블랙리스트에 등록하지 않는다")
+        void 탈퇴_성공_만료된_토큰은_블랙리스트_등록_안함() {
+            // given
+            Long userId = 12L;
+            String expiredAccessToken = "expired-access-token";
+            Users user = Users.builder().id(userId).status(UserStatus.ACTIVE).build();
+            UserRequestDTO.DeleteReasonDTO reasonDTO = new UserRequestDTO.DeleteReasonDTO();
+            reasonDTO.setReason("만료 토큰 테스트");
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+            given(jwtTokenProvider.getRemainingExpiryMs(expiredAccessToken)).willReturn(0L);
+
+            // when
+            userWithdrawService.withdrawUser(userId, reasonDTO, expiredAccessToken);
+
+            // then
+            then(accessTokenBlackListManager)
+                    .should(never())
+                    .addToBlacklist(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyLong());
+        }
+
+        @Test
+        @DisplayName("만료/위조 등으로 토큰 파싱이 실패해도 탈퇴 자체는 정상 처리된다")
+        void 탈퇴_성공_토큰파싱_실패해도_탈퇴는_진행() {
+            // given
+            Long userId = 13L;
+            String malformedAccessToken = "malformed-or-expired-token";
+            Users user = Users.builder().id(userId).status(UserStatus.ACTIVE).build();
+            UserRequestDTO.DeleteReasonDTO reasonDTO = new UserRequestDTO.DeleteReasonDTO();
+            reasonDTO.setReason("파싱 실패 테스트");
+
+            given(userRepository.findById(userId)).willReturn(Optional.of(user));
+            given(userRepository.save(user)).willReturn(user);
+            given(jwtTokenProvider.getRemainingExpiryMs(malformedAccessToken))
+                    .willThrow(new RuntimeException("invalid token"));
+
+            // when : 예외가 밖으로 전파되지 않고 탈퇴 결과가 정상 반환되어야 한다
+            Users result = userWithdrawService.withdrawUser(userId, reasonDTO, malformedAccessToken);
+
+            // then
+            assertThat(result.getStatus()).isEqualTo(UserStatus.INACTIVE);
+            then(refreshTokenManager).should(times(1)).deleteAllTokens(userId);
+            then(accessTokenBlackListManager)
+                    .should(never())
+                    .addToBlacklist(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyLong());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 유저 ID면 USER_NOT_FOUND 예외가 발생하고 토큰 처리도 하지 않는다")
+        void 탈퇴_실패_존재하지않는_유저() {
+            // given
+            Long userId = 999L;
+            UserRequestDTO.DeleteReasonDTO reasonDTO = new UserRequestDTO.DeleteReasonDTO();
+            reasonDTO.setReason("탈퇴 사유");
+            given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> userWithdrawService.withdrawUser(userId, reasonDTO, "any-token"))
+                    .isInstanceOf(GeneralException.class)
+                    .satisfies(e -> {
+                        GeneralException ex = (GeneralException) e;
+                        assertThat(ex.getCode()).isEqualTo(UserErrorStatus._USER_NOT_FOUND);
+                    });
+            then(refreshTokenManager).should(never()).deleteAllTokens(org.mockito.ArgumentMatchers.anyLong());
+            then(accessTokenBlackListManager)
+                    .should(never())
+                    .addToBlacklist(org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.anyLong());
+        }
+    }
 
     @Nested
     @DisplayName("성공 케이스")

--- a/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
@@ -38,7 +38,9 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -265,6 +267,85 @@ class UserControllerTest {
                                 .content(objectMapper.writeValueAsString(request))
                                 .with(csrf()))
                         .andExpect(status().isUnauthorized());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴 엔드포인트")
+    class WithdrawMe {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("성공 - Authorization 헤더의 액세스 토큰을 추출해 서비스로 전달하고, 탈퇴 즉시 로그아웃 처리된다")
+            @WithCustomUser(userId = 4L)
+            void withdraw_me_success_blacklists_current_access_token() throws Exception {
+                UserRequestDTO.DeleteReasonDTO request = new UserRequestDTO.DeleteReasonDTO();
+                request.setReason("더 이상 사용하지 않음");
+
+                Users mockUser = Users.builder()
+                        .id(4L)
+                        .nickName("탈퇴할유저")
+                        .status(UserStatus.INACTIVE)
+                        .build();
+                ReflectionTestUtils.setField(mockUser, "createdAt", LocalDateTime.now());
+
+                String accessToken = "mock-access-token";
+
+                given(userWithdrawService.withdrawUser(eq(4L), any(), eq(accessToken)))
+                        .willReturn(mockUser);
+
+                mockMvc.perform(post("/api/v1/users/inactive")
+                                .header("Authorization", "Bearer " + accessToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf()))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.result.userId").value(4));
+
+                // 컨트롤러가 헤더에서 추출한 액세스 토큰을 그대로 서비스에 넘겨
+                // withdrawUser 내부에서 즉시 블랙리스트 등록되도록 하는지 검증
+                verify(userWithdrawService).withdrawUser(eq(4L), any(), eq(accessToken));
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("실패 - 비인증 사용자가 요청 시 401 에러를 반환한다")
+            void withdraw_me_unauthorized() throws Exception {
+                UserRequestDTO.DeleteReasonDTO request = new UserRequestDTO.DeleteReasonDTO();
+                request.setReason("사유");
+
+                mockMvc.perform(post("/api/v1/users/inactive")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf()))
+                        .andExpect(status().isUnauthorized());
+            }
+
+            @Test
+            @DisplayName("실패 - 존재하지 않는 유저인 경우 예외를 반환한다")
+            @WithCustomUser(userId = 98L)
+            void withdraw_me_user_not_found() throws Exception {
+                UserRequestDTO.DeleteReasonDTO request = new UserRequestDTO.DeleteReasonDTO();
+                request.setReason("사유");
+
+                given(userWithdrawService.withdrawUser(eq(98L), any(), any()))
+                        .willThrow(new UserHandler(UserErrorStatus._USER_NOT_FOUND));
+
+                mockMvc.perform(post("/api/v1/users/inactive")
+                                .header("Authorization", "Bearer some-token")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                                .with(csrf()))
+                        .andExpect(jsonPath("$.isSuccess").value(false));
             }
         }
     }

--- a/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
@@ -323,6 +323,7 @@ class UserControllerTest {
                                 .with(csrf()))
                         .andExpect(status().isOk())
                         .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.code").value("USERS2003"))
                         .andExpect(jsonPath("$.result.userId").value(4));
 
                 // 컨트롤러가 헤더에서 추출한 액세스 토큰을 그대로 서비스에 넘겨
@@ -355,15 +356,35 @@ class UserControllerTest {
                 UserRequestDTO.DeleteReasonDTO request = new UserRequestDTO.DeleteReasonDTO();
                 request.setReason("사유");
 
-                given(userWithdrawService.withdrawUser(eq(98L), any(), any()))
+                String accessToken = "some-token";
+
+                // 성공 케이스와 동일한 이유: Authorization 헤더가 있으면 JwtAuthenticationFilter가
+                // jwtTokenProvider.getAuthentication(token)의 (스텁하지 않으면 null인) 반환값으로
+                // SecurityContext를 덮어써 @WithCustomUser 인증이 지워진다. 이를 막아야
+                // 컨트롤러까지 요청이 도달해 userWithdrawService.withdrawUser의
+                // USER_NOT_FOUND 예외 경로가 실제로 실행된다.
+                Users authUser = Users.builder()
+                        .nickName("존재안함")
+                        .role(Role.USER)
+                        .build();
+                ReflectionTestUtils.setField(authUser, "id", 98L);
+                CustomUserDetails principal = new CustomUserDetails(authUser, "kakao");
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities());
+                given(jwtTokenProvider.getAuthentication(accessToken)).willReturn(authentication);
+
+                given(userWithdrawService.withdrawUser(eq(98L), any(), eq(accessToken)))
                         .willThrow(new UserHandler(UserErrorStatus._USER_NOT_FOUND));
 
                 mockMvc.perform(post("/api/v1/users/inactive")
-                                .header("Authorization", "Bearer some-token")
+                                .header("Authorization", "Bearer " + accessToken)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(request))
                                 .with(csrf()))
-                        .andExpect(jsonPath("$.isSuccess").value(false));
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value("USERS4041"));
+
+                verify(userWithdrawService).withdrawUser(eq(98L), any(), eq(accessToken));
             }
         }
     }

--- a/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
@@ -7,10 +7,12 @@ import com.umc.linkyou.config.common.WebConfig;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.DeviceType;
 import com.umc.linkyou.domain.enums.Gender;
+import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.domain.enums.TermsType;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.CurrentUserArgumentResolver;
+import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.SecurityErrorResponseWriter;
 import com.umc.linkyou.service.email.EmailVerificationService;
@@ -29,6 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -294,6 +298,20 @@ class UserControllerTest {
                 ReflectionTestUtils.setField(mockUser, "createdAt", LocalDateTime.now());
 
                 String accessToken = "mock-access-token";
+
+                // Authorization 헤더가 존재하면 JwtAuthenticationFilter가 SecurityContext를
+                // jwtTokenProvider.getAuthentication(token) 결과로 덮어쓴다.
+                // 이 값을 스텁하지 않으면 Mockito 기본값(null)이 반환되어
+                // @WithCustomUser가 심어둔 인증 정보가 지워지고 401(AUTH4001)이 발생한다.
+                Users authUser = Users.builder()
+                        .nickName("탈퇴할유저")
+                        .role(Role.USER)
+                        .build();
+                ReflectionTestUtils.setField(authUser, "id", 4L);
+                CustomUserDetails principal = new CustomUserDetails(authUser, "kakao");
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities());
+                given(jwtTokenProvider.getAuthentication(accessToken)).willReturn(authentication);
 
                 given(userWithdrawService.withdrawUser(eq(4L), any(), eq(accessToken)))
                         .willReturn(mockUser);


### PR DESCRIPTION
## 🔗 관련 이슈
#403 
---

## 📌 작업 내용
>회원 탈퇴시 토큰 만료
---

## 🧪 테스트 결과
> src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java에 Withdraw 중첩 클래스로 4개 케이스 추가:

accessToken 있으면 리프레시 토큰 삭제 + AccessTokenBlackListManager.addToBlacklist 호출 검증
accessToken 없는 2-arg 오버로드(웹훅 경로)는 블랙리스트 호출 안 함
TTL 0 이하(만료 토큰)는 블랙리스트 등록 안 함
존재하지 않는 유저는 예외 발생하고 토큰 처리 자체를 안 함

UserControllerTest.java에 WithdrawMe 엔드포인트 테스트 추가:

Authorization 헤더의 토큰이 그대로 userWithdrawService.withdrawUser(userId, dto, accessToken)로 전달되는지 검증
비인증 401, 존재하지 않는 유저 예외 케이스

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 회원 탈퇴 시 리프레시 토큰이 즉시 삭제되며, 이후 액세스 토큰은 남은 유효 기간을 기준으로 블랙리스트 처리되어 탈퇴와 동시에 로그아웃됩니다.
  * 토큰 무효화/블랙리스트 처리 중 오류가 발생해도 탈퇴 처리는 계속 진행됩니다.
  * 비활성 사용자 정리 작업에서 리프레시 토큰 삭제가 DB 반영 이후로 처리되도록 개선했습니다.
* **테스트**
  * 토큰 유무/만료/예외 상황 및 컨트롤러 전달 값까지 시나리오별 검증을 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->