### PR TITLE
fix: 약관 요청/응답 DTO에서 termsVersion·userId 필드 정리

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/TermsConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/TermsConverter.java
@@ -21,7 +21,7 @@ public class TermsConverter {
     /**
      * 전체 약관 상태 응답 DTO 생성
      */
-    public static UserResponseDTO.TermsStatusDTO toTermsStatusDTO(Long userId, List<TermsAgreement> agreements) {
+    public static UserResponseDTO.TermsStatusDTO toTermsStatusDTO(List<TermsAgreement> agreements) {
         // 1. 약관 타입별 동의 여부 Map 생성 (순서 보장)
         Map<TermsType, Boolean> termsStatusMap = agreements.stream()
                 .collect(Collectors.toMap(
@@ -41,7 +41,6 @@ public class TermsConverter {
                 && requiredList.stream().allMatch(TermsAgreement::getIsAgreed);
 
         return UserResponseDTO.TermsStatusDTO.builder()
-                .userId(userId)
                 .termsStatus(termsStatusMap)
                 .allRequiredAgreed(allRequiredAgreed)
                 .build();

--- a/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
+++ b/src/main/java/com/umc/linkyou/service/users/TermsAgreementService.java
@@ -47,7 +47,7 @@ public class TermsAgreementService {
         upsertTerms(user, request.termsMap());
 
         List<TermsAgreement> updatedList = termsAgreementRepository.findAllByUserId(user.getId());
-        return TermsConverter.toTermsStatusDTO(user.getId(), updatedList);
+        return TermsConverter.toTermsStatusDTO(updatedList);
     }
 
     /**
@@ -79,7 +79,7 @@ public class TermsAgreementService {
     public UserResponseDTO.TermsStatusDTO getTermsStatus(CustomUserDetails userDetails) {
         // userDetails.getUserId()를 사용하여 단순 조회
         List<TermsAgreement> agreements = termsAgreementRepository.findAllByUserId(userDetails.getUserId());
-        return TermsConverter.toTermsStatusDTO(userDetails.getUserId(), agreements);
+        return TermsConverter.toTermsStatusDTO(agreements);
     }
 
     @Transactional

--- a/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
@@ -145,15 +145,8 @@ public class UserRequestDTO {
                     anyOf = {TermsType.class}
             )
             @NotEmpty(message = "변경할 약관 상태를 하나 이상 입력해주세요.")
-            Map<TermsType, Boolean> termsMap,
-
-            @Schema(description = "약관 버전", example = "v1.0")
-            String termsVersion
+            Map<TermsType, Boolean> termsMap
     ) {
-        // 컴팩트 생성자를 사용하여 기본값 설정
-        public TermsAgreeDTO {
-            if (termsVersion == null) termsVersion = "v1.0";
-        }
     }
 
 }

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -126,9 +126,6 @@ public class UserResponseDTO {
     @Schema(description = "약관 동의 상태 응답 (키-값 형태)")
     public static class TermsStatusDTO {
 
-        @Schema(description = "사용자 ID", example = "123")
-        private Long userId;
-
         @Schema(
                 description = "약관별 동의 상태 맵",
                 example = "{\"TERMS_OF_USE\":true,\"MARKETING\":true,\"PRIVACY_POLICY\":false}")

--- a/src/test/java/com/umc/linkyou/integration/TermsIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/integration/TermsIntegrationTest.java
@@ -120,8 +120,7 @@ class TermsIntegrationTest {
             Users user = createUser("로그인유저");
 
             UserRequestDTO.TermsAgreeDTO request = new UserRequestDTO.TermsAgreeDTO(
-                    Map.of(TermsType.MARKETING, true),
-                    "v1.0"
+                    Map.of(TermsType.MARKETING, true)
             );
 
             mockMvc.perform(patch("/api/v1/users/terms/agree")

--- a/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/user/UserControllerTest.java
@@ -166,7 +166,6 @@ class UserControllerTest {
             @WithCustomUser(userId = 1L)
             void get_terms_status_success() throws Exception {
                 UserResponseDTO.TermsStatusDTO mockResponse = UserResponseDTO.TermsStatusDTO.builder()
-                        .userId(1L)
                         .termsStatus(Map.of(
                                 TermsType.TERMS_OF_USE, true,
                                 TermsType.PRIVACY_POLICY, true,
@@ -212,11 +211,9 @@ class UserControllerTest {
             void update_terms_success() throws Exception {
                 UserRequestDTO.TermsAgreeDTO request = UserRequestDTO.TermsAgreeDTO.builder()
                         .termsMap(Map.of(TermsType.MARKETING, true))
-                        .termsVersion("v1.0")
                         .build();
 
                 UserResponseDTO.TermsStatusDTO mockResponse = UserResponseDTO.TermsStatusDTO.builder()
-                        .userId(1L)
                         .termsStatus(Map.of(
                                 TermsType.TERMS_OF_USE, true,
                                 TermsType.PRIVACY_POLICY, true,
@@ -246,8 +243,7 @@ class UserControllerTest {
             void update_terms_fail_invalid_type() throws Exception {
                 String invalidJson = """
                         {
-                          "termsMap": { "INVALID_TYPE": true },
-                          "termsVersion": "v1.0"
+                          "termsMap": { "INVALID_TYPE": true }
                         }
                         """;
 
@@ -263,7 +259,6 @@ class UserControllerTest {
             void update_terms_unauthorized() throws Exception {
                 UserRequestDTO.TermsAgreeDTO request = UserRequestDTO.TermsAgreeDTO.builder()
                         .termsMap(Map.of(TermsType.MARKETING, true))
-                        .termsVersion("v1.0")
                         .build();
 
                 mockMvc.perform(patch("/api/v1/users/terms/agree")


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용

약관 요청/응답 DTO에서 termsVersion·userId 필드를 정리했습니다. 

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **변경 사항**
  * 약관 동의 요청에서 약관 버전 입력 항목이 제거되었습니다.
  * 약관 상태 응답에서 사용자 ID가 제외됩니다.
  * 약관 상태는 약관별 동의 여부와 필수 약관 전체 동의 여부로 제공됩니다.
  * 약관 조회 및 업데이트 기능이 변경된 응답 형식에 맞게 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->