### PR TITLE
!hotfix: ai article 카테고리 반환

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/LinkuConverter.java
@@ -213,6 +213,7 @@ public class LinkuConverter {
     public static LinkuResponseDTO.AiArticleSummaryDTO toAiArticleSummaryDTO(UsersLinku usersLinku) {
         Linku linku = usersLinku.getLinku();
         Domain domain = linku.getDomain();
+        Category category = linku.getCategory();
         return LinkuResponseDTO.AiArticleSummaryDTO.builder()
                 .linkuId(linku.getLinkuId())
                 .linku(linku.getLinkuUrl())
@@ -221,6 +222,8 @@ public class LinkuConverter {
                 .domainImageUrl(domain != null ? domain.getImageUrl() : null)
                 .title(usersLinku.getTitle() != null ? usersLinku.getTitle() : linku.getTitle())
                 .linkuImageUrl(usersLinku.getImageUrl() != null ? usersLinku.getImageUrl() : linku.getImgUrl())
+                .categoryId(category != null ? category.getCategoryId() : null)
+                .categoryName(category != null ? category.getCategoryName() : null)
                 .build();
     }
 

--- a/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/UserLinkuRepository/UsersLinkuRepositoryImpl.java
@@ -81,10 +81,12 @@ public class UsersLinkuRepositoryImpl implements UsersLinkuRepositoryCustom {
                 .selectFrom(usersLinku)
                 .join(usersLinku.linku, linku).fetchJoin()
                 .leftJoin(linku.aiArticle, aiArticle)
-                // 서비스단(getMyAiArticlesByCategory)에서 ul.getEmotion()/l.getDomain()을 사용하므로
-                // emotion/domain은 페치 조인하되, AiArticle은 응답에서 읽지 않아 일반 LEFT JOIN으로 둔다.
+                // 서비스단(getMyAiArticlesByCategory)에서 ul.getEmotion()/l.getDomain()/l.getCategory()를
+                // 사용하므로 emotion/domain/category는 페치 조인하되, AiArticle은 응답에서 읽지 않아
+                // 일반 LEFT JOIN으로 둔다.
                 .join(usersLinku.emotion).fetchJoin()
                 .join(linku.domain).fetchJoin()
+                .join(linku.category).fetchJoin()
                 .where(
                         usersLinku.user.id.eq(userId),
                         eqCategoryId(categoryId), // null이면 카테고리 필터 없이 전체 조회

--- a/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
@@ -60,7 +60,8 @@ public interface AiArticleApi {
                     - `hasNext=false`이면 `nextCursor`는 null이며 더 이상 가져올 데이터가 없다는 뜻입니다.
 
                     **응답 항목 (linkuList의 각 원소)**
-                    - `linkuId`, `linku`(원본 URL), `emotionId`, `domain`(도메인명), `domainImageUrl`, `title`, `linkuImageUrl`을 반환합니다.
+                    - `linkuId`, `linku`(원본 URL), `emotionId`, `domain`(도메인명), `domainImageUrl`, `title`, `linkuImageUrl`, `categoryId`, `categoryName`을 반환합니다.
+                    - `categoryId`/`categoryName`은 "전체" 탭처럼 여러 카테고리가 섞여 조회될 때 각 항목이 어느 카테고리인지 구분하기 위해 항상 포함됩니다.
 
                     **전체 카테고리 조회**
                     - `categoryId`를 생략하면 카테고리 필터 없이 전체 카테고리의 AI 요약 링크를 조회합니다("전체" 탭).

--- a/src/main/java/com/umc/linkyou/web/dto/linku/LinkuResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/linku/LinkuResponseDTO.java
@@ -106,6 +106,8 @@ public class LinkuResponseDTO {
         private String domainImageUrl;
         private String title;
         private String linkuImageUrl;
+        private Long categoryId;
+        private String categoryName;
     }
 
     // 홈화면 링크 추천(GET /linku/recommend) 커서 페이징 응답.

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -458,6 +458,9 @@ class AiArticleServiceTest {
             verify(usersLinkuRepository).fetchAiArticlesByCategoryIdWithCursor(USER_ID, null, CURSOR, LIMIT);
             assertEquals(1, result.getLinkuList().size());
             assertFalse(result.getHasNext());
+            // "전체" 탭에서는 여러 카테고리가 섞여 나오므로, 각 항목에 카테고리 정보가 실려 있어야 한다.
+            assertEquals(LinkuFixture.CATEGORY_ID, result.getLinkuList().get(0).getCategoryId());
+            assertEquals("기술", result.getLinkuList().get(0).getCategoryName());
         }
 
         @Test

--- a/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
@@ -100,6 +100,8 @@ class AiArticleControllerTest {
                         .domainImageUrl("https://img1.daumcdn.net/thumb/R800x0")
                         .title("첫 번째 AI 제목")
                         .linkuImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .categoryId(1L)
+                        .categoryName("어학")
                         .build();
 
                 LinkuResponseDTO.LinkuSliceResultDTO mockSlice = LinkuResponseDTO.LinkuSliceResultDTO.builder()
@@ -125,6 +127,8 @@ class AiArticleControllerTest {
                         .andExpect(jsonPath("$.result.linkuList[0].emotionId").value(2L))
                         .andExpect(jsonPath("$.result.linkuList[0].domain").value("naver"))
                         .andExpect(jsonPath("$.result.linkuList[0].title").value("첫 번째 AI 제목"))
+                        .andExpect(jsonPath("$.result.linkuList[0].categoryId").value(1L))
+                        .andExpect(jsonPath("$.result.linkuList[0].categoryName").value("어학"))
                         .andExpect(jsonPath("$.result.nextCursor").value("1001"))
                         .andExpect(jsonPath("$.result.hasNext").value(true))
                         .andDo(print());
@@ -198,6 +202,8 @@ class AiArticleControllerTest {
                         .domainImageUrl("https://img1.daumcdn.net/thumb/R800x0")
                         .title("카테고리 A 글")
                         .linkuImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .categoryId(1L)
+                        .categoryName("어학")
                         .build();
                 LinkuResponseDTO.AiArticleSummaryDTO articleFromCategoryB = LinkuResponseDTO.AiArticleSummaryDTO.builder()
                         .linkuId(202L)
@@ -207,6 +213,8 @@ class AiArticleControllerTest {
                         .domainImageUrl("https://img1.daumcdn.net/thumb/R800x0")
                         .title("카테고리 B 글")
                         .linkuImageUrl("https://img1.daumcdn.net/thumb/R800x0")
+                        .categoryId(2L)
+                        .categoryName("뉴스")
                         .build();
 
                 LinkuResponseDTO.LinkuSliceResultDTO mockSlice = LinkuResponseDTO.LinkuSliceResultDTO.builder()
@@ -226,7 +234,11 @@ class AiArticleControllerTest {
                         .andExpect(jsonPath("$.isSuccess").value(true))
                         .andExpect(jsonPath("$.result.linkuList.length()").value(2))
                         .andExpect(jsonPath("$.result.linkuList[0].linkuId").value(201L))
+                        .andExpect(jsonPath("$.result.linkuList[0].categoryId").value(1L))
+                        .andExpect(jsonPath("$.result.linkuList[0].categoryName").value("어학"))
                         .andExpect(jsonPath("$.result.linkuList[1].linkuId").value(202L))
+                        .andExpect(jsonPath("$.result.linkuList[1].categoryId").value(2L))
+                        .andExpect(jsonPath("$.result.linkuList[1].categoryName").value("뉴스"))
                         .andDo(print());
             }
         }


### PR DESCRIPTION
## 🔗 관련 이슈

---

## 📌 작업 내용
전체 탭으로 요청 넣으면 response에서 카테고리 줘야 함


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 요약 링크 목록에 각 링크의 카테고리 ID와 카테고리명이 포함됩니다.
  * 여러 카테고리의 링크를 조회할 때 항목별 카테고리 정보를 확인할 수 있습니다.

* **문서**
  * AI 요약 링크 목록 응답에 제공되는 카테고리 정보가 명확히 안내됩니다.

* **테스트**
  * 특정 카테고리 및 전체 카테고리 조회에서 카테고리 정보가 올바르게 반환되는지 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->