### PR TITLE
fix: 만료된 토큰 응답을 400에서 401로 수정

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/auth/AuthErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/auth/AuthErrorStatus.java
@@ -12,7 +12,7 @@ import org.springframework.http.HttpStatus;
 public enum AuthErrorStatus implements BaseErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH4001", "인증이 필요합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4011", "잘못된 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "AUTH4002", "만료된 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "만료된 토큰입니다."),
     PERMISSION_DENIED(HttpStatus.FORBIDDEN, "AUTH4003", "권한이 없습니다."),
     _REFRESH_TOKEN_SESSION_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "AUTH5002", "세션 저장 중 오류가 발생했습니다.");
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔗 관련 이슈
> 관련 이슈 없음

---

## 📌 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
> 기능, 리팩토링, 문서화 등 주요 변경 사항을 정리합니다.

### 1️⃣ Non-Functional Requirement
- 만료된 JWT는 요청 형식 오류가 아니라 인증 실패에 해당하므로, `AuthErrorStatus.EXPIRED_TOKEN`의 HTTP 상태 코드를 `400 Bad Request` → `401 Unauthorized`로 수정
- `UNAUTHORIZED`, `INVALID_TOKEN`, `EXPIRED_TOKEN` 등 토큰 관련 인증 실패 응답이 모두 401로 일관됨

### 2️⃣ Functional Requirement
- 해당 없음

---

## 🧪 테스트 결과
- `./gradlew compileJava` 통과 확인

---

## 📸 스크린샷 (선택)
- 해당 없음

---

## 📎 참고 사항 (선택)
- 해당 없음
