### PR TITLE
feat: #418 회원탈퇴 dto

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/UserConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/UserConverter.java
@@ -75,6 +75,12 @@ public class UserConverter {
     }
 
     public static UserResponseDTO.withDrawalResultDTO toWithDrawalResultDTO(Users user) {
+        return toWithDrawalResultDTO(user, null, null);
+    }
+
+    // 회원복구 성공 시 accessToken/refreshToken을 함께 담기 위한 오버로드
+    public static UserResponseDTO.withDrawalResultDTO toWithDrawalResultDTO(
+            Users user, String accessToken, String refreshToken) {
         if (user == null) return null;
         return UserResponseDTO.withDrawalResultDTO
                 .builder()
@@ -83,6 +89,8 @@ public class UserConverter {
                 .createdAt(user.getCreatedAt())
                 .status(user.getStatus())
                 .inactiveDate(user.getInactiveDate())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
+++ b/src/main/java/com/umc/linkyou/service/users/UserWithdrawService.java
@@ -3,9 +3,11 @@ package com.umc.linkyou.service.users;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.converter.UserConverter;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
+import com.umc.linkyou.jwt.TokenIssueService;
 import com.umc.linkyou.domain.AuthAccount;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.enums.Provider;
@@ -13,6 +15,7 @@ import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.web.dto.UserRequestDTO;
+import com.umc.linkyou.web.dto.UserResponseDTO;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +37,7 @@ public class UserWithdrawService{
     private final UserStatusValidator userStatusValidator;
     private final JwtTokenProvider jwtTokenProvider;
     private final AccessTokenBlackListManager accessTokenBlackListManager;
+    private final TokenIssueService tokenIssueService;
 
     // 탈퇴 유예 기간
     private static final int GRACE_PERIOD_DAYS = 14;
@@ -51,10 +55,6 @@ public class UserWithdrawService{
      * 회원 탈퇴
      * - Refresh Token 전체 삭제
      * - 현재 요청의 Access Token을 블랙리스트에 등록하여 탈퇴 즉시 로그아웃 처리
-     *
-     * Redis(RefreshToken 삭제/AccessToken 블랙리스트)는 @Transactional 롤백 대상이 아니므로,
-     * DB 커밋이 확정된 뒤(afterCommit)에만 반영한다. 이렇게 하면 DB 저장이 실패해 롤백되는 경우
-     * "DB는 ACTIVE인데 Redis만 로그아웃 처리된" 불일치가 생기지 않는다.
      */
     @Transactional
     public Users withdrawUser(
@@ -90,8 +90,6 @@ public class UserWithdrawService{
 
     /**
      * 리프레시 토큰 전체 삭제 + 현재 액세스 토큰 블랙리스트 등록.
-     * DB 트랜잭션 커밋 후에만 호출되므로, 여기서 실패해도 DB 상태를 되돌릴 수 없다.
-     * 따라서 예외를 던지지 않고 로그만 남긴다(재시도/보상 처리는 후속 개선 과제).
      */
     private void invalidateTokens(Long userId, String accessToken) {
         try {
@@ -120,10 +118,12 @@ public class UserWithdrawService{
 
     /**
      * 회원 탈퇴 복구 API
-     * INACTIVE 상태의 사용자를 다시 ACTIVE로 전환합니다.
+     * - INACTIVE 상태의 사용자를 다시 ACTIVE로 전환합니다.
+     * - 복구 성공 시 재로그인 없이 바로 홈 화면에 진입할 수 있도록 정식 액세스/리프레시 토큰 쌍을 함께 발급
      */
     @Transactional
-    public Users recoverUser(Long userId) {
+    public UserResponseDTO.withDrawalResultDTO recoverUser(
+            Long userId, String providerStr, UserRequestDTO.RecoverDTO request) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
 
@@ -136,8 +136,26 @@ public class UserWithdrawService{
         }
         // 상태 및 탈퇴 관련 필드 초기화
         user.recover();
+        Users savedUser = userRepository.save(user);
 
-        return userRepository.save(user);
+        // 3. 복구 완료 시점에 정식 토큰 쌍 발급
+        Provider provider = Provider.valueOf(providerStr);
+        String email =
+                authAccountRepository
+                        .findEmailByUserIdAndProvider(userId, provider)
+                        .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
+
+        TokenIssueService.IssuedTokenPair tokenPair =
+                tokenIssueService.issueTokenPair(
+                        userId,
+                        email,
+                        providerStr,
+                        savedUser.getRole(),
+                        request.deviceId(),
+                        request.deviceType());
+
+        return UserConverter.toWithDrawalResultDTO(
+                savedUser, tokenPair.accessToken(), tokenPair.refreshToken());
     }
 
     //14 일 이후 삭제

--- a/src/main/java/com/umc/linkyou/web/api/UserApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/UserApi.java
@@ -127,6 +127,13 @@ public interface UserApi {
                 탈퇴 유예 기간(14일) 내에 있는 사용자의 계정을 다시 활성화합니다.
                 - 상태를 ACTIVE로 변경하고 탈퇴 사유 및 날짜를 초기화합니다.
                 - 유예 기간(14일)이 지난 경우 복구 불가 에러를 반환합니다.
+                - 복구 성공 시 별도 재로그인 없이 바로 홈 화면에 진입할 수 있도록 정식 액세스/리프레시 토큰 쌍을 함께 발급합니다.
+
+                Swagger 테스트 시 유의사항
+                - 회원탈퇴(inactive) API를 호출하면 기존 액세스/리프레시 토큰이 즉시 무효화(블랙리스트 등록/삭제)됩니다.
+                - 따라서 탈퇴 직후 이 API를 테스트하려면, 탈퇴로 만료된 토큰이 아니라 로그인 API를 다시 호출해서 새로 발급받은 토큰을 Authorize에 넣어야 합니다.
+                  (탈퇴 유예 기간 내 로그인 시 일반 액세스 토큰이 아닌, 이 API 전용의 복구 토큰(만료 10분)이 발급됩니다.)
+                - 소셜 로그인 계정은 이메일/비밀번호가 없어 Swagger에서 곧바로 재로그인할 수 없으므로, 모바일 소셜 로그인 API를 통해 토큰을 재발급받아야 합니다.
                 """
     )
     @ApiSuccessCode(SuccessStatus._OK)
@@ -134,7 +141,8 @@ public interface UserApi {
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
     @PostMapping("/recover")
     ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(
-            @CurrentUser CustomUserDetails userDetails);
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDTO.RecoverDTO request);
 
     // 계정 즉시 완전 삭제 (QA/테스트용, 대상은 항상 로그인한 본인 계정)
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/user/UserController.java
@@ -71,9 +71,12 @@ public class UserController implements UserApi {
     }
 
     @Override
-    public ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(@CurrentUser CustomUserDetails userDetails) {
-        Users user = userWithdrawService.recoverUser(userDetails.getUserId());
-        return ApiResponse.onSuccess(UserSuccessStatus.USER_RECOVER_OK, UserConverter.toWithDrawalResultDTO(user));
+    public ApiResponse<UserResponseDTO.withDrawalResultDTO> recoverMe(
+            @CurrentUser CustomUserDetails userDetails, UserRequestDTO.RecoverDTO request) {
+        UserResponseDTO.withDrawalResultDTO result =
+                userWithdrawService.recoverUser(
+                        userDetails.getUserId(), userDetails.getProvider(), request);
+        return ApiResponse.onSuccess(UserSuccessStatus.USER_RECOVER_OK, result);
     }
 
     @Override

--- a/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserRequestDTO.java
@@ -135,6 +135,22 @@ public class UserRequestDTO {
     }
 
     /**
+     * 회원 탈퇴 복구 요청 DTO
+     * 복구 성공 시 바로 액세스/리프레시 토큰 쌍을 발급하기 위해 deviceId/deviceType을 함께 받는다.
+     */
+    @Builder
+    public record RecoverDTO(
+            @Schema(example = "ios-iphone-16-pro")
+            @NotBlank(message = "deviceId는 필수입니다.")
+            String deviceId,
+
+            @Schema(example = "PHONE")
+            @NotNull(message = "deviceType은 필수입니다.")
+            DeviceType deviceType
+    ) {
+    }
+
+    /**
      * 약관 일괄 동의/변경 처리 DTO
      */
     @Builder

--- a/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/UserResponseDTO.java
@@ -75,6 +75,8 @@ public class UserResponseDTO {
         LocalDateTime createdAt;
         UserStatus status;
         LocalDateTime inactiveDate;
+        String accessToken;
+        String refreshToken;
     }
 
     @Getter

--- a/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/UserWithdrawServiceTest.java
@@ -6,13 +6,17 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
 import com.umc.linkyou.jwt.JwtTokenProvider;
 import com.umc.linkyou.jwt.RefreshTokenManager;
+import com.umc.linkyou.jwt.TokenIssueService;
 import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.DeviceType;
+import com.umc.linkyou.domain.enums.Provider;
 import com.umc.linkyou.domain.enums.UserStatus;
 import com.umc.linkyou.repository.authAccountRepository.AuthAccountRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.service.users.UserStatusValidator;
 import com.umc.linkyou.service.users.UserWithdrawService;
 import com.umc.linkyou.web.dto.UserRequestDTO;
+import com.umc.linkyou.web.dto.UserResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,6 +28,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -44,9 +50,13 @@ public class UserWithdrawServiceTest {
     @Mock private UserStatusValidator userStatusValidator;
     @Mock private JwtTokenProvider jwtTokenProvider;
     @Mock private AccessTokenBlackListManager accessTokenBlackListManager;
+    @Mock private TokenIssueService tokenIssueService;
 
     @InjectMocks
     private UserWithdrawService userWithdrawService;
+
+    private static final UserRequestDTO.RecoverDTO RECOVER_REQUEST =
+            new UserRequestDTO.RecoverDTO("test-device", DeviceType.PHONE);
 
     @Nested
     @DisplayName("withdrawUser - 회원 탈퇴 테스트")
@@ -181,7 +191,7 @@ public class UserWithdrawServiceTest {
     class Success {
 
         @Test
-        @DisplayName("INACTIVE 상태이고 14일 이내라면 ACTIVE로 복구된다")
+        @DisplayName("INACTIVE 상태이고 14일 이내라면 ACTIVE로 복구되고 액세스/리프레시 토큰이 발급된다")
         void 정상복구_성공() {
             // given
             Long userId = 1L;
@@ -194,14 +204,23 @@ public class UserWithdrawServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
             given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
+            given(authAccountRepository.findEmailByUserIdAndProvider(userId, Provider.GENERAL))
+                    .willReturn(Optional.of("user1@example.com"));
+            given(tokenIssueService.issueTokenPair(
+                            eq(userId), eq("user1@example.com"), eq("GENERAL"), any(),
+                            eq("test-device"), eq(DeviceType.PHONE)))
+                    .willReturn(new TokenIssueService.IssuedTokenPair("access-token", "refresh-token"));
 
             // when
-            Users result = userWithdrawService.recoverUser(userId);
+            UserResponseDTO.withDrawalResultDTO result =
+                    userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
-            assertThat(result.getInactiveDate()).isNull();
-            assertThat(result.getDeleted_reason()).isNull();
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(user.getInactiveDate()).isNull();
+            assertThat(user.getDeleted_reason()).isNull();
+            assertThat(result.getAccessToken()).isEqualTo("access-token");
+            assertThat(result.getRefreshToken()).isEqualTo("refresh-token");
         }
 
         @Test
@@ -218,12 +237,18 @@ public class UserWithdrawServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
             given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
+            given(authAccountRepository.findEmailByUserIdAndProvider(userId, Provider.GENERAL))
+                    .willReturn(Optional.of("user2@example.com"));
+            given(tokenIssueService.issueTokenPair(
+                            eq(userId), eq("user2@example.com"), eq("GENERAL"), any(),
+                            eq("test-device"), eq(DeviceType.PHONE)))
+                    .willReturn(new TokenIssueService.IssuedTokenPair("access-token", "refresh-token"));
 
             // when
-            Users result = userWithdrawService.recoverUser(userId);
+            userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
         }
 
         @Test
@@ -240,12 +265,18 @@ public class UserWithdrawServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
             given(userRepository.save(user)).willReturn(user);
             given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(true);
+            given(authAccountRepository.findEmailByUserIdAndProvider(userId, Provider.GENERAL))
+                    .willReturn(Optional.of("user3@example.com"));
+            given(tokenIssueService.issueTokenPair(
+                            eq(userId), eq("user3@example.com"), eq("GENERAL"), any(),
+                            eq("test-device"), eq(DeviceType.PHONE)))
+                    .willReturn(new TokenIssueService.IssuedTokenPair("access-token", "refresh-token"));
 
             // when
-            Users result = userWithdrawService.recoverUser(userId);
+            userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST);
 
             // then
-            assertThat(result.getStatus()).isEqualTo(UserStatus.ACTIVE);
+            assertThat(user.getStatus()).isEqualTo(UserStatus.ACTIVE);
         }
     }
     @Nested
@@ -260,7 +291,7 @@ public class UserWithdrawServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(e -> {
                         GeneralException ex = (GeneralException) e;
@@ -281,7 +312,7 @@ public class UserWithdrawServiceTest {
             given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
             // when & then
-            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(e -> {
                         GeneralException ex = (GeneralException) e;
@@ -304,7 +335,7 @@ public class UserWithdrawServiceTest {
             given(userStatusValidator.isWithinWithdrawGracePeriod(user)).willReturn(false);
 
             // when & then
-            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId))
+            assertThatThrownBy(() -> userWithdrawService.recoverUser(userId, "GENERAL", RECOVER_REQUEST))
                     .isInstanceOf(GeneralException.class)
                     .satisfies(e -> {
                         GeneralException ex = (GeneralException) e;


### PR DESCRIPTION
## 🔗 관련 이슈
> #418 
---

## 📌 작업 내용
> 회원탈퇴 복구 api에 복구후, 바로 홈집입이 가능하도록 recorver api에서 success일 경우 엑세스, 리프레쉬 토큰 쌍으로 추가햇습니다. 

---

## 🧪 테스트 결과
> 테스트 코드 실행 결과, Postman 테스트, 또는 검수 과정에서의 확인 내용을 작성해주세요.
> 스크린샷이나 링크 첨부도 가능합니다.
테스트 코드 성공
---

## 📸 스크린샷 (선택)
> Swagger UI, 테스트 결과 화면 등 필요 시 첨부해주세요.
스웨거 확인
              Swagger 테스트 시 유의사항
                - 회원탈퇴(inactive) API를 호출하면 기존 액세스/리프레시 토큰이 즉시 무효화(블랙리스트 등록/삭제)됩니다.
                - 따라서 탈퇴 직후 이 API를 테스트하려면, 탈퇴로 만료된 토큰이 아니라 로그인 API를 다시 호출해서 새로 발급받은 토큰을 Authorize에 넣어야 합니다.
                  (탈퇴 유예 기간 내 로그인 시 일반 액세스 토큰이 아닌, 이 API 전용의 복구 토큰(만료 10분)이 발급됩니다.)
                - 소셜 로그인 계정은 이메일/비밀번호가 없어 Swagger에서 곧바로 재로그인할 수 없으므로, 모바일 소셜 로그인 API를 통해 토큰을 재발급받아야 합니다.
---

## 📎 참고 사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 회원 탈퇴 복구 시 디바이스 정보와 인증 제공자를 입력할 수 있습니다.
  * 복구가 완료되면 액세스 토큰과 리프레시 토큰이 발급되어 즉시 재인증할 수 있습니다.
  * 탈퇴 복구 요청에 필수 디바이스 ID와 디바이스 유형 검증이 적용됩니다.
* **문서**
  * 탈퇴 복구 후 재인증에 필요한 API 사용 절차가 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->