### PR TITLE
fix: #410 추천 쿼리 메모리 사용량 개선

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
@@ -9,6 +9,7 @@ import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.mapping.LinkuFolder;
 import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.repository.dto.RankedUsersLinku;
 import com.umc.linkyou.web.dto.linku.LinkuRequestDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 
@@ -187,6 +188,25 @@ public class LinkuConverter {
                 .lastViewedAt(usersLinku != null ? usersLinku.getLastViewedAt() : null)
                 .build();
     } //리스트로 반환할때 쓰이는 것
+
+    public static LinkuResponseDTO.LinkuSimpleDTO toLinkuSimpleDTO(
+            RankedUsersLinku candidate, LinkuFolder linkuFolder) {
+        return LinkuResponseDTO.LinkuSimpleDTO.builder()
+                .userLinkuId(candidate.userLinkuId())
+                .linkuId(candidate.linkuId())
+                .categoryId(candidate.categoryId())
+                .folderName(linkuFolder != null ? linkuFolder.getFolder().getFolderName() : null)
+                .linku(candidate.linku())
+                .memo(candidate.memo())
+                .emotionId(candidate.emotionId())
+                .title(candidate.title())
+                .domain(candidate.domain())
+                .domainImageUrl(candidate.domainImageUrl())
+                .linkuImageUrl(candidate.linkuImageUrl())
+                .aiArticleExists(Boolean.TRUE.equals(candidate.aiArticleExists()))
+                .lastViewedAt(candidate.lastViewedAt())
+                .build();
+    }
 
     // 마이페이지 AI 요약 링크 목록용 - toLinkuSimpleDTO와 동일한 title/linkuImageUrl 우선순위 패턴
     // (usersLinku 우선, 없으면 linku)을 사용한다.

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
@@ -257,7 +257,8 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
     private String nativeTextExpression(String profileTsqueryText, String profileText) {
         if (profileTsqueryText == null && profileText == null) return "0.0";
         String document = "to_tsvector('simple', l.title || ' ' || COALESCE(aa.summary, ''))";
-        String fts = "CAST(ts_rank_cd(" + document + ", to_tsquery('simple', :profileTsqueryText)) AS double precision)";
+        String ftsRank = "CAST(ts_rank_cd(" + document + ", to_tsquery('simple', :profileTsqueryText)) AS double precision)";
+        String fts = "(" + ftsRank + " / (" + ftsRank + " + 1.0))";
         String trgm = "COALESCE(similarity(l.title || ' ' || COALESCE(aa.summary, ''), :profileText), 0)";
         return "CASE WHEN :profileTsqueryText IS NULL OR :profileTsqueryText = '' THEN 0.0 "
                 + "WHEN " + fts + " > 0 THEN " + fts + " ELSE " + trgm + " * 0.7 END";

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
@@ -7,16 +7,23 @@ import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.linkyou.config.properties.RecommendScoreProperties;
 import com.umc.linkyou.domain.QAiArticle;
 import com.umc.linkyou.domain.QLinku;
 import com.umc.linkyou.domain.mapping.QUsersLinku;
 import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.repository.dto.RankedUsersLinku;
 import com.umc.linkyou.service.common.HomeRecommendScoreService;
+import com.umc.linkyou.utils.EmotionSimilarityUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 @RequiredArgsConstructor
 public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
@@ -25,6 +32,8 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
     private final HomeRecommendScoreService homeRecommendScoreService;
+    private final EntityManager entityManager;
+    private final RecommendScoreProperties scoreProperties;
 
     @Override
     public List<UsersLinku> fetchAiArticlesByCategoryId(Long userId, Long categoryId) {
@@ -108,56 +117,154 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
             Long userId, Long selectedEmotionId, Long selectedSituationId, List<Long> mappedCategoryIds,
             LocalDateTime now, String profileTsqueryText, String profileText,
             int recencyThresholdDays, Integer afterScoreBucket, Long afterUserLinkuId, int limit) {
-        QUsersLinku usersLinku = QUsersLinku.usersLinku;
-        QLinku linku = QLinku.linku;
-        QAiArticle aiArticle = QAiArticle.aiArticle;
-        BooleanExpression excludeNovelty =
-                homeRecommendScoreService.notNoveltyCondition(usersLinku, now, recencyThresholdDays);
+        return findNormalRecommendCandidatesNative(
+                userId, selectedEmotionId, selectedSituationId, mappedCategoryIds, now,
+                profileTsqueryText, profileText, recencyThresholdDays, afterScoreBucket,
+                afterUserLinkuId, limit);
+    }
 
-        NumberExpression<Double> totalScore = homeRecommendScoreService.scoreExpression(
-                usersLinku, linku, aiArticle, userId,
-                selectedEmotionId, selectedSituationId, mappedCategoryIds,
-                now, profileTsqueryText, profileText);
-        NumberExpression<Integer> bucket = homeRecommendScoreService.scoreBucketExpression(totalScore);
-        NumberPath<Integer> bucketAlias = Expressions.numberPath(Integer.class, SCORE_BUCKET_ALIAS);
-        NumberExpression<Integer> selectedBucket = bucket.as(bucketAlias);
-        BooleanExpression seek = seekCondition(bucket, usersLinku, afterScoreBucket, afterUserLinkuId);
+    //  점수식을 CTE에서 한 번만 계산해 HQL 파서의 대형 표현식 중복을 피하는 Native 쿼리 방식 조회
+    private List<RankedUsersLinku> findNormalRecommendCandidatesNative(
+            Long userId, Long selectedEmotionId, Long selectedSituationId, List<Long> mappedCategoryIds,
+            LocalDateTime now, String profileTsqueryText, String profileText,
+            int recencyThresholdDays, Integer afterScoreBucket, Long afterUserLinkuId, int limit) {
+        String categoryCondition = mappedCategoryIds == null || mappedCategoryIds.isEmpty()
+                ? "FALSE"
+                : "l.category_id IN (" + mappedCategoryIds.stream().map(String::valueOf).collect(java.util.stream.Collectors.joining(",")) + ")";
+        String scoreExpression = nativeScoreExpression(
+                selectedEmotionId, selectedSituationId, categoryCondition, profileTsqueryText, profileText);
+        boolean hasCursor = afterScoreBucket != null && afterUserLinkuId != null;
+        String cursorCondition = hasCursor
+                ? "(score_bucket, user_linku_id) < (:afterScoreBucket, :afterUserLinkuId)"
+                : "TRUE";
 
-        boolean textMatchEnabled = profileTsqueryText != null || profileText != null;
-        JPAQuery<RankedUsersLinku> query = queryFactory
-                .select(Projections.constructor(
-                        RankedUsersLinku.class,
-                        usersLinku.userLinkuId,
-                        linku.linkuId,
-                        linku.category.categoryId,
-                        linku.linkuUrl,
-                        usersLinku.memo,
-                        usersLinku.emotion.emotionId,
-                        usersLinku.title.coalesce(linku.title),
-                        linku.domain.name,
-                        linku.domain.imageUrl,
-                        usersLinku.imageUrl.coalesce(linku.imgUrl),
-                        usersLinku.aiExist,
-                        usersLinku.lastViewedAt,
-                        selectedBucket))
-                .from(usersLinku)
-                .join(usersLinku.linku, linku)
-                .join(usersLinku.emotion)
-                .join(linku.category)
-                .join(linku.domain)
-                // situation nullable — INNER/경로참조만 하면 situation 없는 링크가 빠지는 버그가 생김
-                .leftJoin(usersLinku.situation);
+        String sql = """
+                WITH scored AS MATERIALIZED (
+                    SELECT
+                        ul.user_linku_id,
+                        l.linku_id,
+                        l.category_id,
+                        l.linku_url,
+                        ul.memo,
+                        ul.emotion_id,
+                        COALESCE(ul.title, l.title) AS title,
+                        d.name AS domain,
+                        d.image_url AS domain_image_url,
+                        COALESCE(ul.image_url, l.img_url) AS linku_image_url,
+                        ul.is_ai_exist,
+                        ul.last_viewed_at,
+                        CAST((%s) * 200 AS integer) AS score_bucket
+                    FROM users_linkus ul
+                    JOIN linkus l ON l.linku_id = ul.linku_id
+                    JOIN domains d ON d.domain_id = l.domain_id
+                    LEFT JOIN ai_articles aa ON aa.linku_id = l.linku_id
+                    WHERE ul.user_id = :userId
+                      AND NOT (COALESCE(ul.last_viewed_at, ul.created_at) < :noveltyThreshold)
+                )
+                SELECT user_linku_id, linku_id, category_id, linku_url, memo, emotion_id,
+                       title, domain, domain_image_url, linku_image_url, is_ai_exist,
+                       last_viewed_at, score_bucket
+                FROM scored
+                WHERE %s
+                ORDER BY score_bucket DESC, user_linku_id DESC
+                LIMIT :limit
+                """.formatted(scoreExpression, cursorCondition);
 
-        if (textMatchEnabled) {
-            query.leftJoin(linku.aiArticle, aiArticle);
+        Query query = entityManager.createNativeQuery(sql)
+                .setParameter("userId", userId)
+                .setParameter("noveltyThreshold", now.minusDays(recencyThresholdDays))
+                .setParameter("now", now)
+                .setParameter("limit", limit)
+                .setParameter("selectedSituationId", selectedSituationId);
+        if (hasCursor) {
+            query.setParameter("afterScoreBucket", afterScoreBucket);
+            query.setParameter("afterUserLinkuId", afterUserLinkuId);
+        }
+        if (profileTsqueryText != null || profileText != null) {
+            query.setParameter("profileTsqueryText", profileTsqueryText);
+            query.setParameter("profileText", profileText);
         }
 
-        return query
-                // SELECT alias로 정렬해 거대한 점수식의 HQL 중복을 막는다.
-                .where(usersLinku.user.id.eq(userId), excludeNovelty, seek)
-                .orderBy(bucketAlias.desc(), usersLinku.userLinkuId.desc())
-                .limit(limit)
-                .fetch();
+        List<RankedUsersLinku> result = new ArrayList<>();
+        for (Object rowObject : query.getResultList()) {
+            Object[] row = (Object[]) rowObject;
+            result.add(new RankedUsersLinku(
+                    ((Number) row[0]).longValue(),
+                    ((Number) row[1]).longValue(),
+                    ((Number) row[2]).longValue(),
+                    (String) row[3],
+                    (String) row[4],
+                    ((Number) row[5]).longValue(),
+                    (String) row[6],
+                    (String) row[7],
+                    (String) row[8],
+                    (String) row[9],
+                    (Boolean) row[10],
+                    row[11] instanceof Timestamp timestamp ? timestamp.toLocalDateTime() : (LocalDateTime) row[11],
+                    ((Number) row[12]).intValue()));
+        }
+        return result;
+    }
+
+    private String nativeScoreExpression(
+            Long selectedEmotionId, Long selectedSituationId, String categoryCondition,
+            String profileTsqueryText, String profileText) {
+        RecommendScoreProperties.Weight weight = scoreProperties.weight();
+        RecommendScoreProperties.Normalization normalization = scoreProperties.normalization();
+        RecommendScoreProperties.Confidence confidence = scoreProperties.confidence();
+
+        String emotion = nativeEmotionExpression(selectedEmotionId, confidence.aiEmotionDiscount());
+        String situation = "(CASE WHEN ul.situation_id = CAST(:selectedSituationId AS bigint) THEN 1.0 ELSE 0.0 END)"
+                + " * CASE WHEN ul.is_situation_ai THEN " + decimal(confidence.aiSituationDiscount()) + " ELSE 1.0 END";
+        String engagement = "((LEAST(CAST(ul.view_count AS double precision), " + normalization.viewCountCap() + ") / "
+                + normalization.viewCountCap() + ") + CASE WHEN ul.last_viewed_at IS NULL THEN 0.0 ELSE "
+                + "EXP(-GREATEST(EXTRACT(EPOCH FROM (:now - ul.last_viewed_at)) / 86400.0, 0) / "
+                + normalization.recencyHalfLifeDays() + ") END) / 2.0";
+        String popularity = "LEAST(LN(1 + CAST(l.total_view_count AS double precision)) / LN(1 + "
+                + normalization.popularityViewCountCap() + "), 1.0)";
+        String text = nativeTextExpression(profileTsqueryText, profileText);
+        String keyword = "LEAST(CAST(COALESCE((SELECT SUM(upk.weight) FROM linku_keywords lk "
+                + "JOIN user_profile_keywords upk ON upk.keyword_id = lk.keyword_id "
+                + "WHERE lk.linku_id = l.linku_id AND upk.user_id = :userId), 0) AS double precision), "
+                + normalization.keywordWeightCap() + ") / " + normalization.keywordWeightCap();
+        String category = "CASE WHEN " + categoryCondition + " THEN 1.0 ELSE 0.0 END";
+
+        return "(" + emotion + " * " + decimal(weight.emotion())
+                + " + " + situation + " * " + decimal(weight.situation())
+                + " + " + engagement + " * " + decimal(weight.engagement())
+                + " + " + popularity + " * " + decimal(weight.popularity())
+                + " + " + text + " * " + decimal(weight.text())
+                + " + " + keyword + " * " + decimal(weight.keyword())
+                + " + " + category + " * " + decimal(weight.category()) + ")";
+    }
+
+    private String nativeEmotionExpression(Long selectedEmotionId, double aiDiscount) {
+        if (selectedEmotionId == null) return "0.0";
+        StringBuilder expression = new StringBuilder("(CASE ul.emotion_id");
+        boolean hasMatch = false;
+        for (long candidateEmotionId = 1; candidateEmotionId <= 6; candidateEmotionId++) {
+            int similarity = EmotionSimilarityUtil.getSimilarityScore(selectedEmotionId, candidateEmotionId);
+            if (similarity > 0) {
+                hasMatch = true;
+                expression.append(" WHEN ").append(candidateEmotionId).append(" THEN ").append(similarity);
+            }
+        }
+        if (!hasMatch) return "0.0";
+        return expression.append(" ELSE 0 END / 60.0) * CASE WHEN ul.is_emotion_ai THEN ")
+                .append(decimal(aiDiscount)).append(" ELSE 1.0 END").toString();
+    }
+
+    private String nativeTextExpression(String profileTsqueryText, String profileText) {
+        if (profileTsqueryText == null && profileText == null) return "0.0";
+        String document = "to_tsvector('simple', l.title || ' ' || COALESCE(aa.summary, ''))";
+        String fts = "CAST(ts_rank_cd(" + document + ", to_tsquery('simple', :profileTsqueryText)) AS double precision)";
+        String trgm = "COALESCE(similarity(l.title || ' ' || COALESCE(aa.summary, ''), :profileText), 0)";
+        return "CASE WHEN :profileTsqueryText IS NULL OR :profileTsqueryText = '' THEN 0.0 "
+                + "WHEN " + fts + " > 0 THEN " + fts + " ELSE " + trgm + " * 0.7 END";
+    }
+
+    private String decimal(double value) {
+        return String.format(Locale.ROOT, "%.12f", value);
     }
 
     @Override
@@ -203,7 +310,7 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
                 .fetch();
     }
 
-    /** seek 탐색 조건. 둘 다 null이면 첫 페이지(조건 없음), 아니면 (bucket, userLinkuId) 이전 행부터 */
+    // seek 탐색 조건으로, 둘다 null이면 조건 없음으로 첫 페이지로, 아니라면 이전 행부터 탐색
     private BooleanExpression seekCondition(
             NumberExpression<Integer> bucket, QUsersLinku usersLinku,
             Integer afterScoreBucket, Long afterUserLinkuId) {

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
@@ -1,27 +1,27 @@
 package com.umc.linkyou.repository.UserLinkuRepository;
 
-import com.querydsl.core.Tuple;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.linkyou.domain.QAiArticle;
 import com.umc.linkyou.domain.QLinku;
 import com.umc.linkyou.domain.mapping.QUsersLinku;
 import com.umc.linkyou.domain.mapping.UsersLinku;
-import com.umc.linkyou.domain.recommend.QUserProfileKeyword;
 import com.umc.linkyou.repository.dto.RankedUsersLinku;
 import com.umc.linkyou.service.common.HomeRecommendScoreService;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
+
+    private static final String SCORE_BUCKET_ALIAS = "scoreBucket";
 
     private final JPAQueryFactory queryFactory;
     private final HomeRecommendScoreService homeRecommendScoreService;
@@ -71,9 +71,9 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
         return queryFactory
                 .selectFrom(usersLinku)
                 .join(usersLinku.linku, linku).fetchJoin()
-                .leftJoin(linku.aiArticle, aiArticle).fetchJoin()
+                .leftJoin(linku.aiArticle, aiArticle)
                 // 서비스단(getMyAiArticlesByCategory)에서 ul.getEmotion()/l.getDomain()을 사용하므로
-                // 추가 쿼리(N+1)를 막기 위해 emotion/domain도 함께 페치 조인한다. 둘 다 not-null 연관관계.
+                // emotion/domain은 페치 조인하되, AiArticle은 응답에서 읽지 않아 일반 LEFT JOIN으로 둔다.
                 .join(usersLinku.emotion).fetchJoin()
                 .join(linku.domain).fetchJoin()
                 .where(
@@ -115,34 +115,49 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
                 homeRecommendScoreService.notNoveltyCondition(usersLinku, now, recencyThresholdDays);
 
         NumberExpression<Double> totalScore = homeRecommendScoreService.scoreExpression(
-                usersLinku, linku, aiArticle, fetchUserKeywordWeights(userId),
+                usersLinku, linku, aiArticle, userId,
                 selectedEmotionId, selectedSituationId, mappedCategoryIds,
                 now, profileTsqueryText, profileText);
         NumberExpression<Integer> bucket = homeRecommendScoreService.scoreBucketExpression(totalScore);
+        NumberPath<Integer> bucketAlias = Expressions.numberPath(Integer.class, SCORE_BUCKET_ALIAS);
+        NumberExpression<Integer> selectedBucket = bucket.as(bucketAlias);
         BooleanExpression seek = seekCondition(bucket, usersLinku, afterScoreBucket, afterUserLinkuId);
 
-        JPAQuery<Tuple> query = queryFactory
-                .select(usersLinku, bucket)
+        boolean textMatchEnabled = profileTsqueryText != null || profileText != null;
+        JPAQuery<RankedUsersLinku> query = queryFactory
+                .select(Projections.constructor(
+                        RankedUsersLinku.class,
+                        usersLinku.userLinkuId,
+                        linku.linkuId,
+                        linku.category.categoryId,
+                        linku.linkuUrl,
+                        usersLinku.memo,
+                        usersLinku.emotion.emotionId,
+                        usersLinku.title.coalesce(linku.title),
+                        linku.domain.name,
+                        linku.domain.imageUrl,
+                        usersLinku.imageUrl.coalesce(linku.imgUrl),
+                        usersLinku.aiExist,
+                        usersLinku.lastViewedAt,
+                        selectedBucket))
                 .from(usersLinku)
-                .join(usersLinku.linku, linku).fetchJoin()
-                .join(usersLinku.emotion).fetchJoin()
-                .join(linku.category).fetchJoin()
-                .join(linku.domain).fetchJoin()
+                .join(usersLinku.linku, linku)
+                .join(usersLinku.emotion)
+                .join(linku.category)
+                .join(linku.domain)
                 // situation nullable — INNER/경로참조만 하면 situation 없는 링크가 빠지는 버그가 생김
-                .leftJoin(usersLinku.situation)
-                // fetchJoin 필수: AiArticle.linku 가 owning side라 Linku.aiArticle(mappedBy, LAZY)은
-                // 진짜 지연로딩이 안 되고(프록시를 못 만들어서) 엔티티 로드 시점에 무조건 존재 확인
-                // 쿼리를 한 번 더 던진다 — fetchJoin으로 여기서 같이 실어야 결과 row당 N+1이 안 생김.
-                .leftJoin(linku.aiArticle, aiArticle).fetchJoin()
-                .where(usersLinku.user.id.eq(userId), excludeNovelty, seek);
+                .leftJoin(usersLinku.situation);
 
-        List<Tuple> rows = query
-                // bucket 내 동점은 userLinkuId로 타이브레이크
-                .orderBy(bucket.desc(), usersLinku.userLinkuId.desc())
+        if (textMatchEnabled) {
+            query.leftJoin(linku.aiArticle, aiArticle);
+        }
+
+        return query
+                // SELECT alias로 정렬해 거대한 점수식의 HQL 중복을 막는다.
+                .where(usersLinku.user.id.eq(userId), excludeNovelty, seek)
+                .orderBy(bucketAlias.desc(), usersLinku.userLinkuId.desc())
                 .limit(limit)
                 .fetch();
-
-        return toRankedList(rows, usersLinku, bucket);
     }
 
     @Override
@@ -151,52 +166,41 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
             LocalDateTime now, int recencyThresholdDays, Integer afterScoreBucket, Long afterUserLinkuId, int limit) {
         QUsersLinku usersLinku = QUsersLinku.usersLinku;
         QLinku linku = QLinku.linku;
-        QAiArticle aiArticle = QAiArticle.aiArticle;
-
         NumberExpression<Double> contextScore = homeRecommendScoreService
                 .noveltyContextScoreExpression(usersLinku, selectedEmotionId, selectedSituationId);
         NumberExpression<Integer> bucket = homeRecommendScoreService.scoreBucketExpression(contextScore);
+        NumberPath<Integer> bucketAlias = Expressions.numberPath(Integer.class, SCORE_BUCKET_ALIAS);
+        NumberExpression<Integer> selectedBucket = bucket.as(bucketAlias);
         BooleanExpression noveltyCondition =
                 homeRecommendScoreService.noveltyCondition(usersLinku, now, recencyThresholdDays);
         BooleanExpression seek = seekCondition(bucket, usersLinku, afterScoreBucket, afterUserLinkuId);
 
-        List<Tuple> rows = queryFactory
-                .select(usersLinku, bucket)
+        return queryFactory
+                .select(Projections.constructor(
+                        RankedUsersLinku.class,
+                        usersLinku.userLinkuId,
+                        linku.linkuId,
+                        linku.category.categoryId,
+                        linku.linkuUrl,
+                        usersLinku.memo,
+                        usersLinku.emotion.emotionId,
+                        usersLinku.title.coalesce(linku.title),
+                        linku.domain.name,
+                        linku.domain.imageUrl,
+                        usersLinku.imageUrl.coalesce(linku.imgUrl),
+                        usersLinku.aiExist,
+                        usersLinku.lastViewedAt,
+                        selectedBucket))
                 .from(usersLinku)
-                .join(usersLinku.linku, linku).fetchJoin()
-                .join(usersLinku.emotion).fetchJoin()
-                .join(linku.category).fetchJoin()
-                .join(linku.domain).fetchJoin()
+                .join(usersLinku.linku, linku)
+                .join(usersLinku.emotion)
+                .join(linku.category)
+                .join(linku.domain)
                 .leftJoin(usersLinku.situation)
-                // findNormalRecommendCandidates와 동일한 이유로 fetchJoin 필요 (AiArticle이 owning
-                // side라 Linku.aiArticle이 진짜 지연로딩 안 됨 — row당 존재확인 쿼리 N+1 방지).
-                .leftJoin(linku.aiArticle, aiArticle).fetchJoin()
                 .where(usersLinku.user.id.eq(userId), noveltyCondition, seek)
-                .orderBy(bucket.desc(), usersLinku.userLinkuId.desc())
+                .orderBy(bucketAlias.desc(), usersLinku.userLinkuId.desc())
                 .limit(limit)
                 .fetch();
-
-        return toRankedList(rows, usersLinku, bucket);
-    }
-
-    /**
-     * 이 유저의 keywordId -> weight 맵을 요청당 한 번만 조회한다 (최대 10개,
-     * UserProfileRefreshWorker#TOP_KEYWORD_COUNT). HomeRecommendScoreService#keywordMatchExpression이
-     * 이 맵을 후보 row마다 다시 조회하는 대신 CASE WHEN 상수로 SQL에 박아넣는 데 쓴다 — 원래는
-     * user_profile_keywords를 후보 row마다 상관 서브쿼리로 조인했는데, 이 테이블은 유저당 10개뿐이라
-     * 여기서 한 번에 메모리로 올려두는 게 훨씬 싸다.
-     */
-    private Map<Long, Integer> fetchUserKeywordWeights(Long userId) {
-        QUserProfileKeyword profileKeyword = QUserProfileKeyword.userProfileKeyword;
-        return queryFactory
-                .select(profileKeyword.keywordId, profileKeyword.weight)
-                .from(profileKeyword)
-                .where(profileKeyword.userId.eq(userId))
-                .fetch()
-                .stream()
-                .collect(Collectors.toMap(
-                        t -> t.get(profileKeyword.keywordId),
-                        t -> t.get(profileKeyword.weight)));
     }
 
     /** seek 탐색 조건. 둘 다 null이면 첫 페이지(조건 없음), 아니면 (bucket, userLinkuId) 이전 행부터 */
@@ -206,18 +210,10 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
         if (afterScoreBucket == null || afterUserLinkuId == null) {
             return null;
         }
-        return bucket.lt(afterScoreBucket)
-                .or(bucket.eq(afterScoreBucket).and(usersLinku.userLinkuId.lt(afterUserLinkuId)));
-    }
-
-    /** Tuple(usersLinku, bucket) → RankedUsersLinku 변환 */
-    private List<RankedUsersLinku> toRankedList(
-            List<Tuple> rows, QUsersLinku usersLinku, NumberExpression<Integer> bucket) {
-        List<RankedUsersLinku> result = new ArrayList<>(rows.size());
-        for (Tuple row : rows) {
-            result.add(new RankedUsersLinku(row.get(usersLinku), row.get(bucket)));
-        }
-        return result;
+        // 복합 커서를 튜플로 비교해 bucket 표현식을 WHERE에 한 번만 사용한다.
+        return Expressions.booleanTemplate(
+                "({0}, {1}) < ({2}, {3})",
+                bucket, usersLinku.userLinkuId, afterScoreBucket, afterUserLinkuId);
     }
 
     /** findHomeRecommendCandidates 전용 OFFSET 쿼리 — 하위호환용으로 유지, seek 쿼리와 통합 안 함 */
@@ -230,7 +226,7 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
         QAiArticle aiArticle = QAiArticle.aiArticle;
 
         NumberExpression<Double> totalScore = homeRecommendScoreService.scoreExpression(
-                usersLinku, linku, aiArticle, fetchUserKeywordWeights(userId),
+                usersLinku, linku, aiArticle, userId,
                 selectedEmotionId, selectedSituationId, mappedCategoryIds,
                 now, profileTsqueryText, profileText);
 

--- a/src/main/java/com/umc/linkyou/repository/dto/RankedUsersLinku.java
+++ b/src/main/java/com/umc/linkyou/repository/dto/RankedUsersLinku.java
@@ -1,6 +1,19 @@
 package com.umc.linkyou.repository.dto;
 
-import com.umc.linkyou.domain.mapping.UsersLinku;
+import java.time.LocalDateTime;
 
-/** seek 페이징 후보 1건. scoreBucket은 다음 커서의 탐색 키로 쓰인다 */
-public record RankedUsersLinku(UsersLinku usersLinku, int scoreBucket) {}
+/** 추천 커서 조회에서 응답에 필요한 필드만 조회한 후보 */
+public record RankedUsersLinku(
+        Long userLinkuId,
+        Long linkuId,
+        Long categoryId,
+        String linku,
+        String memo,
+        Long emotionId,
+        String title,
+        String domain,
+        String domainImageUrl,
+        String linkuImageUrl,
+        Boolean aiArticleExists,
+        LocalDateTime lastViewedAt,
+        int scoreBucket) {}

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuRecommendService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuRecommendService.java
@@ -6,12 +6,10 @@ import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.properties.RecommendScoreProperties;
 import com.umc.linkyou.converter.LinkuConverter;
-import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.Emotion;
 import com.umc.linkyou.domain.mapping.LinkuFolder;
 import com.umc.linkyou.domain.mapping.SituationJob;
-import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.domain.recommend.UserContentProfile;
 import com.umc.linkyou.repository.EmotionRepository;
 import com.umc.linkyou.repository.classification.SituationRepository;
@@ -138,12 +136,12 @@ public class LinkuRecommendService {
 
         // normal/novelty는 서로소라 중복 없지만 userLinkuId 기준으로 한 번 더 방어
         Set<Long> seen = new LinkedHashSet<>();
-        List<UsersLinku> merged = new ArrayList<>(noveltyCandidates.size() + normalCandidates.size());
+        List<RankedUsersLinku> merged = new ArrayList<>(noveltyCandidates.size() + normalCandidates.size());
         for (RankedUsersLinku candidate : noveltyCandidates) {
-            if (seen.add(candidate.usersLinku().getUserLinkuId())) merged.add(candidate.usersLinku());
+            if (seen.add(candidate.userLinkuId())) merged.add(candidate);
         }
         for (RankedUsersLinku candidate : normalCandidates) {
-            if (seen.add(candidate.usersLinku().getUserLinkuId())) merged.add(candidate.usersLinku());
+            if (seen.add(candidate.userLinkuId())) merged.add(candidate);
         }
 
         // 다음 seek 지점 = 이번 페이지 마지막 행의 (scoreBucket, userLinkuId). 못 뽑았으면 기존 값 유지
@@ -159,9 +157,9 @@ public class LinkuRecommendService {
         // 맞춰서 언박싱이 안 일어나게 한다.
         RecommendCursorUtil.RecommendCursor nextCursor = new RecommendCursorUtil.RecommendCursor(
                 lastNovelty != null ? Integer.valueOf(lastNovelty.scoreBucket()) : cursor.noveltyBucket(),
-                lastNovelty != null ? lastNovelty.usersLinku().getUserLinkuId() : cursor.noveltyLastId(),
+                lastNovelty != null ? lastNovelty.userLinkuId() : cursor.noveltyLastId(),
                 lastNormal != null ? Integer.valueOf(lastNormal.scoreBucket()) : cursor.normalBucket(),
-                lastNormal != null ? lastNormal.usersLinku().getUserLinkuId() : cursor.normalLastId(),
+                lastNormal != null ? lastNormal.userLinkuId() : cursor.normalLastId(),
                 noveltyExhaustedNext);
         boolean hasNext = !noveltyExhaustedNext || hasMoreNormal;
 
@@ -169,7 +167,7 @@ public class LinkuRecommendService {
     }
 
     private record CandidatePage(
-            List<UsersLinku> candidates, RecommendCursorUtil.RecommendCursor nextCursor, boolean hasNext) {}
+            List<RankedUsersLinku> candidates, RecommendCursorUtil.RecommendCursor nextCursor, boolean hasNext) {}
 
     private Emotion validateAndFetchContext(Long userId, Long situationId, Long emotionId) {
         Users user = userRepository.findById(userId)
@@ -196,26 +194,16 @@ public class LinkuRecommendService {
     }
 
     // 2. DTO 변환 (AiArticle 존재 여부는 UsersLinku.aiExist 플래그를 그대로 사용 — 별도 조회 없음)
-    private List<LinkuResponseDTO.LinkuSimpleDTO> mapCandidatesToDto(List<UsersLinku> candidates) {
+    private List<LinkuResponseDTO.LinkuSimpleDTO> mapCandidatesToDto(List<RankedUsersLinku> candidates) {
         List<Long> userLinkuIds = candidates.stream()
-                .map(UsersLinku::getUserLinkuId)
+                .map(RankedUsersLinku::userLinkuId)
                 .collect(Collectors.toList());
         Map<Long, LinkuFolder> latestFolderByUserLinkuId = fetchLatestLinkuFolders(userLinkuIds);
 
         return candidates.stream()
-                .map(userLinku -> {
-                    Linku linku = userLinku.getLinku();
-                    boolean aiArticleExists = Boolean.TRUE.equals(userLinku.getAiExist());
-                    LinkuFolder linkuFolder = latestFolderByUserLinkuId.get(userLinku.getUserLinkuId());
-
-                    return LinkuConverter.toLinkuSimpleDTO(
-                            linku,
-                            userLinku,
-                            linku.getDomain(),
-                            aiArticleExists,
-                            linkuFolder
-                    );
-                })
+                .map(candidate -> LinkuConverter.toLinkuSimpleDTO(
+                        candidate,
+                        latestFolderByUserLinkuId.get(candidate.userLinkuId())))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/umc/linkyou/service/common/HomeRecommendScoreService.java
+++ b/src/main/java/com/umc/linkyou/service/common/HomeRecommendScoreService.java
@@ -10,6 +10,7 @@ import com.umc.linkyou.domain.QAiArticle;
 import com.umc.linkyou.domain.QLinku;
 import com.umc.linkyou.domain.mapping.QLinkuKeyword;
 import com.umc.linkyou.domain.mapping.QUsersLinku;
+import com.umc.linkyou.domain.recommend.QUserProfileKeyword;
 import com.umc.linkyou.utils.EmotionSimilarityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,7 +18,6 @@ import org.springframework.stereotype.Component;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.Map;
 
 /**
  * 홈화면 링크 추천 스코어링.
@@ -36,8 +36,6 @@ import java.util.Map;
  *                    가중치 합을 정규화한 값 — "이 유저가 평소 저장하는 키워드와 얼마나 겹치는가"라는
  *                    intra-user 신호. 협업 필터링(inter-user)용으로 keyword를 쓸 때는 이 신호를 건드리지
  *                    않고 별도 feature를 추가한다 (service/common/README.md 참고).
- *                    UserProfileKeyword 자체는 row당 서브쿼리로 다시 조회하지 않고, 호출하는 쿼리(리포지토리)가
- *                    요청당 한 번만 조회해 Map으로 넘겨준다 — keywordMatchExpression()의 파라미터 참고.
  * - CategoryMatch  : 후보 Linku.category가 situation→category 매핑(SituationCategoryService)에 걸리면 1.0,
  *                    아니면 0. SituationMatch(저장 당시 태깅)와 달리 순수 콘텐츠 속성(Linku.category)만 보므로
  *                    emotionAi/situationAi 같은 신뢰도 감쇠를 적용하지 않는다.
@@ -176,13 +174,11 @@ public class HomeRecommendScoreService {
      *
      * @param profileTsqueryText UserContentProfile.profileTsqueryText (없으면 null — TextMatch는 0 처리)
      * @param profileText        UserContentProfile.profileText (trgm fallback용, 없으면 null)
-     * @param keywordWeights     이 유저의 UserProfileKeyword(keywordId -> weight, 최대 10개)를 호출부가
-     *                           미리 한 번 조회해서 넘긴 것. row마다 user_profile_keywords를 다시 조인하지
-     *                           않기 위함 — keywordMatchExpression() 참고.
+     * @param userId             KeywordMatch에 사용할 UserProfileKeyword 소유자
      */
     public NumberExpression<Double> scoreExpression(
             QUsersLinku usersLinku, QLinku linku, QAiArticle aiArticle,
-            Map<Long, Integer> keywordWeights, Long targetEmotionId, Long targetSituationId,
+            Long userId, Long targetEmotionId, Long targetSituationId,
             Collection<Long> mappedCategoryIds,
             LocalDateTime now, String profileTsqueryText, String profileText) {
 
@@ -193,7 +189,7 @@ public class HomeRecommendScoreService {
                 .add(personalEngagementExpression(usersLinku, now).multiply(w.engagement()))
                 .add(popularityExpression(linku).multiply(w.popularity()))
                 .add(textMatchExpression(linku, aiArticle, profileTsqueryText, profileText).multiply(w.text()))
-                .add(keywordMatchExpression(linku, keywordWeights).multiply(w.keyword()))
+                .add(keywordMatchExpression(linku, userId).multiply(w.keyword()))
                 .add(categoryMatchExpression(linku, mappedCategoryIds).multiply(w.category()));
     }
 
@@ -377,45 +373,26 @@ public class HomeRecommendScoreService {
     }
 
     /**
-     * 후보 링크의 linku_keywords와 이 유저의 키워드 가중치 맵을 겹쳐서 weight 합을 구하고,
-     * keywordWeightCap으로 정규화한다.
+     * 후보의 linku_keywords와 유저의 UserProfileKeyword를 상관 서브쿼리로 겹쳐
+     * 가중치 합을 keywordWeightCap으로 정규화한다.
      *
-     * {@code keywordWeights}는 호출부(리포지토리)가 요청당 딱 한 번 {@code user_profile_keywords}를
-     * 조회해서 만든 Map이다 — 유저당 최대 10개(UserProfileRefreshWorker#TOP_KEYWORD_COUNT)뿐이라
-     * 애플리케이션 메모리에 올려두기 충분히 작다. 이전엔 이 테이블을 row(후보)마다 상관 서브쿼리로
-     * 다시 조인했는데, 후보 수만큼 반복 실행되는 비용이 있어서 — emotionMatchExpression처럼 미리
-     * 알고 있는 값을 CASE WHEN으로 SQL에 상수로 박아넣는 방식으로 바꿨다. 이러면 row마다 남는 건
-     * linku_keywords 하나뿐이고, user_profile_keywords는 이 메서드 밖에서 한 번만 조회된다.
-     *
-     * linku_keywords는 여전히 row(후보 linku)마다 서브쿼리로 조회한다 — 후보마다 키워드 집합이
-     * 다르므로 이건 구조상 피할 수 없다. JOIN + GROUP BY로 하면 메인 쿼리의 fetch join 구조
-     * (행당 1건 보장)가 깨지므로 서브쿼리로 처리한다.
+     * CASE WHEN 인라인은 점수식이 반복될 때 HQL 파서 상태를 급증시키므로 사용하지 않는다.
      */
-    public NumberExpression<Double> keywordMatchExpression(QLinku linku, Map<Long, Integer> keywordWeights) {
-        if (keywordWeights == null || keywordWeights.isEmpty()) {
+    public NumberExpression<Double> keywordMatchExpression(QLinku linku, Long userId) {
+        if (userId == null) {
             return Expressions.asNumber(0.0);
         }
 
         QLinkuKeyword linkuKeyword = QLinkuKeyword.linkuKeyword;
+        QUserProfileKeyword profileKeyword = QUserProfileKeyword.userProfileKeyword;
         double cap = properties.normalization().keywordWeightCap();
 
-        // keywordId -> weight를 CASE WHEN 체인으로 SQL에 상수로 박아넣는다 (emotionMatchExpression과
-        // 동일한 패턴). user_profile_keywords 테이블을 여기서 다시 조인하지 않는다.
-        CaseBuilder.Cases<Integer, NumberExpression<Integer>> chain = null;
-        for (Map.Entry<Long, Integer> entry : keywordWeights.entrySet()) {
-            BooleanExpression condition = linkuKeyword.keyword.id.eq(entry.getKey());
-            chain = (chain == null)
-                    ? new CaseBuilder().when(condition).then(entry.getValue())
-                    : chain.when(condition).then(entry.getValue());
-        }
-        NumberExpression<Integer> weightPerKeyword = chain.otherwise(0);
-
-        // 서브쿼리 자체를 NumberExpression으로 담지 않고 Object 인자로 바로 넘긴다
-        // (JPAQuery는 Expression이긴 하지만 NumberExpression의 산술 연산까지는 지원하지 않는다).
+        // fetch join의 행 중복을 피하기 위해 키워드 집계만 서브쿼리로 분리한다.
         var matchedWeightSum = JPAExpressions
-                .select(weightPerKeyword.sum())
+                .select(profileKeyword.weight.sum())
                 .from(linkuKeyword)
-                .where(linkuKeyword.linku.eq(linku));
+                .join(profileKeyword).on(profileKeyword.keywordId.eq(linkuKeyword.keyword.id))
+                .where(linkuKeyword.linku.eq(linku), profileKeyword.userId.eq(userId));
 
         // 서브쿼리 결과를 COALESCE/LEAST에 바로 섞어 넣으면(구 버전) Hibernate 6 HQL 분석기가
         // 이 표현식이 select 절(findNormalRecommendCandidates의 select(usersLinku, bucket))에

--- a/src/main/java/com/umc/linkyou/service/common/README.md
+++ b/src/main/java/com/umc/linkyou/service/common/README.md
@@ -235,7 +235,7 @@ seek(keyset) 방식으로 다시 바꿨다.
 - **트레이드오프**: 버킷 안에서는 정확한 score 순서 대신 userLinkuId 순서로 정렬되는 정밀도 손실이 있다.
   200구간(해상도 0.005)이면 이진(0/1.0) 신호 하나의 가중치(기본 0.10)보다 훨씬 촘촘해서 실제로 순위가
   갈리는 두 후보가 같은 버킷에 묶이는 경우는 드물 것으로 본다 — 다만 실측 검증은 아직 안 했다.
-- `RankedUsersLinku`(`repository/dto/`) — `(UsersLinku, scoreBucket)` 튜플. QueryDSL이 fetch join된 엔티티와
+- `RankedUsersLinku`(`repository/dto/`) — 추천 응답에 필요한 scalar 필드와 `scoreBucket`을 담는 DTO projection.
   스칼라 표현식(scoreBucket)을 함께 Tuple로 뽑아야 해서 도입했다(`.select(usersLinku, bucket)` 형태,
   fetchJoin은 FROM 절에서 그대로 유지됨).
 - `findHomeRecommendCandidates`(novelty 필터 없는 원본, OFFSET 기반)는 손대지 않았다 — 다른 테스트 호출부와의

--- a/src/main/java/com/umc/linkyou/service/common/README.md
+++ b/src/main/java/com/umc/linkyou/service/common/README.md
@@ -235,9 +235,9 @@ seek(keyset) 방식으로 다시 바꿨다.
 - **트레이드오프**: 버킷 안에서는 정확한 score 순서 대신 userLinkuId 순서로 정렬되는 정밀도 손실이 있다.
   200구간(해상도 0.005)이면 이진(0/1.0) 신호 하나의 가중치(기본 0.10)보다 훨씬 촘촘해서 실제로 순위가
   갈리는 두 후보가 같은 버킷에 묶이는 경우는 드물 것으로 본다 — 다만 실측 검증은 아직 안 했다.
-- `RankedUsersLinku`(`repository/dto/`) — 추천 응답에 필요한 scalar 필드와 `scoreBucket`을 담는 DTO projection.
-  스칼라 표현식(scoreBucket)을 함께 Tuple로 뽑아야 해서 도입했다(`.select(usersLinku, bucket)` 형태,
-  fetchJoin은 FROM 절에서 그대로 유지됨).
+- `RankedUsersLinku`(`repository/dto/`) — 추천 응답에 필요한 scalar 필드와 `scoreBucket`을 담는 DTO.
+  novelty 조회는 `Projections.constructor(...)` 기반 scalar projection을 사용하고, normal 조회는 Native CTE 결과를
+  같은 DTO로 매핑한다. 추천 커서 조회에서는 기존 `Tuple`/`.select(usersLinku, bucket)` 및 불필요한 fetch join을 사용하지 않는다.
 - `findHomeRecommendCandidates`(novelty 필터 없는 원본, OFFSET 기반)는 손대지 않았다 — 다른 테스트 호출부와의
   하위호환을 위해서다. `findNormalRecommendCandidates`/`findNoveltyRecommendCandidates`만 seek 방식으로
   바꿨고, 내부 쿼리 빌더는 기존 `queryRankedCandidates`(OFFSET)와 통합하지 않고 별도로 분리했다.

--- a/src/test/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImplTest.java
+++ b/src/test/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImplTest.java
@@ -9,6 +9,7 @@ import com.umc.linkyou.domain.classification.Situation;
 import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.domain.folder.Fcolor;
 import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.domain.recommend.UserProfileKeyword;
 import com.umc.linkyou.repository.dto.RankedUsersLinku;
 import com.umc.linkyou.repository.EmotionRepository;
 import com.umc.linkyou.repository.categoryRepository.FcolorRepository;
@@ -16,6 +17,7 @@ import com.umc.linkyou.repository.classification.CategoryRepository;
 import com.umc.linkyou.repository.classification.SituationRepository;
 import com.umc.linkyou.repository.classification.domainRepository.DomainRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
+import com.umc.linkyou.repository.recommend.UserProfileKeywordRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.support.config.TestExternalConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -62,6 +64,7 @@ class UsersLinkuRepositoryImplTest {
     @Autowired private EmotionRepository emotionRepository;
     @Autowired private SituationRepository situationRepository;
     @Autowired private LinkuRepository linkuRepository;
+    @Autowired private UserProfileKeywordRepository userProfileKeywordRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
 
     // BaseEntity.createdAt은 @CreatedDate(updatable=false)라 JPA로는 저장 후 값을 바꿀 수 없어서,
@@ -114,7 +117,7 @@ class UsersLinkuRepositoryImplTest {
             List<RankedUsersLinku> result = usersLinkuRepository.findNoveltyRecommendCandidates(
                     user.getId(), emotion.getEmotionId(), situation.getId(), now, recencyThresholdDays, null, null, 10);
 
-            assertThat(result).extracting(r -> r.usersLinku().getUserLinkuId())
+            assertThat(result).extracting(RankedUsersLinku::userLinkuId)
                     .containsExactlyInAnyOrder(neverViewedOld.getUserLinkuId(), viewedOld.getUserLinkuId());
         }
 
@@ -147,8 +150,55 @@ class UsersLinkuRepositoryImplTest {
                     user.getId(), emotion.getEmotionId(), situation.getId(), List.of(category.getCategoryId()),
                     now, null, null, recencyThresholdDays, null, null, 10);
 
-            assertThat(result).extracting(r -> r.usersLinku().getUserLinkuId())
+            assertThat(result).extracting(RankedUsersLinku::userLinkuId)
                     .containsExactly(normal.getUserLinkuId());
+        }
+    }
+
+    @Nested
+    @DisplayName("점수 커서")
+    class ScoreCursor {
+
+        @Test
+        @DisplayName("키워드 10개와 커서가 있을 시 다음 후보를 반환한다")
+        void 키워드_10개와_커서가_있을_시_다음_후보를_반환한다() {
+            Users user = userRepository.save(createUser("home-reco-cursor"));
+            Domain domain = domainRepository.save(createDomain("cursor-test"));
+            Fcolor fcolor = fcolorRepository.save(createFcolor());
+            Category category = categoryRepository.save(createCategory("카테고리", fcolor));
+            Emotion emotion = emotionRepository.save(createEmotion());
+            Situation situation = situationRepository.save(createSituation("상황"));
+
+            for (long keywordId = 1; keywordId <= 10; keywordId++) {
+                userProfileKeywordRepository.save(UserProfileKeyword.builder()
+                        .userId(user.getId())
+                        .keywordId(keywordId)
+                        .weight((int) keywordId)
+                        .build());
+            }
+
+            LocalDateTime now = LocalDateTime.now();
+            for (int i = 0; i < 3; i++) {
+                Linku linku = createAndSaveLinku(domain, category, emotion, situation);
+                usersLinkuRepository.save(baseUsersLinku(user, linku, emotion)
+                        .situation(situation)
+                        .lastViewedAt(now.minusDays(1))
+                        .build());
+            }
+
+            List<RankedUsersLinku> firstPage = usersLinkuRepository.findNormalRecommendCandidates(
+                    user.getId(), emotion.getEmotionId(), situation.getId(), List.of(category.getCategoryId()),
+                    now, null, null, 14, null, null, 1);
+            assertThat(firstPage).hasSize(1);
+            RankedUsersLinku cursor = firstPage.get(0);
+
+            List<RankedUsersLinku> secondPage = usersLinkuRepository.findNormalRecommendCandidates(
+                    user.getId(), emotion.getEmotionId(), situation.getId(), List.of(category.getCategoryId()),
+                    now, null, null, 14, cursor.scoreBucket(), cursor.userLinkuId(), 1);
+
+            assertThat(secondPage).hasSize(1);
+            assertThat(secondPage.get(0).userLinkuId())
+                    .isLessThan(cursor.userLinkuId());
         }
     }
 

--- a/src/test/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImplTest.java
+++ b/src/test/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.repository.UserLinkuRepository;
 
 import com.umc.linkyou.domain.Linku;
+import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.classification.Domain;
@@ -9,6 +10,7 @@ import com.umc.linkyou.domain.classification.Situation;
 import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.domain.folder.Fcolor;
 import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.domain.mapping.LinkuKeyword;
 import com.umc.linkyou.domain.recommend.UserProfileKeyword;
 import com.umc.linkyou.repository.dto.RankedUsersLinku;
 import com.umc.linkyou.repository.EmotionRepository;
@@ -17,6 +19,8 @@ import com.umc.linkyou.repository.classification.CategoryRepository;
 import com.umc.linkyou.repository.classification.SituationRepository;
 import com.umc.linkyou.repository.classification.domainRepository.DomainRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
+import com.umc.linkyou.repository.keywordRepository.KeywordRepository;
+import com.umc.linkyou.repository.mapping.LinkuKeywordRepository;
 import com.umc.linkyou.repository.recommend.UserProfileKeywordRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.support.config.TestExternalConfig;
@@ -38,10 +42,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * UsersLinkuRepositoryImpl#findHomeRecommendCandidates 통합 테스트.
  *
- * TextMatch/KeywordMatch용 profileTsqueryText/profileText는 전부 null로 넘긴다 — 둘 다 null이면
- * HomeRecommendScoreService#textMatchExpression이 similarity()/ts_rank_cd를 아예 호출하지 않는
- * 상수(0.0) 표현식만 반환하므로, pg_trgm 확장 설치 여부와 무관하게 이 테스트가 검증하려는
- * EmotionMatch/SituationMatch/PersonalEngagement/Popularity 동작에 집중할 수 있다.
+ * TextMatch용 profileTsqueryText/profileText는 null로 넘긴다 — 둘 다 null이면
+ * HomeRecommendScoreService#textMatchExpression이 similarity()/ts_rank_cd를 호출하지 않아
+ * pg_trgm 확장 설치 여부와 무관하게 KeywordMatch 및 커서 동작을 검증할 수 있다.
  *
  * 감정(EmotionMatch) 자체는 EmotionSimilarityUtil이 감정 ID 1~6을 하드코딩 매핑하고 있어서, 테스트
  * DB에서 매번 새로 생성되는(IDENTITY 시퀀스가 테스트 클래스 간에도 누적되는) Emotion의 실제 ID가 1~6
@@ -64,6 +67,8 @@ class UsersLinkuRepositoryImplTest {
     @Autowired private EmotionRepository emotionRepository;
     @Autowired private SituationRepository situationRepository;
     @Autowired private LinkuRepository linkuRepository;
+    @Autowired private KeywordRepository keywordRepository;
+    @Autowired private LinkuKeywordRepository linkuKeywordRepository;
     @Autowired private UserProfileKeywordRepository userProfileKeywordRepository;
     @Autowired private JdbcTemplate jdbcTemplate;
 
@@ -169,27 +174,47 @@ class UsersLinkuRepositoryImplTest {
             Emotion emotion = emotionRepository.save(createEmotion());
             Situation situation = situationRepository.save(createSituation("상황"));
 
-            for (long keywordId = 1; keywordId <= 10; keywordId++) {
+            List<Keyword> keywords = keywordRepository.saveAll(
+                    java.util.stream.IntStream.rangeClosed(1, 10)
+                            .mapToObj(keywordId -> Keyword.builder().name("cursor-keyword-" + keywordId).build())
+                            .toList());
+            for (int keywordIndex = 0; keywordIndex < keywords.size(); keywordIndex++) {
                 userProfileKeywordRepository.save(UserProfileKeyword.builder()
                         .userId(user.getId())
-                        .keywordId(keywordId)
-                        .weight((int) keywordId)
+                        .keywordId(keywords.get(keywordIndex).getId())
+                        .weight(keywordIndex + 1)
                         .build());
             }
 
             LocalDateTime now = LocalDateTime.now();
-            for (int i = 0; i < 3; i++) {
-                Linku linku = createAndSaveLinku(domain, category, emotion, situation);
-                usersLinkuRepository.save(baseUsersLinku(user, linku, emotion)
-                        .situation(situation)
-                        .lastViewedAt(now.minusDays(1))
-                        .build());
-            }
+            Linku lowKeywordLinku = createAndSaveLinku(domain, category, emotion, situation);
+            Linku highKeywordLinku = createAndSaveLinku(domain, category, emotion, situation);
+            Linku noKeywordLinku = createAndSaveLinku(domain, category, emotion, situation);
+            linkuKeywordRepository.saveAll(List.of(
+                    LinkuKeyword.builder().linku(lowKeywordLinku).keyword(keywords.get(8)).build(),
+                    LinkuKeyword.builder().linku(lowKeywordLinku).keyword(keywords.get(9)).build()));
+            linkuKeywordRepository.saveAll(keywords.stream()
+                    .map(keyword -> LinkuKeyword.builder().linku(highKeywordLinku).keyword(keyword).build())
+                    .toList());
+
+            UsersLinku lowKeywordCandidate = usersLinkuRepository.save(baseUsersLinku(user, lowKeywordLinku, emotion)
+                    .situation(situation)
+                    .lastViewedAt(now.minusDays(1))
+                    .build());
+            UsersLinku highKeywordCandidate = usersLinkuRepository.save(baseUsersLinku(user, highKeywordLinku, emotion)
+                    .situation(situation)
+                    .lastViewedAt(now.minusDays(1))
+                    .build());
+            usersLinkuRepository.save(baseUsersLinku(user, noKeywordLinku, emotion)
+                    .situation(situation)
+                    .lastViewedAt(now.minusDays(1))
+                    .build());
 
             List<RankedUsersLinku> firstPage = usersLinkuRepository.findNormalRecommendCandidates(
                     user.getId(), emotion.getEmotionId(), situation.getId(), List.of(category.getCategoryId()),
                     now, null, null, 14, null, null, 1);
             assertThat(firstPage).hasSize(1);
+            assertThat(firstPage.get(0).userLinkuId()).isEqualTo(highKeywordCandidate.getUserLinkuId());
             RankedUsersLinku cursor = firstPage.get(0);
 
             List<RankedUsersLinku> secondPage = usersLinkuRepository.findNormalRecommendCandidates(
@@ -197,8 +222,8 @@ class UsersLinkuRepositoryImplTest {
                     now, null, null, 14, cursor.scoreBucket(), cursor.userLinkuId(), 1);
 
             assertThat(secondPage).hasSize(1);
-            assertThat(secondPage.get(0).userLinkuId())
-                    .isLessThan(cursor.userLinkuId());
+            assertThat(secondPage.get(0).userLinkuId()).isEqualTo(lowKeywordCandidate.getUserLinkuId());
+            assertThat(cursor.scoreBucket()).isGreaterThan(secondPage.get(0).scoreBucket());
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈

closes [#410](https://github.com/LinkYou-2025/LinkU_backend/issues/410)

---

## 📌 작업 내용

추천 조회 시 Hibernate HQL 파서 메모리 사용량이 급증하며 발생하던 `OutOfMemoryError`를 개선했습니다.

### 1️⃣ Non-Functional Requirement

- 일반 추천 커서 조회를 Native SQL + CTE 방식으로 변경했습니다.
- 추천 점수식을 CTE 내부에서 한 번만 계산하도록 수정했습니다. 기존에는 추천 점수식을 여러번 계산해서 문제가 생겼습니다. 
- 계산된 `score_bucket`을 외부 커서 조건과 정렬에서 재사용하도록 했습니다.
- 추천 결과를 DTO projection으로 조회하도록 변경했습니다. 
- 불필요한 엔티티 로딩 및 `fetchJoin`을 제거했습니다. 
- 기존 novelty 추천 및 offset 기반 하위 호환 메서드는 유지했습니다.

### 2️⃣ Functional Requirement

- `WITH scored AS MATERIALIZED` 기반 추천 쿼리를 추가했습니다. 
- `(score_bucket, user_linku_id)` 복합 커서 페이지네이션을 적용했습니다. 
- 감정, 상황, 참여도, 인기도, 텍스트, 키워드, 카테고리 점수를 Native SQL로 계산하도록 수정했습니다(QueryDSL에서는 서브쿼리에서의 FROM 사용이 제한적이라 수정했습니다.)
- Native 조회 결과를 `RankedUsersLinku`로 매핑합니다.
- 매칭되는 감정 점수가 없을 때도 유효한 SQL이 생성되도록 처리했습니다.

---

## 🧪 테스트 결과
