### PR TITLE
feat: 검색어 중복제거 

### DIFF
--- a/src/main/java/com/umc/linkyou/repository/LinkuSearchHistoryRepository.java
+++ b/src/main/java/com/umc/linkyou/repository/LinkuSearchHistoryRepository.java
@@ -16,7 +16,7 @@ public interface LinkuSearchHistoryRepository extends JpaRepository<LinkuSearchH
 
     Optional<LinkuSearchHistory> findFirstByUserIdOrderByCreatedAtAsc(Long userId);
 
-
+    void deleteByUserIdAndKeyword(Long userId, String keyword);
 
     void deleteAllByUserId(Long userId);
 }

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuSearchService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuSearchService.java
@@ -39,7 +39,8 @@ public class LinkuSearchService{
         List<LinkuSearchResponseDTO.LinkuSearchItemDTO> items = hasNext ? fetched.subList(0, size) : fetched;
         Long nextCursor = hasNext ? items.get(items.size() - 1).userLinkuId() : null;
 
-        // 키워드 저장
+        // 동일 키워드 기존 기록 제거 후 저장 (중복 제거, 최신순 재정렬)
+        linkuSearchHistoryRepository.deleteByUserIdAndKeyword(userId, trimmed);
         linkuSearchHistoryRepository.save(LinkuSearchHistory.of(userId, trimmed));
         // 10개 넘으면 가장 오래된 것 삭제
         if (linkuSearchHistoryRepository.countByUserId(userId) > 10) {

--- a/src/test/java/com/umc/linkyou/service/Linku/LinkuSearchServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/Linku/LinkuSearchServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -131,6 +133,20 @@ class LinkuSearchServiceTest {
                 linkuSearchService.search(1L, "Java", null, 10);
 
                 verify(linkuSearchHistoryRepository).save(any(LinkuSearchHistory.class));
+            }
+
+            @Test
+            @DisplayName("검색 성공 시 동일 키워드의 기존 기록을 삭제한 뒤 저장한다")
+            void 검색_성공_시_동일_키워드_기존_기록을_삭제한_뒤_저장한다() {
+                when(linkuRepository.searchUserLinks(1L, "Java", null, 10))
+                        .thenReturn(List.of(searchItem(1L, "A")));
+                when(linkuSearchHistoryRepository.countByUserId(1L)).thenReturn(5L);
+
+                linkuSearchService.search(1L, "Java", null, 10);
+
+                InOrder inOrder = inOrder(linkuSearchHistoryRepository);
+                inOrder.verify(linkuSearchHistoryRepository).deleteByUserIdAndKeyword(1L, "Java");
+                inOrder.verify(linkuSearchHistoryRepository).save(any(LinkuSearchHistory.class));
             }
 
             @Test


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련된 이슈 번호를 적어주세요.
> 예: closes [#1](https://github.com/사용자명/프로젝트명/issues/1)

---

## 📌 작업 내용

중복된 검색어가 저장되지 않도록 수정했습니다. 
검색어 저장 시 중복되면 제거하고 최근 것으로 덮어쓰기 하도록 수정했습니다.

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.

---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.

---

## 📎 참고 사항 (선택)
> 리뷰어에게 전달할 참고사항이나 추가 확인이 필요한 내용을 적어주세요.
> 예시:
> - 특정 패키지 구조의 적절성 검토  
> - 협의가 필요한 응답 포맷 관련 내용  
> - 리팩토링 또는 확장 계획


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 동일한 키워드로 검색할 때 기존 검색 기록을 갱신한 후 새 기록이 저장되도록 변경했습니다.
  * 동일 사용자·키워드의 중복 검색 기록이 쌓이지 않습니다.

* **테스트**
  * 기존 기록 삭제 후 새 기록이 저장되는 처리 순서를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->