### PR TITLE
feat: #429 ai article get post분리 및 폴링 구조

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/aiarticle/AiArticleErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/aiarticle/AiArticleErrorStatus.java
@@ -23,6 +23,7 @@ public enum AiArticleErrorStatus implements BaseErrorCode {
 
     // 409 Conflict
     _DUPLICATE_AI_ARTICLE(HttpStatus.CONFLICT, "AIARTICLE4091", "이미 해당 링크로 생성된 AI Article이 존재합니다."),
+    _AI_ARTICLE_GENERATING(HttpStatus.CONFLICT, "AIARTICLE4092", "이미 AI 요약 생성이 진행 중입니다."),
 
     // 500 Internal Server Error
     _AI_INVALID_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI5002", "AI 응답이 예상한 형식이 아닙니다."),

--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/aiarticle/AiArticleSuccessStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/aiarticle/AiArticleSuccessStatus.java
@@ -11,7 +11,8 @@ import org.springframework.http.HttpStatus;
 public enum AiArticleSuccessStatus implements BaseSuccessCode {
 
     AI_ARTICLE_OK(HttpStatus.OK, "AIARTICLE2001", "AI 요약을 가져왔습니다."),
-    AI_ARTICLE_LIST_OK(HttpStatus.OK, "AIARTICLE2002", "AI 요약 목록을 가져왔습니다.");
+    AI_ARTICLE_LIST_OK(HttpStatus.OK, "AIARTICLE2002", "AI 요약 목록을 가져왔습니다."),
+    AI_ARTICLE_CREATE_ACCEPTED(HttpStatus.OK, "AIARTICLE2003", "AI 요약 생성을 시작했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/config/common/AsyncConfig.java
+++ b/src/main/java/com/umc/linkyou/config/common/AsyncConfig.java
@@ -118,4 +118,19 @@ public class AsyncConfig {
         ex.initialize();
         return ex;
     }
+
+    // AI 요약 생성용 (크롤링 + Gemini 호출, POST /aiarticle/{linkuid} 요청 스레드에서 분리)
+    @Bean(name = "aiArticleTaskExecutor")
+    public Executor aiArticleTaskExecutor() {
+        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(4);
+        ex.setMaxPoolSize(8);
+        ex.setQueueCapacity(200);
+        ex.setThreadNamePrefix("ai-article-");
+        ex.setWaitForTasksToCompleteOnShutdown(true);
+        ex.setAwaitTerminationSeconds(30);
+        ex.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        ex.initialize();
+        return ex;
+    }
 }

--- a/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/AiArticleConverter.java
@@ -4,22 +4,15 @@ import com.umc.linkyou.domain.AiArticle;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.classification.Emotion;
 import com.umc.linkyou.domain.mapping.UsersLinku;
-import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
 import com.umc.linkyou.web.dto.AiArticleResponseDTO;
 
 public class AiArticleConverter {
-
-    public static AiArticle toEntity(AiArticleResultDTO result, Linku linku) {
-        return AiArticle.builder()
-                .linku(linku)
-                .summary(result.summary())
-                .build();
-    }
 
     // tags는 지연 로딩 컬렉션(linku.getLinkuKeywords())을 순회해야 해서 트랜잭션을 쥔 서비스
     // 레이어에서 계산해 넘겨받는다 (LinkuService/LinkuCreateService/FolderServiceImpl과 동일한 패턴).
     // title/imgUrl은 단순 필드 우선순위 결정(usersLinku 우선, 없으면 linku)이라 지연 로딩과 무관하므로
     // LinkuConverter와 동일하게 컨버터가 직접 계산한다.
+    // status가 PENDING/FAILED이면 entity.getSummary()는 아직 null일 수 있다 — 그대로 내려준다.
     public static AiArticleResponseDTO.AiArticleResultDTO toDto(
             AiArticle entity,
             Linku linku,
@@ -39,6 +32,8 @@ public class AiArticleConverter {
                 .emotionId(emotion != null ? emotion.getEmotionId() : null)
                 .emotionName(emotion != null ? emotion.getName() : null)
                 .categoryName(linku.getCategory() != null ? linku.getCategory().getCategoryName() : null)
+                .status(entity.getStatus().name())
+                .failReason(entity.getFailReason())
                 .summary(entity.getSummary())
                 .imgUrl(imgUrl)
                 .memo(usersLinku != null ? usersLinku.getMemo() : null)

--- a/src/main/java/com/umc/linkyou/domain/AiArticle.java
+++ b/src/main/java/com/umc/linkyou/domain/AiArticle.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.domain;
 
 import com.umc.linkyou.domain.common.BaseEntity;
+import com.umc.linkyou.domain.enums.AiArticleStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -21,10 +22,43 @@ public class AiArticle extends BaseEntity {
     @JoinColumn(name = "linku_id", nullable = false, unique = true)
     private Linku linku;
 
-    @Column(name = "summary", nullable = false, length = 255)
+    // PENDING 상태에서는 아직 채워지지 않으므로 nullable.
+    @Column(name = "summary", length = 255)
     private String summary;
 
-    public void updateSummary(String summary) {
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private AiArticleStatus status = AiArticleStatus.PENDING;
+
+    // 실패 사유 코드 (예: CRAWLER4031, GEMINI5041). status=FAILED일 때만 값이 있다.
+    @Column(name = "fail_reason", length = 50)
+    private String failReason;
+
+    // 생성 요청 접수 시점에 쓰는 정적 팩터리. summary는 아직 없고 status=PENDING으로 시작한다.
+    public static AiArticle pending(Linku linku) {
+        return AiArticle.builder()
+                .linku(linku)
+                .status(AiArticleStatus.PENDING)
+                .build();
+    }
+
+    // 비동기 생성이 성공적으로 끝났을 때 호출한다.
+    public void complete(String summary) {
         this.summary = summary;
+        this.status = AiArticleStatus.DONE;
+        this.failReason = null;
+    }
+
+    // 비동기 생성이 실패했을 때 호출한다. failReasonCode는 AiArticleErrorStatus/GeminiErrorStatus 등의 code 값.
+    public void markFailed(String failReasonCode) {
+        this.status = AiArticleStatus.FAILED;
+        this.failReason = failReasonCode;
+    }
+
+    // FAILED 상태에서 재시도할 때 PENDING으로 되돌린다.
+    public void restartPending() {
+        this.status = AiArticleStatus.PENDING;
+        this.failReason = null;
     }
 }

--- a/src/main/java/com/umc/linkyou/domain/enums/AiArticleStatus.java
+++ b/src/main/java/com/umc/linkyou/domain/enums/AiArticleStatus.java
@@ -1,0 +1,9 @@
+package com.umc.linkyou.domain.enums;
+
+// AiArticle 생성 상태. POST가 크롤링+Gemini 호출을 비동기로 처리하면서,
+// GET에서 이 상태를 보고 프론트가 폴링을 계속할지(PENDING) 멈출지(DONE/FAILED) 판단한다.
+public enum AiArticleStatus {
+    PENDING, // 생성 요청 접수, 크롤링/Gemini 호출 진행 중
+    DONE,    // 생성 완료, summary 사용 가능
+    FAILED   // 생성 실패 (robots.txt 차단, 크롤링 실패, Gemini 오류 등). failReason 참고
+}

--- a/src/main/java/com/umc/linkyou/service/AiArticleGenerationWorker.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleGenerationWorker.java
@@ -1,0 +1,85 @@
+package com.umc.linkyou.service;
+
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.AiArticle;
+import com.umc.linkyou.domain.AlarmPayload;
+import com.umc.linkyou.domain.Linku;
+import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
+import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
+import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
+import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
+import com.umc.linkyou.service.alarm.AlarmService;
+import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * AiArticleService.createAiArticle()이 커밋해둔 PENDING 레코드를 실제로 채우는 비동기 워커.
+ *
+ * AiArticleService 안에 두지 않고 별도 빈으로 분리한 이유: {@code @Async}는 스프링 프록시를 거쳐야
+ * 동작하는데, 같은 클래스 안에서 this.generateAsync(...)로 자기 자신을 호출하면 프록시를 우회해서
+ * 실제로는 동기 실행되어 버린다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AiArticleGenerationWorker {
+
+    private final AiArticleRepository aiArticleRepository;
+    private final UsersLinkuRepository usersLinkuRepository;
+    private final AiArticleAnalyzer aiArticleAnalyzer;
+    private final AlarmService alarmService;
+
+    // userId: 생성을 요청한 사용자. 크롤링/Gemini 응답을 기다리지 않고 즉시 리턴하므로
+    // 호출부(AiArticleService.createAiArticle)는 이 메서드의 완료를 기다리지 않는다.
+    // aiExist 표시와 완료 알림은 "요청한 본인"에게만 남긴다 (리팩터링 전 AiArticleService의 기존 정책과 동일).
+    @Async("aiArticleTaskExecutor")
+    @Transactional
+    public void generateAsync(Long aiArticleId, Long userId) {
+        AiArticle article = aiArticleRepository.findById(aiArticleId).orElse(null);
+        if (article == null) {
+            log.warn("[AI 요약 생성] AiArticle(id={})을 찾을 수 없어 생성을 건너뜁니다.", aiArticleId);
+            return;
+        }
+
+        Linku linku = article.getLinku();
+        Long linkuId = linku.getLinkuId();
+
+        try {
+            AiArticleResultDTO result = aiArticleAnalyzer.analyzeByUrl(linku.getLinkuUrl());
+            article.complete(result.summary());
+
+            List<UsersLinku> usersLinkus = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(userId, linkuId);
+            usersLinkus.forEach(ul -> ul.markAiExist(true));
+
+            UsersLinku latest = usersLinkus.stream()
+                    .max(Comparator.comparing(UsersLinku::getCreatedAt))
+                    .orElse(null);
+            String linkTitle = resolveTitle(linku, latest);
+
+            alarmService.sendAlarm(userId, new AlarmRequestDTO.AlarmSendRequestDTO(
+                    AlarmType.LINK_SUMMARY_COMPLETE, linkuId, new AlarmPayload.LinkTitle(linkTitle)));
+        } catch (GeneralException e) {
+            String reasonCode = e.getCode().getReason().getCode();
+            log.warn("[AI 요약 생성 실패] linkuId={}, code={}, message={}", linkuId, reasonCode, e.getMessage());
+            article.markFailed(reasonCode);
+        } catch (Exception e) {
+            log.warn("[AI 요약 생성 실패] linkuId={}, 알 수 없는 오류: {}", linkuId, e.getMessage(), e);
+            article.markFailed("UNKNOWN");
+        }
+    }
+
+    private String resolveTitle(Linku linku, UsersLinku usersLinku) {
+        return (usersLinku != null && usersLinku.getTitle() != null)
+                ? usersLinku.getTitle()
+                : linku.getTitle();
+    }
+}

--- a/src/main/java/com/umc/linkyou/service/AiArticleService.java
+++ b/src/main/java/com/umc/linkyou/service/AiArticleService.java
@@ -8,31 +8,26 @@ import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.converter.AiArticleConverter;
 import com.umc.linkyou.converter.LinkuConverter;
 import com.umc.linkyou.domain.AiArticle;
-import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.Linku;
-import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.enums.AiArticleStatus;
 import com.umc.linkyou.domain.mapping.UsersLinku;
-import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
-import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
 
 import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
 import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
-import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.web.dto.AiArticleResponseDTO;
-import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AiArticleService {
@@ -41,80 +36,86 @@ public class AiArticleService {
     private final LinkuRepository linkuRepository;
     private final AiArticleRepository aiArticleRepository;
     private final UsersLinkuRepository usersLinkuRepository;
-    private final AiArticleAnalyzer aiArticleAnalyzer;
-    private final AlarmService alarmService;
+    private final AiArticleGenerationWorker aiArticleGenerationWorker;
 
+    /**
+     * GET /aiarticle/{linkuid} — 순수 조회. 생성은 하지 않는다.
+     * 레코드가 아예 없으면 404(_AI_ARTICLE_NOT_FOUND)를 던지고, 프론트는 이 경우에만 POST로 생성을 요청한다.
+     * 레코드가 있으면 PENDING/DONE/FAILED 중 현재 상태를 그대로 실어 보낸다 — 프론트는 PENDING이면 계속 폴링한다.
+     */
     @Transactional
-    public AiArticleResponseDTO.AiArticleResultDTO saveAiArticle(Long linkuId, Long userId) {
+    public AiArticleResponseDTO.AiArticleResultDTO getAiArticle(Long linkuId, Long userId) {
         Linku linku = linkuRepository.findById(linkuId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        // 동일 (user, linku) 조합으로 저장된 UsersLinku가 여러 건일 수 있다. 응답/알림에는 최신 1건을
-        // 대표로 쓰지만, "AI 요약 있음" 표시는 같은 링크를 여러 번 저장한 모든 건에 동일하게 남아야 한다
-        // (요약은 linku 단위로 한 번만 생성되므로, 그 link를 저장한 기록이라면 몇 번째 저장이든 동일하게 적용된다).
+
+        // 요청 유저가 이 linku를 저장한 적이 없으면(=UsersLinku 없음) 소유권이 없는 것이므로 예외를 던진다.
+        // (다른 유저가 먼저 만든 AiArticle의 linkuId를 알기만 하면 조회되는 것을 막기 위함)
         List<UsersLinku> usersLinkus = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(userId, linkuId);
         UsersLinku usersLinku = usersLinkus.stream()
                 .max(Comparator.comparing(UsersLinku::getCreatedAt))
                 .orElseThrow(() -> new GeneralException(LinkuErrorStatus._USER_LINKU_NOT_FOUND));
 
-        AiArticleResultDTO result = aiArticleAnalyzer.analyzeByUrl(linku.getLinkuUrl());
-
         AiArticle article = aiArticleRepository.findByLinku(linku)
-                .map(existing -> {
-                    existing.updateSummary(result.summary());
-                    return existing;
-                })
-                .orElseGet(() -> aiArticleRepository.save(
-                        AiArticleConverter.toEntity(result, linku)
-                ));
+                .orElseThrow(() -> new GeneralException(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND));
 
-        usersLinkus.forEach(ul -> ul.markAiExist(true));
-
-        String linkTitle = resolveTitle(linku, usersLinku);
-
-        // 요약 완료 시 링크 요약 알림 발송. 설정 필터링은 sendAlarm 내부에서 처리한다.
-        alarmService.sendAlarm(userId, new AlarmRequestDTO.AlarmSendRequestDTO(
-                AlarmType.LINK_SUMMARY_COMPLETE, linkuId, new AlarmPayload.LinkTitle(linkTitle)));
+        // 다른 유저가 먼저 만들어둔 요약이라도, 본인이 직접 조회한 시점부터는 본인 소유 UsersLinku에도
+        // "AI 요약 있음"으로 남긴다. 단, PENDING/FAILED는 아직 실제로 볼 수 있는 요약이 없으므로 표시하지 않는다.
+        if (article.getStatus() == AiArticleStatus.DONE) {
+            usersLinkus.forEach(ul -> ul.markAiExist(true));
+        }
 
         return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku));
     }
 
+    /**
+     * POST /aiarticle/{linkuid} — 생성 트리거만 한다. 크롤링/Gemini 호출은 여기서 기다리지 않고
+     * {@link AiArticleGenerationWorker}에 넘겨 비동기로 처리한다. 응답은 항상 status=PENDING으로 즉시 내려간다.
+     * 이미 DONE이면 409(_DUPLICATE_AI_ARTICLE), 이미 PENDING이면 409(_AI_ARTICLE_GENERATING) — 두 경우 모두
+     * 프론트는 GET으로 전환해 조회/폴링해야 한다. FAILED였다면 재시도로 간주하고 다시 PENDING으로 돌린다.
+     */
     @Transactional
-    public AiArticleResponseDTO.AiArticleResultDTO saveOrGetAiArticle(Long linkuId, Long userId) {
+    public AiArticleResponseDTO.AiArticleResultDTO createAiArticle(Long linkuId, Long userId) {
         Linku linku = linkuRepository.findById(linkuId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
-
-        AiArticle aiArticle = aiArticleRepository.findByLinku(linku).orElse(null);
-
-        if (aiArticle == null || aiArticle.getSummary() == null || aiArticle.getSummary().isBlank()) {
-            return saveAiArticle(linkuId, userId);
-        } else {
-            return showAiArticle(linkuId, userId);
-        }
-    }
-
-    @Transactional
-    public AiArticleResponseDTO.AiArticleResultDTO showAiArticle(Long linkuId, Long userId) {
-        Linku linku = linkuRepository.findById(linkuId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus._BAD_REQUEST));
-        AiArticle article = aiArticleRepository.findByLinku(linku)
-                .orElseThrow(() -> new GeneralException(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND));
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
-        // 동일 (user, linku) 조합으로 저장된 UsersLinku가 여러 건일 수 있다. 응답에는 최신 1건을 대표로
-        // 쓰되, "AI 요약 있음" 표시는 본인이 저장한 모든 건에 동일하게 남긴다 (saveAiArticle과 동일한 패턴).
-        // 요청 유저가 이 linku를 저장한 적이 없으면(=UsersLinku 없음) 소유권이 없는 것이므로 예외를 던진다.
-        // (다른 유저가 먼저 요약을 만들어둔 linkuId를 알기만 하면 조회되는 것을 막기 위함)
+
+        // 동일 (user, linku) 조합으로 저장된 UsersLinku가 여러 건일 수 있다. 응답에는 최신 1건을
+        // 대표로 쓰지만, "AI 요약 있음" 표시는 같은 링크를 여러 번 저장한 모든 건에 동일하게 남아야 한다.
         List<UsersLinku> usersLinkus = usersLinkuRepository.findByUser_IdAndLinku_LinkuId(userId, linkuId);
         UsersLinku usersLinku = usersLinkus.stream()
                 .max(Comparator.comparing(UsersLinku::getCreatedAt))
                 .orElseThrow(() -> new GeneralException(LinkuErrorStatus._USER_LINKU_NOT_FOUND));
 
-        // 다른 유저가 먼저 만들어둔 요약이라도, 본인이 직접 조회한 시점부터는 본인 소유 UsersLinku에도
-        // "AI 요약 있음"으로 남긴다 (본인이 요청/조회한 적 없는데 true로 보이는 문제를 막기 위해 저장
-        // 시점에는 더 이상 자동으로 표시하지 않으므로, 대신 실제 조회 시점에 표시한다).
-        usersLinkus.forEach(ul -> ul.markAiExist(true));
+        AiArticle article = aiArticleRepository.findByLinku(linku).orElse(null);
+
+        if (article == null) {
+            article = aiArticleRepository.save(AiArticle.pending(linku));
+        } else if (article.getStatus() == AiArticleStatus.DONE) {
+            throw new GeneralException(AiArticleErrorStatus._DUPLICATE_AI_ARTICLE);
+        } else if (article.getStatus() == AiArticleStatus.PENDING) {
+            throw new GeneralException(AiArticleErrorStatus._AI_ARTICLE_GENERATING);
+        } else {
+            // FAILED -> 재시도
+            article.restartPending();
+        }
+
+        Long articleId = article.getId();
+
+        // 트랜잭션이 실제로 커밋된 뒤에 비동기 워커를 띄운다. 커밋 전에 띄우면 워커 스레드가 아직
+        // 다른 트랜잭션에서는 보이지 않는 PENDING 레코드를 읽으려다 실패할 수 있다.
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    aiArticleGenerationWorker.generateAsync(articleId, userId);
+                }
+            });
+        } else {
+            aiArticleGenerationWorker.generateAsync(articleId, userId);
+        }
 
         return AiArticleConverter.toDto(article, linku, usersLinku, resolveTags(linku));
     }
@@ -125,14 +126,6 @@ public class AiArticleService {
         return linku.getLinkuKeywords().stream()
                 .map(lk -> lk.getKeyword().getName())
                 .collect(Collectors.joining(", "));
-    }
-
-    // 알림 페이로드에 넣을 제목 계산용. DTO의 title은 AiArticleConverter.toDto가 동일한
-    // 우선순위(usersLinku 우선, 없으면 linku)로 자체 계산하므로 여기서는 알림 발송에만 쓰인다.
-    private String resolveTitle(Linku linku, UsersLinku usersLinku) {
-        return (usersLinku != null && usersLinku.getTitle() != null)
-                ? usersLinku.getTitle()
-                : linku.getTitle();
     }
 
     // categoryId가 null이면(=쿼리 파라미터 생략) "전체" 카테고리로 간주해 필터 없이 조회한다.

--- a/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/AiArticleApi.java
@@ -4,6 +4,7 @@ import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.SuccessStatus;
+import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
@@ -20,31 +21,53 @@ import org.springframework.web.bind.annotation.*;
 public interface AiArticleApi {
 
     @Operation(
-            summary = "AI 요약 저장 또는 조회",
+            summary = "AI 요약 조회",
             description = """
-                    - 해당 링크에 대한 AI 분석 결과(`ai_articles`)가 이미 존재하고 summary가 채워져 있으면, 새로 분석하지 않고 기존 데이터를 그대로 반환합니다.
-                    - 분석이 완료되면 `LINK_SUMMARY_COMPLETE` 알림이 발송됩니다.
+                    해당 링크에 대한 AI 요약(`ai_articles`) 레코드를 조회합니다. 생성은 하지 않습니다 — 레코드가 아예 없으면
+                    404(`AIARTICLE4041`)를 반환하며, 이 경우에만 `POST /aiarticle/{linkuid}`로 생성을 요청하세요.
 
-                   - 크롤링 대상 사이트의 robots.txt가 크롤링을 금지하는 경우 403(`CRAWLER4031`)이 반환되며, 이 경우 재시도해도 결과는 같습니다.
-                    - 그 외 크롤링 자체가 실패(네트워크 오류, 파싱 실패 등)하거나 Gemini 응답이 예상 형식이 아닌 경우 500이 반환될 수 있습니다. 이런 경우는 일시적인 문제일 수 있으니 API를 다시 요청해 보세요.
+                    응답의 `status` 필드로 진행 상태를 판단합니다.
+                    - `PENDING`: 생성 진행 중. summary는 아직 null이며, 프론트는 일정 간격으로 이 GET을 다시 호출(폴링)합니다.
+                    - `DONE`: 생성 완료. summary/tags 등을 그대로 표시합니다.
+                    - `FAILED`: 생성 실패. `failReason`에 실패 사유 코드가 담깁니다(예: `CRAWLER4031` - robots.txt 차단,
+                      재시도해도 동일한 사유로 다시 실패합니다). `POST`를 다시 호출하면 재시도합니다.
                     """
     )
     @ApiSuccessCode(SuccessStatus._OK)
-    // 공통 에러 (잘못된 요청 등)
     @ApiErrorCode(errorStatus = {ErrorStatus._BAD_REQUEST})
-    // 유저 관련 에러
     @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
-    // AI Article 도메인 전용 에러 (분리한 Enum 사용)
+    @ApiErrorCode(linkuErrorStatus = {LinkuErrorStatus._USER_LINKU_NOT_FOUND})
+    @ApiErrorCode(aiArticleErrorStatus = {AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND})
+    @GetMapping("/{linkuid}")
+    ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> getAiArticle(
+            @Parameter(description = "AI 요약을 조회할 대상 링크 ID (Linku 엔티티의 linkuId). 요청 유저가 저장한 링크여야 합니다.", example = "101") @PathVariable("linkuid") Long linkuId,
+            @CurrentUser CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "AI 요약 생성 요청",
+            description = """
+                    해당 링크에 대한 AI 요약 생성을 시작합니다. 크롤링/Gemini 호출을 기다리지 않고 즉시
+                    status=`PENDING` 응답을 반환합니다 — 실제 완료 여부는 `GET /aiarticle/{linkuid}`를 폴링해 확인하세요.
+
+                    - 이미 생성이 완료(`DONE`)된 링크에 다시 요청하면 409(`AIARTICLE4091`)가 반환됩니다. `GET`으로 조회하세요.
+                    - 이미 생성이 진행 중(`PENDING`)인 링크에 다시 요청하면 409(`AIARTICLE4092`)가 반환됩니다.
+                    - 이전 시도가 실패(`FAILED`)했던 링크는 재시도로 간주되어 다시 `PENDING`으로 생성을 시작합니다.
+                    - robots.txt 차단, 크롤링 실패, Gemini 오류 등 생성 자체의 실패는 이 API의 에러가 아니라, 이후
+                      `GET`에서 status=`FAILED`와 `failReason`으로 나타납니다.
+                    """
+    )
+    @ApiSuccessCode(SuccessStatus._OK)
+    @ApiErrorCode(errorStatus = {ErrorStatus._BAD_REQUEST})
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @ApiErrorCode(linkuErrorStatus = {LinkuErrorStatus._USER_LINKU_NOT_FOUND})
     @ApiErrorCode(aiArticleErrorStatus = {
-            AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND,
-            AiArticleErrorStatus._AI_PARSE_ERROR,
-            AiArticleErrorStatus._AI_INVALID_RESPONSE,
-            AiArticleErrorStatus._CONTENT_EXTRACTION_FAILED,
-            AiArticleErrorStatus._CONTENT_EXTRACTION_PROHIBITED
+            AiArticleErrorStatus._DUPLICATE_AI_ARTICLE,
+            AiArticleErrorStatus._AI_ARTICLE_GENERATING
     })
     @PostMapping("/{linkuid}")
-    ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> saveOrGetAiArticle(
-            @Parameter(description = "AI 요약을 저장/조회할 대상 링크 ID (Linku 엔티티의 linkuId). 요청 유저가 저장한 링크여야 합니다.", example = "101") @PathVariable("linkuid") Long linkuId,
+    ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> createAiArticle(
+            @Parameter(description = "AI 요약을 생성할 대상 링크 ID (Linku 엔티티의 linkuId). 요청 유저가 저장한 링크여야 합니다.", example = "101") @PathVariable("linkuid") Long linkuId,
             @CurrentUser CustomUserDetails userDetails
     );
 

--- a/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/AiArticleController.java
@@ -21,16 +21,29 @@ public class AiArticleController implements AiArticleApi {
     final private AiArticleService aiArticleService;
 
     @Override
-    @PostMapping("/{linkuid}")
-    public ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> saveOrGetAiArticle(
+    @GetMapping("/{linkuid}")
+    public ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> getAiArticle(
             @PathVariable("linkuid") Long linkuId,
             @CurrentUser CustomUserDetails userDetails
     ) {
         Long userId = userDetails.getUserId();
 
         AiArticleResponseDTO.AiArticleResultDTO result =
-                aiArticleService.saveOrGetAiArticle(linkuId, userId);
+                aiArticleService.getAiArticle(linkuId, userId);
         return ApiResponse.onSuccess(AiArticleSuccessStatus.AI_ARTICLE_OK, result);
+    }
+
+    @Override
+    @PostMapping("/{linkuid}")
+    public ApiResponse<AiArticleResponseDTO.AiArticleResultDTO> createAiArticle(
+            @PathVariable("linkuid") Long linkuId,
+            @CurrentUser CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        AiArticleResponseDTO.AiArticleResultDTO result =
+                aiArticleService.createAiArticle(linkuId, userId);
+        return ApiResponse.onSuccess(AiArticleSuccessStatus.AI_ARTICLE_CREATE_ACCEPTED, result);
     }
 
     @Override

--- a/src/main/java/com/umc/linkyou/web/dto/AiArticleResponseDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/AiArticleResponseDTO.java
@@ -1,19 +1,27 @@
 package com.umc.linkyou.web.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class AiArticleResponseDTO {
     @Getter
     @Setter
     @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class AiArticleResultDTO {
         private Long id;
         private Long linkuId;
         private Long emotionId;
         private String emotionName;
         private String categoryName;
+        // PENDING/DONE/FAILED. PENDING이면 프론트는 계속 GET으로 폴링, FAILED면 멈추고 failReason으로 안내.
+        private String status;
+        // status=FAILED일 때만 채워지는 실패 사유 코드 (예: CRAWLER4031 - robots.txt 차단, 재시도해도 동일).
+        private String failReason;
         private String summary;
         private String imgUrl;
         private String memo;

--- a/src/main/resources/db/migration/V21__add_ai_article_status.sql
+++ b/src/main/resources/db/migration/V21__add_ai_article_status.sql
@@ -1,0 +1,28 @@
+-- ai_articles에 생성 상태(PENDING/DONE/FAILED) 컬럼을 추가한다.
+-- POST /aiarticle/{linkuid}가 크롤링+Gemini 호출을 동기로 처리하던 것을 비동기로 바꾸면서,
+-- "생성 중" 상태를 DB에 실제로 기록해야 GET /aiarticle/{linkuid}로 폴링(PENDING -> DONE/FAILED)이 가능해진다.
+
+-- summary는 PENDING 상태에서는 아직 비어있으므로 NOT NULL 제약을 푼다.
+ALTER TABLE ai_articles ALTER COLUMN summary DROP NOT NULL;
+
+ALTER TABLE ai_articles ADD COLUMN IF NOT EXISTS status varchar(20) NOT NULL DEFAULT 'PENDING';
+-- 실패 사유 코드(예: CRAWLER4031, GEMINI5041)를 저장해 프론트가 재시도 가능 여부를 판단할 수 있게 한다.
+ALTER TABLE ai_articles ADD COLUMN IF NOT EXISTS fail_reason varchar(50);
+
+-- 기존에 이미 summary가 채워져 있던 행은 전부 완료 상태로 백필한다.
+UPDATE ai_articles SET status = 'DONE' WHERE summary IS NOT NULL AND summary <> '';
+
+-- 새로 추가되는 행은 애플리케이션(엔티티)이 항상 명시적으로 status를 지정하므로 DB 기본값은 제거한다.
+ALTER TABLE ai_articles ALTER COLUMN status DROP DEFAULT;
+
+DO $$ BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'ai_articles_status_check') THEN
+        ALTER TABLE ai_articles
+            ADD CONSTRAINT ai_articles_status_check
+                CHECK (status = ANY (ARRAY [
+                    'PENDING',
+                    'DONE',
+                    'FAILED'
+                    ]::varchar[]));
+    END IF;
+END $$;

--- a/src/test/java/com/umc/linkyou/service/AiArticleGenerationWorkerTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleGenerationWorkerTest.java
@@ -1,0 +1,156 @@
+package com.umc.linkyou.service;
+
+import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
+import com.umc.linkyou.apiPayload.exception.GeneralException;
+import com.umc.linkyou.domain.AiArticle;
+import com.umc.linkyou.domain.AlarmPayload;
+import com.umc.linkyou.domain.Linku;
+import com.umc.linkyou.domain.Users;
+import com.umc.linkyou.domain.enums.AiArticleStatus;
+import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.mapping.UsersLinku;
+import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
+import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
+import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
+import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
+import com.umc.linkyou.service.alarm.AlarmService;
+import com.umc.linkyou.support.fixture.LinkuFixture;
+import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AiArticleGenerationWorker 테스트")
+class AiArticleGenerationWorkerTest {
+
+    @InjectMocks
+    private AiArticleGenerationWorker worker;
+
+    @Mock private AiArticleRepository aiArticleRepository;
+    @Mock private UsersLinkuRepository usersLinkuRepository;
+    @Mock private AiArticleAnalyzer aiArticleAnalyzer;
+    @Mock private AlarmService alarmService;
+
+    private static final Long ARTICLE_ID = 700L;
+    private static final Long LINKU_ID = 100L;
+    private static final Long USER_ID = 1L;
+    private static final String SUMMARY = "테스트 AI 요약 내용";
+
+    @Nested
+    @DisplayName("generateAsync()")
+    class GenerateAsync {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("분석에 성공하면 status가 DONE으로 바뀌고 aiExist 표시와 알림 발송이 이루어진다")
+            void 분석_성공시_DONE으로_바뀌고_aiExist_표시와_알림이_발송된다() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                AiArticle article = AiArticle.builder()
+                        .id(ARTICLE_ID)
+                        .linku(linku)
+                        .status(AiArticleStatus.PENDING)
+                        .build();
+                UsersLinku usersLinku = UsersLinku.builder()
+                        .userLinkuId(10L)
+                        .linku(linku)
+                        .user(user)
+                        .emotion(LinkuFixture.emotion())
+                        .emotionAi(true)
+                        .situationAi(true)
+                        .title("내가 지은 제목")
+                        .build();
+
+                given(aiArticleRepository.findById(ARTICLE_ID)).willReturn(Optional.of(article));
+                given(aiArticleAnalyzer.analyzeByUrl(linku.getLinkuUrl())).willReturn(new AiArticleResultDTO(SUMMARY));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
+
+                worker.generateAsync(ARTICLE_ID, USER_ID);
+
+                assertEquals(AiArticleStatus.DONE, article.getStatus());
+                assertEquals(SUMMARY, article.getSummary());
+                assertNull(article.getFailReason());
+                assertTrue(usersLinku.getAiExist());
+
+                verify(alarmService).sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
+                        AlarmType.LINK_SUMMARY_COMPLETE, LINKU_ID, new AlarmPayload.LinkTitle("내가 지은 제목")));
+            }
+
+            @Test
+            @DisplayName("AiArticle 레코드를 찾을 수 없으면 아무 것도 하지 않고 조용히 종료한다")
+            void AiArticle을_찾을_수_없으면_아무것도_하지_않는다() {
+                given(aiArticleRepository.findById(ARTICLE_ID)).willReturn(Optional.empty());
+
+                worker.generateAsync(ARTICLE_ID, USER_ID);
+
+                verify(aiArticleAnalyzer, never()).analyzeByUrl(any());
+                verify(alarmService, never()).sendAlarm(any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("robots.txt 차단 등 GeneralException이면 status가 FAILED로 바뀌고 실패 사유 코드가 남는다")
+            void GeneralException이면_FAILED로_바뀌고_실패사유가_남는다() {
+                Linku linku = LinkuFixture.linku(null);
+                AiArticle article = AiArticle.builder()
+                        .id(ARTICLE_ID)
+                        .linku(linku)
+                        .status(AiArticleStatus.PENDING)
+                        .build();
+
+                given(aiArticleRepository.findById(ARTICLE_ID)).willReturn(Optional.of(article));
+                given(aiArticleAnalyzer.analyzeByUrl(linku.getLinkuUrl()))
+                        .willThrow(new GeneralException(AiArticleErrorStatus._CONTENT_EXTRACTION_PROHIBITED));
+
+                worker.generateAsync(ARTICLE_ID, USER_ID);
+
+                assertEquals(AiArticleStatus.FAILED, article.getStatus());
+                assertEquals("CRAWLER4031", article.getFailReason());
+                assertNull(article.getSummary());
+                verify(alarmService, never()).sendAlarm(any(), any());
+            }
+
+            @Test
+            @DisplayName("예상치 못한 예외면 status가 FAILED로 바뀌고 실패 사유가 UNKNOWN으로 남는다")
+            void 알수없는_예외면_FAILED로_바뀌고_UNKNOWN이_남는다() {
+                Linku linku = LinkuFixture.linku(null);
+                AiArticle article = AiArticle.builder()
+                        .id(ARTICLE_ID)
+                        .linku(linku)
+                        .status(AiArticleStatus.PENDING)
+                        .build();
+
+                given(aiArticleRepository.findById(ARTICLE_ID)).willReturn(Optional.of(article));
+                given(aiArticleAnalyzer.analyzeByUrl(linku.getLinkuUrl()))
+                        .willThrow(new RuntimeException("네트워크 오류"));
+
+                worker.generateAsync(ARTICLE_ID, USER_ID);
+
+                assertEquals(AiArticleStatus.FAILED, article.getStatus());
+                assertEquals("UNKNOWN", article.getFailReason());
+                verify(alarmService, never()).sendAlarm(any(), any());
+            }
+        }
+    }
+}

--- a/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/AiArticleServiceTest.java
@@ -1,21 +1,21 @@
 package com.umc.linkyou.service;
 
+import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.AiArticle;
-import com.umc.linkyou.domain.AlarmPayload;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
-import com.umc.linkyou.domain.enums.AlarmType;
+import com.umc.linkyou.domain.enums.AiArticleStatus;
 import com.umc.linkyou.domain.mapping.UsersLinku;
-import com.umc.linkyou.infra.ai.AiArticleAnalyzer;
-import com.umc.linkyou.infra.ai.dto.AiArticleResultDTO;
 import com.umc.linkyou.repository.UserLinkuRepository.UsersLinkuRepository;
 import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
-import com.umc.linkyou.service.alarm.AlarmService;
 import com.umc.linkyou.support.fixture.LinkuFixture;
-import com.umc.linkyou.web.dto.alarm.AlarmRequestDTO;
+import com.umc.linkyou.web.dto.AiArticleResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -44,180 +44,76 @@ class AiArticleServiceTest {
     @Mock private LinkuRepository linkuRepository;
     @Mock private AiArticleRepository aiArticleRepository;
     @Mock private UsersLinkuRepository usersLinkuRepository;
-    @Mock private AiArticleAnalyzer aiArticleAnalyzer;
-    @Mock private AlarmService alarmService;
+    @Mock private AiArticleGenerationWorker aiArticleGenerationWorker;
 
     private static final Long LINKU_ID = 100L;
     private static final Long USER_ID = 1L;
     private static final String SUMMARY = "테스트 AI 요약 내용";
 
     @Nested
-    @DisplayName("saveAiArticle() - AI 요약 저장")
-    class SaveAiArticle {
+    @DisplayName("createAiArticle() - AI 요약 생성 요청")
+    class CreateAiArticle {
 
         @Nested
         @DisplayName("성공")
         class Success {
 
             @Test
-            @DisplayName("AiArticle이 없으면 새로 생성하고 usersLinku.aiExist가 true로 설정된다")
-            void AiArticle이_없으면_새로_생성하고_aiExist가_true이다() {
+            @DisplayName("AiArticle이 없으면 PENDING으로 새로 생성하고 비동기 워커를 호출한다")
+            void AiArticle이_없으면_PENDING으로_생성하고_워커를_호출한다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
                 UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
                 given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
+                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> {
+                    AiArticle saved = inv.getArgument(0);
+                    org.springframework.test.util.ReflectionTestUtils.setField(saved, "id", 500L);
+                    return saved;
+                });
 
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
+                AiArticleResponseDTO.AiArticleResultDTO result =
+                        aiArticleService.createAiArticle(LINKU_ID, USER_ID);
+
+                assertEquals("PENDING", result.getStatus());
+                assertNull(result.getSummary());
 
                 ArgumentCaptor<AiArticle> captor = ArgumentCaptor.forClass(AiArticle.class);
                 verify(aiArticleRepository).save(captor.capture());
-                assertEquals(SUMMARY, captor.getValue().getSummary());
-                assertTrue(usersLinku.getAiExist());
+                assertEquals(AiArticleStatus.PENDING, captor.getValue().getStatus());
+
+                verify(aiArticleGenerationWorker).generateAsync(500L, USER_ID);
             }
 
             @Test
-            @DisplayName("AiArticle이 이미 있으면 summary만 업데이트하고 save를 다시 호출하지 않는다")
-            void AiArticle이_있으면_summary_업데이트하고_save_재호출_안_한다() {
+            @DisplayName("이전 생성이 실패(FAILED)했던 링크는 재시도로 PENDING으로 되돌리고 워커를 다시 호출한다")
+            void FAILED_상태면_재시도로_PENDING으로_되돌리고_워커를_호출한다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
                 UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, "이전 요약");
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
+                AiArticle failedArticle = AiArticle.builder()
+                        .id(700L)
+                        .linku(linku)
+                        .status(AiArticleStatus.FAILED)
+                        .failReason("CRAWLER4031")
+                        .build();
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(failedArticle));
 
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
+                AiArticleResponseDTO.AiArticleResultDTO result =
+                        aiArticleService.createAiArticle(LINKU_ID, USER_ID);
 
-                assertEquals(SUMMARY, existingArticle.getSummary());
+                assertEquals(AiArticleStatus.PENDING, failedArticle.getStatus());
+                assertNull(failedArticle.getFailReason());
+                assertEquals("PENDING", result.getStatus());
                 verify(aiArticleRepository, never()).save(any());
-                assertTrue(usersLinku.getAiExist());
-            }
-
-            @Test
-            @DisplayName("AI 분석 결과가 저장될 때 summary 값이 반영된다")
-            void AI_분석_결과가_저장될때_summary_값이_반영된다() {
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
-
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
-
-                ArgumentCaptor<AiArticle> captor = ArgumentCaptor.forClass(AiArticle.class);
-                verify(aiArticleRepository).save(captor.capture());
-                assertEquals(SUMMARY, captor.getValue().getSummary());
-            }
-
-            @Test
-            @DisplayName("요약 완료 시 링크 요약 알림을 발송한다")
-            void 요약완료시_링크알림_발송() {
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku usersLinku = UsersLinku.builder()
-                        .userLinkuId(10L)
-                        .linku(linku)
-                        .user(user)
-                        .emotion(LinkuFixture.emotion())
-                        .emotionAi(true)
-                        .situationAi(true)
-                        .title("내가 지은 링크 제목")
-                        .build();
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
-
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
-
-                verify(alarmService).sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
-                        AlarmType.LINK_SUMMARY_COMPLETE, LINKU_ID,
-                        new AlarmPayload.LinkTitle("내가 지은 링크 제목")));
-            }
-
-            @Test
-            @DisplayName("사용자 지정 제목이 없으면 링크 원제목으로 알림을 발송한다")
-            void 제목없으면_링크원제목으로_알림발송() {
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku usersLinku = buildUsersLinku(linku, user); // title 미설정
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
-
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
-
-                verify(alarmService).sendAlarm(USER_ID, new AlarmRequestDTO.AlarmSendRequestDTO(
-                        AlarmType.LINK_SUMMARY_COMPLETE, LINKU_ID,
-                        new AlarmPayload.LinkTitle(linku.getTitle())));
-            }
-
-            @Test
-            @DisplayName("동일 (user, linku)로 저장된 UsersLinku가 여러 건이면 전부 aiExist가 true로 표시된다")
-            void UsersLinku가_여러건이면_전부_aiExist가_true로_표시된다() {
-                // 같은 링크를 두 번 저장한 상황(1번째 저장, 2번째 저장) - 요약은 linku 단위로 한 번만
-                // 생성되므로, 몇 번째 저장 건에 대해 요청했든 이 링크를 저장한 모든 건에 표시가 남아야 한다.
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku older = UsersLinku.builder()
-                        .userLinkuId(1L)
-                        .linku(linku)
-                        .user(user)
-                        .emotion(LinkuFixture.emotion())
-                        .emotionAi(true)
-                        .situationAi(true)
-                        .build();
-                org.springframework.test.util.ReflectionTestUtils.setField(
-                        older, "createdAt", java.time.LocalDateTime.now().minusDays(1));
-                UsersLinku newer = UsersLinku.builder()
-                        .userLinkuId(2L)
-                        .linku(linku)
-                        .user(user)
-                        .emotion(LinkuFixture.emotion())
-                        .emotionAi(true)
-                        .situationAi(true)
-                        .build();
-                org.springframework.test.util.ReflectionTestUtils.setField(
-                        newer, "createdAt", java.time.LocalDateTime.now());
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(older, newer));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
-
-                aiArticleService.saveAiArticle(LINKU_ID, USER_ID);
-
-                assertTrue(newer.getAiExist());
-                assertTrue(older.getAiExist());
+                verify(aiArticleGenerationWorker).generateAsync(700L, USER_ID);
             }
         }
 
@@ -230,8 +126,9 @@ class AiArticleServiceTest {
             void 존재하지_않는_linkuId이면_예외가_발생한다() {
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.empty());
 
-                assertThrows(GeneralException.class,
-                        () -> aiArticleService.saveAiArticle(LINKU_ID, USER_ID));
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.createAiArticle(LINKU_ID, USER_ID));
+                assertEquals(ErrorStatus._BAD_REQUEST, ex.getCode());
             }
 
             @Test
@@ -241,8 +138,9 @@ class AiArticleServiceTest {
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
-                assertThrows(GeneralException.class,
-                        () -> aiArticleService.saveAiArticle(LINKU_ID, USER_ID));
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.createAiArticle(LINKU_ID, USER_ID));
+                assertEquals(UserErrorStatus._USER_NOT_FOUND, ex.getCode());
             }
 
             @Test
@@ -255,162 +153,109 @@ class AiArticleServiceTest {
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of());
 
-                assertThrows(GeneralException.class,
-                        () -> aiArticleService.saveAiArticle(LINKU_ID, USER_ID));
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.createAiArticle(LINKU_ID, USER_ID));
+                assertEquals(LinkuErrorStatus._USER_LINKU_NOT_FOUND, ex.getCode());
             }
-        }
-    }
-
-    @Nested
-    @DisplayName("saveOrGetAiArticle() - AI 요약 요청/조회 분기")
-    class SaveOrGetAiArticle {
-
-        @Nested
-        @DisplayName("성공")
-        class Success {
 
             @Test
-            @DisplayName("AiArticle이 없으면 AI를 호출하여 새로 생성한다")
-            void AiArticle이_없으면_AI를_호출하여_새로_생성한다() {
+            @DisplayName("이미 생성 완료(DONE)된 링크면 409 예외가 발생하고 워커를 호출하지 않는다")
+            void 이미_DONE이면_예외가_발생하고_워커를_호출하지_않는다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
                 UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
+                AiArticle doneArticle = LinkuFixture.aiArticle(linku, SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-                given(aiArticleRepository.save(any(AiArticle.class))).willAnswer(inv -> inv.getArgument(0));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(doneArticle));
 
-                aiArticleService.saveOrGetAiArticle(LINKU_ID, USER_ID);
-
-                verify(aiArticleAnalyzer).analyzeByUrl(any());
-                verify(aiArticleRepository).save(any(AiArticle.class));
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.createAiArticle(LINKU_ID, USER_ID));
+                assertEquals(AiArticleErrorStatus._DUPLICATE_AI_ARTICLE, ex.getCode());
+                verify(aiArticleGenerationWorker, never()).generateAsync(any(), any());
             }
 
             @Test
-            @DisplayName("AiArticle의 summary가 blank이면 AI를 재호출하여 업데이트한다")
-            void AiArticle_summary가_blank이면_AI를_재호출하여_업데이트한다() {
+            @DisplayName("이미 생성 진행 중(PENDING)인 링크면 409 예외가 발생하고 워커를 호출하지 않는다")
+            void 이미_PENDING이면_예외가_발생하고_워커를_호출하지_않는다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
                 UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, "");
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
-
-                aiArticleService.saveOrGetAiArticle(LINKU_ID, USER_ID);
-
-                verify(aiArticleAnalyzer).analyzeByUrl(any());
-                assertEquals(SUMMARY, existingArticle.getSummary());
-            }
-
-            @Test
-            @DisplayName("AiArticle의 summary가 있으면 AI를 호출하지 않고 기존 데이터를 사용한다")
-            void AiArticle_summary가_있으면_AI_미호출하고_기존_데이터를_사용한다() {
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
-
-                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
-                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-
-                aiArticleService.saveOrGetAiArticle(LINKU_ID, USER_ID);
-
-                verify(aiArticleAnalyzer, never()).analyzeByUrl(any());
-                verify(aiArticleRepository, never()).save(any());
-                // 요약 생성을 직접 요청한 게 아니라 이미 있는 요약을 조회(showAiArticle)한 경우에도
-                // 본인이 실제로 확인한 것이므로 aiExist는 true로 표시되어야 한다.
-                assertTrue(usersLinku.getAiExist());
-            }
-
-            @Test
-            @DisplayName("AiArticle의 summary가 null이면 AI를 재호출하여 업데이트한다")
-            void AiArticle_summary가_null이면_AI를_재호출하여_업데이트한다() {
-                Linku linku = LinkuFixture.linku(null);
-                Users user = LinkuFixture.user();
-                UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticle articleWithNullSummary = AiArticle.builder()
-                        .id(1L)
+                AiArticle pendingArticle = AiArticle.builder()
+                        .id(800L)
                         .linku(linku)
-                        .summary(null)
+                        .status(AiArticleStatus.PENDING)
                         .build();
-                AiArticleResultDTO result = new AiArticleResultDTO(SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(articleWithNullSummary));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
-                given(aiArticleAnalyzer.analyzeByUrl(any())).willReturn(result);
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(pendingArticle));
 
-                aiArticleService.saveOrGetAiArticle(LINKU_ID, USER_ID);
-
-                verify(aiArticleAnalyzer).analyzeByUrl(any());
-                assertEquals(SUMMARY, articleWithNullSummary.getSummary());
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.createAiArticle(LINKU_ID, USER_ID));
+                assertEquals(AiArticleErrorStatus._AI_ARTICLE_GENERATING, ex.getCode());
+                verify(aiArticleGenerationWorker, never()).generateAsync(any(), any());
             }
         }
     }
 
     @Nested
-    @DisplayName("showAiArticle() - AI 요약 조회")
-    class ShowAiArticle {
+    @DisplayName("getAiArticle() - AI 요약 조회")
+    class GetAiArticle {
 
         @Nested
         @DisplayName("성공")
         class Success {
 
             @Test
-            @DisplayName("다른 유저가 먼저 만들어둔 요약이라도 본인이 조회하면 본인 소유 UsersLinku의 aiExist가 true로 표시된다")
-            void 다른_유저가_만든_요약이라도_본인이_조회하면_aiExist가_true로_표시된다() {
+            @DisplayName("status가 DONE이면 본인 소유 UsersLinku의 aiExist가 true로 표시된다")
+            void status가_DONE이면_aiExist가_true로_표시된다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
-                // 저장 시점에는 본인이 요청/조회한 적이 없어 aiExist=false였던 상태 (다른 유저가 먼저 요약함)
                 UsersLinku usersLinku = buildUsersLinku(linku, user);
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
+                AiArticle article = LinkuFixture.aiArticle(linku, SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(article));
 
                 assertFalse(usersLinku.getAiExist());
 
-                aiArticleService.showAiArticle(LINKU_ID, USER_ID);
+                AiArticleResponseDTO.AiArticleResultDTO result =
+                        aiArticleService.getAiArticle(LINKU_ID, USER_ID);
 
+                assertEquals("DONE", result.getStatus());
+                assertEquals(SUMMARY, result.getSummary());
                 assertTrue(usersLinku.getAiExist());
             }
 
             @Test
-            @DisplayName("동일 (user, linku)로 저장된 UsersLinku가 여러 건이면 조회 시 전부 aiExist가 true로 표시된다")
-            void 여러건이면_조회시_전부_aiExist가_true로_표시된다() {
+            @DisplayName("status가 PENDING이면 아직 aiExist를 표시하지 않는다")
+            void status가_PENDING이면_aiExist를_표시하지_않는다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
-                UsersLinku older = buildUsersLinku(linku, user);
-                org.springframework.test.util.ReflectionTestUtils.setField(
-                        older, "createdAt", java.time.LocalDateTime.now().minusDays(1));
-                UsersLinku newer = buildUsersLinku(linku, user);
-                org.springframework.test.util.ReflectionTestUtils.setField(
-                        newer, "createdAt", java.time.LocalDateTime.now());
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
+                UsersLinku usersLinku = buildUsersLinku(linku, user);
+                AiArticle article = AiArticle.builder()
+                        .id(900L)
+                        .linku(linku)
+                        .status(AiArticleStatus.PENDING)
+                        .build();
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
-                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(older, newer));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(article));
 
-                aiArticleService.showAiArticle(LINKU_ID, USER_ID);
+                AiArticleResponseDTO.AiArticleResultDTO result =
+                        aiArticleService.getAiArticle(LINKU_ID, USER_ID);
 
-                assertTrue(older.getAiExist());
-                assertTrue(newer.getAiExist());
+                assertEquals("PENDING", result.getStatus());
+                assertNull(result.getSummary());
+                assertFalse(usersLinku.getAiExist());
             }
         }
 
@@ -419,19 +264,35 @@ class AiArticleServiceTest {
         class Failure {
 
             @Test
+            @DisplayName("AiArticle 레코드가 없으면 예외가 발생한다")
+            void AiArticle이_없으면_예외가_발생한다() {
+                Linku linku = LinkuFixture.linku(null);
+                Users user = LinkuFixture.user();
+                UsersLinku usersLinku = buildUsersLinku(linku, user);
+
+                given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of(usersLinku));
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
+
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.getAiArticle(LINKU_ID, USER_ID));
+                assertEquals(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND, ex.getCode());
+            }
+
+            @Test
             @DisplayName("요청 유저가 이 linku를 저장한 적이 없으면 예외가 발생한다")
             void 소유권_없으면_예외가_발생한다() {
                 Linku linku = LinkuFixture.linku(null);
                 Users user = LinkuFixture.user();
-                AiArticle existingArticle = LinkuFixture.aiArticle(linku, SUMMARY);
 
                 given(linkuRepository.findById(LINKU_ID)).willReturn(Optional.of(linku));
-                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(existingArticle));
                 given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
                 given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, LINKU_ID)).willReturn(List.of());
 
-                assertThrows(GeneralException.class,
-                        () -> aiArticleService.showAiArticle(LINKU_ID, USER_ID));
+                GeneralException ex = assertThrows(GeneralException.class,
+                        () -> aiArticleService.getAiArticle(LINKU_ID, USER_ID));
+                assertEquals(LinkuErrorStatus._USER_LINKU_NOT_FOUND, ex.getCode());
             }
         }
     }

--- a/src/test/java/com/umc/linkyou/service/Linku/LinkuServiceTest.java
+++ b/src/test/java/com/umc/linkyou/service/Linku/LinkuServiceTest.java
@@ -1,11 +1,14 @@
 package com.umc.linkyou.service.Linku;
 
+import com.umc.linkyou.apiPayload.ApiResponse;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.category.CategoryErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.folder.FolderErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.awss3.AwsS3Service;
+import com.umc.linkyou.domain.AiArticle;
+import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.classification.Domain;
@@ -13,6 +16,7 @@ import com.umc.linkyou.domain.classification.Emotion;
 import com.umc.linkyou.domain.classification.Situation;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.domain.mapping.LinkuFolder;
+import com.umc.linkyou.domain.mapping.LinkuKeyword;
 import com.umc.linkyou.domain.mapping.UsersLinku;
 import com.umc.linkyou.repository.EmotionRepository;
 import com.umc.linkyou.repository.FolderRepository.FolderRepository;
@@ -71,6 +75,95 @@ class LinkuServiceTest {
 
     private static final Long NEW_EMOTION_ID = 3L;
     private static final Long NEW_SITUATION_ID = 3L;
+
+    @Nested
+    @DisplayName("detailGetLinku() - 링크 상세조회")
+    class DetailGetLinku {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("aiArticleExists가 true면 키워드와 요약이 함께 내려간다")
+            void aiArticleExists_true면_키워드와_요약이_함께_내려간다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                usersLinku.markAiExist(true);
+                Linku linku = usersLinku.getLinku();
+
+                Keyword keyword1 = Keyword.builder().id(1L).name("스프링").build();
+                Keyword keyword2 = Keyword.builder().id(2L).name("백엔드").build();
+                linku.getLinkuKeywords().add(
+                        LinkuKeyword.builder().id(1L).linku(linku).keyword(keyword1).build());
+                linku.getLinkuKeywords().add(
+                        LinkuKeyword.builder().id(2L).linku(linku).keyword(keyword2).build());
+
+                AiArticle aiArticle = LinkuFixture.aiArticle(linku, "이 글은 스프링 백엔드에 대한 요약입니다.");
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.empty());
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.of(aiArticle));
+
+                // when
+                ApiResponse<LinkuResponseDTO.LinkuResultDTO> response =
+                        linkuService.detailGetLinku(USER_ID, 100L);
+
+                // then
+                LinkuResponseDTO.LinkuResultDTO result = response.getResult();
+                assertTrue(result.getAiArticleExists());
+                assertEquals("스프링, 백엔드", result.getKeyword());
+                assertEquals("이 글은 스프링 백엔드에 대한 요약입니다.", result.getSummary());
+                verify(linkuViewService).recordView(usersLinku.getUserLinkuId(), linku.getLinkuId());
+            }
+
+            @Test
+            @DisplayName("aiArticleExists가 false면 키워드와 요약은 내려가지 않는다")
+            void aiArticleExists_false면_키워드와_요약은_내려가지_않는다() {
+                // given
+                UsersLinku usersLinku = createDefaultUsersLinku();
+                usersLinku.markAiExist(false);
+                Linku linku = usersLinku.getLinku();
+
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of(usersLinku));
+                given(linkuFolderRepository
+                        .findFirstByUsersLinku_UserLinkuIdOrderByLinkuFolderIdDesc(usersLinku.getUserLinkuId()))
+                        .willReturn(Optional.empty());
+                given(aiArticleRepository.findByLinku(linku)).willReturn(Optional.empty());
+
+                // when
+                ApiResponse<LinkuResponseDTO.LinkuResultDTO> response =
+                        linkuService.detailGetLinku(USER_ID, 100L);
+
+                // then
+                LinkuResponseDTO.LinkuResultDTO result = response.getResult();
+                assertFalse(result.getAiArticleExists());
+                assertNull(result.getKeyword());
+                assertNull(result.getSummary());
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("해당 사용자의 링크가 없으면 예외가 발생한다")
+            void 해당_사용자의_링크가_없으면_예외가_발생한다() {
+                // given
+                given(usersLinkuRepository.findByUser_IdAndLinku_LinkuId(USER_ID, 100L))
+                        .willReturn(List.of());
+
+                // when & then
+                assertThrows(GeneralException.class,
+                        () -> linkuService.detailGetLinku(USER_ID, 100L));
+            }
+        }
+    }
 
     @Nested
     @DisplayName("updateLinku() - 감정/상황 수정 및 AI 플래그")

--- a/src/test/java/com/umc/linkyou/support/fixture/LinkuFixture.java
+++ b/src/test/java/com/umc/linkyou/support/fixture/LinkuFixture.java
@@ -8,6 +8,7 @@ import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.classification.Domain;
 import com.umc.linkyou.domain.classification.Emotion;
 import com.umc.linkyou.domain.classification.Situation;
+import com.umc.linkyou.domain.enums.AiArticleStatus;
 import com.umc.linkyou.domain.enums.Role;
 import com.umc.linkyou.domain.folder.Folder;
 import com.umc.linkyou.web.dto.linku.LinkuQuickSearchResponseDTO;
@@ -105,11 +106,14 @@ public final class LinkuFixture {
                 .build();
     }
 
+    // summary가 이미 채워진, 생성 완료(DONE) 상태의 AiArticle. PENDING/FAILED가 필요하면 호출부에서
+    // AiArticle.builder()로 직접 만들거나 ReflectionTestUtils로 status를 덮어쓴다.
     public static AiArticle aiArticle(Linku linku, String summary) {
         return AiArticle.builder()
                 .id(1L)
                 .linku(linku)
                 .summary(summary)
+                .status(AiArticleStatus.DONE)
                 .build();
     }
 }

--- a/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
+++ b/src/test/java/com/umc/linkyou/web/controller/AiArticleControllerTest.java
@@ -3,6 +3,7 @@ package com.umc.linkyou.web.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.linkyou.apiPayload.code.status.CommonErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.ErrorStatus;
+import com.umc.linkyou.apiPayload.code.status.aiarticle.AiArticleErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.config.common.WebConfig;
 import com.umc.linkyou.jwt.AccessTokenBlackListManager;
@@ -12,6 +13,7 @@ import com.umc.linkyou.repository.aiArticleRepository.AiArticleRepository;
 import com.umc.linkyou.service.AiArticleService;
 import com.umc.linkyou.support.security.TestSecurityConfig;
 import com.umc.linkyou.support.security.WithCustomUser;
+import com.umc.linkyou.web.dto.AiArticleResponseDTO;
 import com.umc.linkyou.web.dto.linku.LinkuResponseDTO;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,6 +35,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,6 +63,162 @@ class AiArticleControllerTest {
     private AccessTokenBlackListManager accessTokenBlackListManager;
 
     private static final Long TEST_USER_ID = 1L;
+    private static final Long TEST_LINKU_ID = 101L;
+
+    @Nested
+    @DisplayName("GET /api/v1/aiarticle/{linkuid} - AI 요약 조회")
+    class GetAiArticle {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("생성이 완료된 링크를 조회하면 status=DONE과 summary를 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 생성완료된_링크_조회시_DONE과_summary를_반환한다() throws Exception {
+                AiArticleResponseDTO.AiArticleResultDTO response = AiArticleResponseDTO.AiArticleResultDTO.builder()
+                        .id(1L)
+                        .linkuId(TEST_LINKU_ID)
+                        .status("DONE")
+                        .summary("요약된 내용입니다.")
+                        .tags("스프링, 백엔드")
+                        .title("테스트 제목")
+                        .build();
+
+                given(aiArticleService.getAiArticle(TEST_LINKU_ID, TEST_USER_ID)).willReturn(response);
+
+                MvcResult result = mockMvc.perform(get("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andReturn();
+
+                AiArticleResponseDTO.AiArticleResultDTO body =
+                        readResult(result, objectMapper, AiArticleResponseDTO.AiArticleResultDTO.class);
+                assertThat(body.getStatus()).isEqualTo("DONE");
+                assertThat(body.getSummary()).isEqualTo("요약된 내용입니다.");
+            }
+
+            @Test
+            @DisplayName("생성이 진행 중인 링크를 조회하면 status=PENDING과 null summary를 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 생성중인_링크_조회시_PENDING과_null_summary를_반환한다() throws Exception {
+                AiArticleResponseDTO.AiArticleResultDTO response = AiArticleResponseDTO.AiArticleResultDTO.builder()
+                        .id(1L)
+                        .linkuId(TEST_LINKU_ID)
+                        .status("PENDING")
+                        .build();
+
+                given(aiArticleService.getAiArticle(TEST_LINKU_ID, TEST_USER_ID)).willReturn(response);
+
+                MvcResult result = mockMvc.perform(get("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andReturn();
+
+                AiArticleResponseDTO.AiArticleResultDTO body =
+                        readResult(result, objectMapper, AiArticleResponseDTO.AiArticleResultDTO.class);
+                assertThat(body.getStatus()).isEqualTo("PENDING");
+                assertThat(body.getSummary()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("아직 생성 요청조차 없었던 링크면 404를 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 레코드가_없으면_404를_반환한다() throws Exception {
+                given(aiArticleService.getAiArticle(TEST_LINKU_ID, TEST_USER_ID))
+                        .willThrow(new GeneralException(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND));
+
+                mockMvc.perform(get("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isNotFound())
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value(AiArticleErrorStatus._AI_ARTICLE_NOT_FOUND.getCode()));
+            }
+
+            @Test
+            @DisplayName("인증되지 않으면 401을 반환한다")
+            void 인증되지_않으면_401을_반환한다() throws Exception {
+                mockMvc.perform(get("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isUnauthorized());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/aiarticle/{linkuid} - AI 요약 생성 요청")
+    class CreateAiArticle {
+
+        @Nested
+        @DisplayName("성공")
+        class Success {
+
+            @Test
+            @DisplayName("생성 요청이 접수되면 status=PENDING을 즉시 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 생성_요청이_접수되면_PENDING을_즉시_반환한다() throws Exception {
+                AiArticleResponseDTO.AiArticleResultDTO response = AiArticleResponseDTO.AiArticleResultDTO.builder()
+                        .id(1L)
+                        .linkuId(TEST_LINKU_ID)
+                        .status("PENDING")
+                        .build();
+
+                given(aiArticleService.createAiArticle(TEST_LINKU_ID, TEST_USER_ID)).willReturn(response);
+
+                MvcResult result = mockMvc.perform(post("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isOk())
+                        .andExpect(jsonPath("$.isSuccess").value(true))
+                        .andReturn();
+
+                AiArticleResponseDTO.AiArticleResultDTO body =
+                        readResult(result, objectMapper, AiArticleResponseDTO.AiArticleResultDTO.class);
+                assertThat(body.getStatus()).isEqualTo("PENDING");
+                assertThat(body.getSummary()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("실패")
+        class Failure {
+
+            @Test
+            @DisplayName("이미 생성이 완료된 링크면 409를 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 이미_DONE이면_409를_반환한다() throws Exception {
+                given(aiArticleService.createAiArticle(TEST_LINKU_ID, TEST_USER_ID))
+                        .willThrow(new GeneralException(AiArticleErrorStatus._DUPLICATE_AI_ARTICLE));
+
+                mockMvc.perform(post("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isConflict())
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value(AiArticleErrorStatus._DUPLICATE_AI_ARTICLE.getCode()));
+            }
+
+            @Test
+            @DisplayName("이미 생성이 진행 중인 링크면 409를 반환한다")
+            @WithCustomUser(userId = 1L)
+            void 이미_PENDING이면_409를_반환한다() throws Exception {
+                given(aiArticleService.createAiArticle(TEST_LINKU_ID, TEST_USER_ID))
+                        .willThrow(new GeneralException(AiArticleErrorStatus._AI_ARTICLE_GENERATING));
+
+                mockMvc.perform(post("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isConflict())
+                        .andExpect(jsonPath("$.isSuccess").value(false))
+                        .andExpect(jsonPath("$.code").value(AiArticleErrorStatus._AI_ARTICLE_GENERATING.getCode()));
+            }
+
+            @Test
+            @DisplayName("인증되지 않으면 401을 반환한다")
+            void 인증되지_않으면_401을_반환한다() throws Exception {
+                mockMvc.perform(post("/api/v1/aiarticle/{linkuid}", TEST_LINKU_ID))
+                        .andExpect(status().isUnauthorized());
+            }
+        }
+    }
 
     @Nested
     @DisplayName("GET /api/v1/aiarticle - 카테고리별 AI 아티클 조회")


### PR DESCRIPTION
## 🔗 관련 이슈
> #429
---

## 📌 작업 내용
> ai article get post분리 및 폴링 구조 처리

### 1️⃣ Non-Functional Requirement
- restful하게 get, post분리

### 2️⃣ Functional Requirement

---

## 📎 참고 사항 (선택)
프론트와 협의후 pr 머지 바람



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 요약 생성을 비동기 방식으로 처리합니다.
  * 요약 조회와 생성 요청을 별도 API로 제공합니다.
  * 생성 상태를 진행 중, 완료, 실패로 구분해 표시합니다.
  * 실패한 요약은 재시도할 수 있습니다.
  * 생성 완료 및 실패 상태와 실패 사유를 응답에 포함합니다.

* **개선 사항**
  * 생성 중인 요약에 대한 중복 요청을 안내합니다.
  * AI 요약 생성 완료 시 관련 알림을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->