### PR TITLE
!hotfix: ai article 전체 필터

### DIFF
--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryCustom.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryCustom.java
@@ -12,6 +12,7 @@ public interface UsersLinkuRepositoryCustom {
     // 특정 유저의 링크들을 카테고리별로 조회 (AiArticle 정보 포함)
     List<UsersLinku> fetchAiArticlesByCategoryId(Long userId, Long categoryId);
     List<UsersLinku> findRecentLinkCandidatesByUser(Long userId, int limit);
+    // categoryId가 null이면 카테고리 필터 없이 전체 카테고리를 조회한다 ("전체" 탭)
     List<UsersLinku> fetchAiArticlesByCategoryIdWithCursor(Long userId, Long categoryId, Long cursorId, int limit);
 
     // 홈화면 추천 원본(OFFSET). 7축 가중합 정렬 — HomeRecommendScoreService#scoreExpression.

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
@@ -87,13 +87,21 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
                 .join(linku.domain).fetchJoin()
                 .where(
                         usersLinku.user.id.eq(userId),
-                        linku.category.categoryId.eq(categoryId),
+                        eqCategoryId(categoryId), // null이면 카테고리 필터 없이 전체 조회
                         usersLinku.aiExist.isTrue(),
                         ltCursorId(cursorId) // 커서 조건 추가
                 )
                 .orderBy(usersLinku.createdAt.desc(), usersLinku.userLinkuId.desc()) // 정렬 순서 보장
                 .limit(limit + 1) // 다음 페이지 여부 확인용
                 .fetch();
+    }
+
+    // categoryId가 없으면(=전체 카테고리 조회) 조건을 걸지 않는다
+    private BooleanExpression eqCategoryId(Long categoryId) {
+        if (categoryId == null) {
+            return null;
+        }
+        return QLinku.linku.category.categoryId.eq(categoryId);
     }
 
     // 커서 조건 처리 (최신순이므로 현재 커서보다 작은 ID를 가져옴)

--- a/src/main/java/com/umc/linkyou/service/AiArticleService.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleService.java
@@ -135,6 +135,7 @@ public class AiArticleService {
                 : linku.getTitle();
     }
 
+    // categoryId가 null이면(=쿼리 파라미터 생략) "전체" 카테고리로 간주해 필터 없이 조회한다.
     @Transactional(readOnly = true)
     public LinkuResponseDTO.LinkuSliceResultDTO getMyAiArticlesByCategory(Long userId, Long categoryId, Long cursor, int limit) {
         List<UsersLinku> usersLinkus = usersLinkuRepository.fetchAiArticlesByCategoryIdWithCursor(userId, categoryId, cursor, limit);

--- a/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
@@ -61,6 +61,9 @@ public interface AiArticleApi {
 
                     **응답 항목 (linkuList의 각 원소)**
                     - `linkuId`, `linku`(원본 URL), `emotionId`, `domain`(도메인명), `domainImageUrl`, `title`, `linkuImageUrl`을 반환합니다.
+
+                    **전체 카테고리 조회**
+                    - `categoryId`를 생략하면 카테고리 필터 없이 전체 카테고리의 AI 요약 링크를 조회합니다("전체" 탭).
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
@@ -69,12 +72,12 @@ public interface AiArticleApi {
     @GetMapping
     ApiResponse<LinkuResponseDTO.LinkuSliceResultDTO> getMyAiArticlesByCategory(
             @Parameter(description = """
-                    조회할 카테고리 ID
+                    조회할 카테고리 ID. 생략하면 전체 카테고리를 조회합니다("전체" 탭).
                     1: 어학, 2: 뉴스, 3: 공부법, 4: IT·개발, 5: 자기계발, 6: 취업·이직,
                     7: 비즈니스 인사이트, 8: 생산성·툴, 9: 라이프스타일, 10: 심리·자기이해,
                     11: 에세이·칼럼, 12: 트렌드, 13: 디자인·예술, 14: 영상·뮤직,
                     15: 맛집·여행, 16: 기타
-                    """, example = "1") @RequestParam("categoryId") Long categoryId,
+                    """, example = "1", required = false) @RequestParam(name = "categoryId", required = false) Long categoryId,
             @Parameter(description = "커서 ID. 이전 응답의 nextCursor 값을 그대로 전달하며, 첫 조회 시에는 생략합니다.") @RequestParam(name = "cursor", required = false) Long cursor,
             @Parameter(description = "한 번에 조회할 개수", example = "10") @RequestParam(name = "limit", defaultValue = "10") int limit,
             @CurrentUser CustomUserDetails userDetails

--- a/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
@@ -36,7 +36,7 @@ public class AiArticleController implements AiArticleApi {
     @Override
     @GetMapping
     public ApiResponse<LinkuResponseDTO.LinkuSliceResultDTO> getMyAiArticlesByCategory(
-            @RequestParam("categoryId") Long categoryId,
+            @RequestParam(name = "categoryId", required = false) Long categoryId,
             @RequestParam(name = "cursor", required = false) Long cursor,
             @RequestParam(name = "limit", defaultValue = "10") int limit,
             @CurrentUser CustomUserDetails userDetails

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -436,6 +436,70 @@ class AiArticleServiceTest {
         }
     }
 
+    @Nested
+    @DisplayName("getMyAiArticlesByCategory() - 카테고리별 AI 요약 링크 조회")
+    class GetMyAiArticlesByCategory {
+
+        private static final Long CURSOR = null;
+        private static final int LIMIT = 10;
+
+        @Test
+        @DisplayName("categoryId가 null이면 카테고리 필터 없이 repository를 호출한다(전체 카테고리 조회)")
+        void categoryId가_null이면_전체_카테고리로_조회한다() {
+            Linku linku = LinkuFixture.linku(null);
+            Users user = LinkuFixture.user();
+            UsersLinku usersLinku = buildUsersLinku(linku, user);
+
+            given(usersLinkuRepository.fetchAiArticlesByCategoryIdWithCursor(USER_ID, null, CURSOR, LIMIT))
+                    .willReturn(List.of(usersLinku));
+
+            var result = aiArticleService.getMyAiArticlesByCategory(USER_ID, null, CURSOR, LIMIT);
+
+            verify(usersLinkuRepository).fetchAiArticlesByCategoryIdWithCursor(USER_ID, null, CURSOR, LIMIT);
+            assertEquals(1, result.getLinkuList().size());
+            assertFalse(result.getHasNext());
+        }
+
+        @Test
+        @DisplayName("categoryId가 있으면 해당 카테고리로 필터링해 repository를 호출한다")
+        void categoryId가_있으면_해당_카테고리로_필터링한다() {
+            Long categoryId = 3L;
+            Linku linku = LinkuFixture.linku(null);
+            Users user = LinkuFixture.user();
+            UsersLinku usersLinku = buildUsersLinku(linku, user);
+
+            given(usersLinkuRepository.fetchAiArticlesByCategoryIdWithCursor(USER_ID, categoryId, CURSOR, LIMIT))
+                    .willReturn(List.of(usersLinku));
+
+            var result = aiArticleService.getMyAiArticlesByCategory(USER_ID, categoryId, CURSOR, LIMIT);
+
+            verify(usersLinkuRepository).fetchAiArticlesByCategoryIdWithCursor(USER_ID, categoryId, CURSOR, LIMIT);
+            assertEquals(1, result.getLinkuList().size());
+        }
+
+        @Test
+        @DisplayName("결과가 limit보다 많으면 hasNext=true와 다음 커서를 반환한다")
+        void 결과가_limit보다_많으면_hasNext와_nextCursor를_반환한다() {
+            Linku linku = LinkuFixture.linku(null);
+            Users user = LinkuFixture.user();
+            UsersLinku first = UsersLinku.builder()
+                    .userLinkuId(1L).linku(linku).user(user)
+                    .emotion(LinkuFixture.emotion()).emotionAi(true).situationAi(true).build();
+            UsersLinku second = UsersLinku.builder()
+                    .userLinkuId(2L).linku(linku).user(user)
+                    .emotion(LinkuFixture.emotion()).emotionAi(true).situationAi(true).build();
+
+            given(usersLinkuRepository.fetchAiArticlesByCategoryIdWithCursor(USER_ID, null, CURSOR, 1))
+                    .willReturn(List.of(first, second)); // limit(1) + 1건 = 다음 페이지 있음
+
+            var result = aiArticleService.getMyAiArticlesByCategory(USER_ID, null, CURSOR, 1);
+
+            assertTrue(result.getHasNext());
+            assertEquals("1", result.getNextCursor());
+            assertEquals(1, result.getLinkuList().size());
+        }
+    }
+
     private UsersLinku buildUsersLinku(Linku linku, Users user) {
         return UsersLinku.builder()
                 .userLinkuId(10L)

--- a/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -184,6 +185,50 @@ class AiArticleControllerTest {
                         .andExpect(jsonPath("$.result.nextCursor").doesNotExist())
                         .andDo(print());
             }
+
+            @Test
+            @DisplayName("categoryId를 생략하면 전체 카테고리 결과를 반환한다")
+            void getMyAiArticlesByCategory_AllCategories_WhenCategoryIdOmitted() throws Exception {
+                // given
+                LinkuResponseDTO.AiArticleSummaryDTO articleFromCategoryA = LinkuResponseDTO.AiArticleSummaryDTO.builder()
+                        .linkuId(201L)
+                        .linku("https://example.com/a")
+                        .emotionId(1L)
+                        .domain("naver")
+                        .domainImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .title("카테고리 A 글")
+                        .linkuImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .build();
+                LinkuResponseDTO.AiArticleSummaryDTO articleFromCategoryB = LinkuResponseDTO.AiArticleSummaryDTO.builder()
+                        .linkuId(202L)
+                        .linku("https://example.com/b")
+                        .emotionId(2L)
+                        .domain("google")
+                        .domainImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .title("카테고리 B 글")
+                        .linkuImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .build();
+
+                LinkuResponseDTO.LinkuSliceResultDTO mockSlice = LinkuResponseDTO.LinkuSliceResultDTO.builder()
+                        .linkuList(List.of(articleFromCategoryA, articleFromCategoryB))
+                        .nextCursor(null)
+                        .hasNext(false)
+                        .build();
+
+                given(aiArticleService.getMyAiArticlesByCategory(eq(TEST_USER_ID), isNull(), any(), anyInt()))
+                        .willReturn(mockSlice);
+
+                // when & then
+                mockMvc.perform(get("/api/v1/aiarticle")
+                                .param("limit", "10")
+                                .contentType(MediaType.APPLICATION_JSON))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andExpect(jsonPath("$.result.linkuList.length()").value(2))
+                        .andExpect(jsonPath("$.result.linkuList[0].linkuId").value(201L))
+                        .andExpect(jsonPath("$.result.linkuList[1].linkuId").value(202L))
+                        .andDo(print());
+            }
         }
 
         @Nested
@@ -196,16 +241,6 @@ class AiArticleControllerTest {
                 // when & then
                 mockMvc.perform(get("/api/v1/aiarticle")
                                 .param("categoryId", "invalid")
-                                .contentType(MediaType.APPLICATION_JSON))
-                        .andExpect(status().isBadRequest())
-                        .andDo(print());
-            }
-
-            @Test
-            @DisplayName("categoryId가 없으면 400 Bad Request를 반환한다")
-            void getMyAiArticlesByCategory_MissingCategoryId() throws Exception {
-                // when & then
-                mockMvc.perform(get("/api/v1/aiarticle")
                                 .contentType(MediaType.APPLICATION_JSON))
                         .andExpect(status().isBadRequest())
                         .andDo(print());


### PR DESCRIPTION
## 🔗 관련 이슈

---

## 📌 작업 내용
ai article 전체 필터추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 카테고리 ID를 생략해도 AI 요약 링크를 조회할 수 있습니다.
  * 카테고리 미지정 시 모든 카테고리의 결과가 제공됩니다.
  * 카테고리를 지정하면 해당 카테고리로 필터링됩니다.

* **버그 수정**
  * 전체 카테고리 조회 시 페이지네이션과 다음 커서 정보가 올바르게 처리됩니다.

* **테스트**
  * 카테고리 생략, 카테고리 필터링, 페이지네이션 동작을 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->