### PR TITLE
feat: #431 키워드로 링크 조회 api 구현

### DIFF
--- a/src/main/java/com/umc/linkyou/converter/CurationConverter.java
+++ b/src/main/java/com/umc/linkyou/converter/CurationConverter.java
@@ -5,6 +5,7 @@ import com.umc.linkyou.domain.CurationSectionInfo;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.classification.Category;
 import com.umc.linkyou.domain.classification.Domain;
+import com.umc.linkyou.domain.classification.Emotion;
 import com.umc.linkyou.domain.enums.CurationLinkuType;
 import com.umc.linkyou.domain.mapping.CurationLinku;
 import com.umc.linkyou.domain.mapping.UsersLinku;
@@ -23,6 +24,7 @@ public class CurationConverter {
         Linku linku = usersLinku != null ? usersLinku.getLinku() : null;
         Domain domain = linku != null ? linku.getDomain() : null;
         Category category = linku != null ? linku.getCategory() : null;
+        Emotion emotion = usersLinku != null ? usersLinku.getEmotion() : null;
         return RecommendedLinkResponse.builder()
                 .userLinkuId(usersLinku != null ? usersLinku.getUserLinkuId() : null)
                 .url(entity.getUrl())
@@ -30,7 +32,8 @@ public class CurationConverter {
                 .domain(domain != null ? domain.getName() : null)
                 .domainImageUrl(domain != null ? domain.getImageUrl() : null)
                 .imageUrl(entity.getImageUrl())
-                .categories(category != null ? List.of(category.getCategoryName()) : null)
+                // 카테고리 + 감정 태그 (링크의 카테고리, 저장 시 남긴 감정)
+                .categories(category != null ? List.of(category.getCategoryName(), emotion.getName()) : null)
                 .type(CurationLinkuType.INTERNAL)
                 .build();
     }

--- a/src/main/java/com/umc/linkyou/repository/linkuRepository/LinkuRepositoryCustom.java
+++ b/src/main/java/com/umc/linkyou/repository/linkuRepository/LinkuRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.umc.linkyou.repository.linkuRepository;
 
 import com.umc.linkyou.domain.Linku;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 import com.umc.linkyou.web.dto.linku.LinkuQuickSearchResponseDTO;
 import com.umc.linkyou.web.dto.linku.LinkuSearchResponseDTO;
 
@@ -11,6 +12,6 @@ public interface LinkuRepositoryCustom {
     List<LinkuSearchResponseDTO.LinkuSearchItemDTO> searchUserLinks(Long userId, String keyword, Long cursor, int size);
     List<LinkuQuickSearchResponseDTO> findQuickByKeyword(Long userId, String keyword);
     Optional<Linku> findByLinku(String normalizedLink);
-
+    List<KeywordLinkuItemDTO> findUserLinksByExactKeyword(Long userId, String keyword);
 
 }

--- a/src/main/java/com/umc/linkyou/repository/linkuRepository/LinkuRepositoryImpl.java
+++ b/src/main/java/com/umc/linkyou/repository/linkuRepository/LinkuRepositoryImpl.java
@@ -8,9 +8,12 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.QKeyword;
 import com.umc.linkyou.domain.QLinku;
+import com.umc.linkyou.domain.classification.QCategory;
 import com.umc.linkyou.domain.classification.QDomain;
+import com.umc.linkyou.domain.classification.QEmotion;
 import com.umc.linkyou.domain.mapping.QLinkuKeyword;
 import com.umc.linkyou.domain.mapping.QUsersLinku;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 import com.umc.linkyou.web.dto.linku.LinkuQuickSearchResponseDTO;
 import com.umc.linkyou.web.dto.linku.LinkuSearchResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -90,6 +93,51 @@ public class LinkuRepositoryImpl implements LinkuRepositoryCustom {
                         tagsByLinkuId.getOrDefault(r.get(l.linkuId), List.of()),
                         r.get(d.imageUrl),
                         r.get(d.name)
+                ))
+                .toList();
+    }
+
+    @Override
+    public List<KeywordLinkuItemDTO> findUserLinksByExactKeyword(Long userId, String keyword) {
+        QUsersLinku ul = QUsersLinku.usersLinku;
+        QLinku l = QLinku.linku;
+        QDomain d = QDomain.domain;
+        QCategory c = QCategory.category;
+        QEmotion e = QEmotion.emotion;
+        QLinkuKeyword lk = QLinkuKeyword.linkuKeyword;
+
+        StringExpression displayTitle = ul.title.coalesce(l.title);
+        StringExpression displayImage = ul.imageUrl.coalesce(l.imgUrl);
+
+        BooleanExpression keywordMatches = JPAExpressions
+                .selectOne()
+                .from(lk)
+                .where(lk.linku.eq(l), lk.keyword.name.eq(keyword))
+                .exists();
+
+        List<Tuple> rows = queryFactory
+                .select(ul.userLinkuId, l.linkuUrl, displayTitle, displayImage, d.name, d.imageUrl, c.categoryName, e.name)
+                .from(ul)
+                .join(ul.linku, l)
+                .leftJoin(l.domain, d)
+                .join(l.category, c)
+                .join(ul.emotion, e)
+                .where(
+                        ul.user.id.eq(userId),
+                        keywordMatches
+                )
+                .orderBy(ul.userLinkuId.desc())
+                .fetch();
+
+        return rows.stream()
+                .map(r -> new KeywordLinkuItemDTO(
+                        r.get(ul.userLinkuId),
+                        r.get(displayTitle),
+                        r.get(l.linkuUrl),
+                        r.get(displayImage),
+                        r.get(d.name),
+                        r.get(d.imageUrl),
+                        List.of(r.get(c.categoryName), r.get(e.name))
                 ))
                 .toList();
     }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordService.java
@@ -2,6 +2,7 @@ package com.umc.linkyou.service.keyword;
 
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 
 import java.time.YearMonth;
 import java.util.List;
@@ -10,4 +11,6 @@ public interface KeywordService {
     void saveKeywords(Linku linku, String rawKeywords);
 
     List<JobKeywordRankResponse> getJobTopKeywords(Long userId, YearMonth month, int limit);
+
+    List<KeywordLinkuItemDTO> getLinkusByKeyword(Long userId, String keyword);
 }

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class KeywordServiceImpl implements KeywordService {
 
     private final LinkuKeywordRepository linkuKeywordRepository;
@@ -52,7 +53,6 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<JobKeywordRankResponse> getJobTopKeywords(Long userId, YearMonth month, int limit) {
         Users user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
@@ -75,7 +75,6 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Override
-    @Transactional(readOnly = true)
     public List<KeywordLinkuItemDTO> getLinkusByKeyword(Long userId, String keyword) {
         keywordRepository.findByName(keyword)
                 .orElseThrow(() -> new GeneralException(LinkuErrorStatus._KEYWORD_NOT_FOUND));

--- a/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/keyword/KeywordServiceImpl.java
@@ -1,14 +1,18 @@
 package com.umc.linkyou.service.keyword;
 
+import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.apiPayload.exception.GeneralException;
 import com.umc.linkyou.domain.Keyword;
 import com.umc.linkyou.domain.Linku;
 import com.umc.linkyou.domain.Users;
 import com.umc.linkyou.domain.mapping.LinkuKeyword;
+import com.umc.linkyou.repository.keywordRepository.KeywordRepository;
+import com.umc.linkyou.repository.linkuRepository.LinkuRepository;
 import com.umc.linkyou.repository.mapping.LinkuKeywordRepository;
 import com.umc.linkyou.repository.userRepository.UserRepository;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -25,6 +29,8 @@ public class KeywordServiceImpl implements KeywordService {
     private final LinkuKeywordRepository linkuKeywordRepository;
     private final KeywordUpsertService keywordUpsertService;
     private final UserRepository userRepository;
+    private final KeywordRepository keywordRepository;
+    private final LinkuRepository linkuRepository;
 
     @Override
     @Transactional
@@ -66,5 +72,14 @@ public class KeywordServiceImpl implements KeywordService {
                         .count(row.count())
                         .build())
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<KeywordLinkuItemDTO> getLinkusByKeyword(Long userId, String keyword) {
+        keywordRepository.findByName(keyword)
+                .orElseThrow(() -> new GeneralException(LinkuErrorStatus._KEYWORD_NOT_FOUND));
+
+        return linkuRepository.findUserLinksByExactKeyword(userId, keyword);
     }
 }

--- a/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
@@ -31,7 +31,7 @@ public interface KeywordApi {
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit
     );
 
-    @Operation(summary = "키워드로 내 링크 목록 조회", description = "직업별 키워드 랭킹에서 선택한 키워드가 정확히 일치하는, 내가 저장한 링크 전체를 최신 저장순으로 조회합니다.")
+    @Operation(summary = "키워드로 내 링크 목록 조회", description = "선택한 키워드와 일치하는, 내가 저장한 링크 전체를 최신 저장순으로 조회합니다.")
     @ApiErrorCode(linkuErrorStatus = {LinkuErrorStatus._KEYWORD_NOT_FOUND})
     @GetMapping("/{keyword}/linkus")
     ResponseEntity<ApiResponse<List<KeywordLinkuItemDTO>>> getLinkusByKeyword(

--- a/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/KeywordApi.java
@@ -1,11 +1,13 @@
 package com.umc.linkyou.web.api;
 
 import com.umc.linkyou.apiPayload.ApiResponse;
+import com.umc.linkyou.apiPayload.code.status.linku.LinkuErrorStatus;
 import com.umc.linkyou.apiPayload.code.status.user.UserErrorStatus;
 import com.umc.linkyou.jwt.CurrentUser;
 import com.umc.linkyou.jwt.CustomUserDetails;
 import com.umc.linkyou.validation.annotation.swagger.ApiErrorCode;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
@@ -27,5 +29,13 @@ public interface KeywordApi {
             @CurrentUser CustomUserDetails userDetails,
             @RequestParam YearMonth month,
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit
+    );
+
+    @Operation(summary = "키워드로 내 링크 목록 조회", description = "직업별 키워드 랭킹에서 선택한 키워드가 정확히 일치하는, 내가 저장한 링크 전체를 최신 저장순으로 조회합니다.")
+    @ApiErrorCode(linkuErrorStatus = {LinkuErrorStatus._KEYWORD_NOT_FOUND})
+    @GetMapping("/{keyword}/linkus")
+    ResponseEntity<ApiResponse<List<KeywordLinkuItemDTO>>> getLinkusByKeyword(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable String keyword
     );
 }

--- a/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/KeywordController.java
@@ -7,6 +7,7 @@ import com.umc.linkyou.service.keyword.KeywordService;
 import com.umc.linkyou.validation.annotation.ApiV1;
 import com.umc.linkyou.web.api.KeywordApi;
 import com.umc.linkyou.web.dto.keyword.JobKeywordRankResponse;
+import com.umc.linkyou.web.dto.keyword.KeywordLinkuItemDTO;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
@@ -30,5 +31,12 @@ public class KeywordController implements KeywordApi {
             @RequestParam YearMonth month,
             @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit) {
         return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getJobTopKeywords(userDetails.getUserId(), month, limit)));
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse<List<KeywordLinkuItemDTO>>> getLinkusByKeyword(
+            @CurrentUser CustomUserDetails userDetails,
+            @PathVariable String keyword) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(keywordService.getLinkusByKeyword(userDetails.getUserId(), keyword)));
     }
 }

--- a/src/main/java/com/umc/linkyou/web/dto/curation/RecommendedLinkResponse.java
+++ b/src/main/java/com/umc/linkyou/web/dto/curation/RecommendedLinkResponse.java
@@ -34,7 +34,7 @@ public class RecommendedLinkResponse {
     @Schema(description = "도메인 아이콘 이미지 URL", example = "https://cdn.example.com/domains/example.png")
     private String domainImageUrl;
 
-    @Schema(description = "카테고리 목록 (내부 추천만 포함, 외부 추천이면 null)", example = "[\"라이프스타일\"]")
+    @Schema(description = "카테고리 + 감정 태그 (내부 추천만 포함, 외부 추천이면 null)", example = "[\"라이프스타일\", \"평온\"]")
     private List<String> categories;
 
     @Schema(description = "추천 종류 (INTERNAL: 내가 저장한 링크 기반, EXTERNAL: AI 웹 검색 기반)", example = "INTERNAL")

--- a/src/main/java/com/umc/linkyou/web/dto/keyword/KeywordLinkuItemDTO.java
+++ b/src/main/java/com/umc/linkyou/web/dto/keyword/KeywordLinkuItemDTO.java
@@ -1,0 +1,23 @@
+package com.umc.linkyou.web.dto.keyword;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+// 키워드로 필터링한 내 링크 카드 1건
+public record KeywordLinkuItemDTO(
+        @Schema(description = "사용자링크 ID (커서로 사용)")
+        Long userLinkuId,
+        @Schema(description = "표시 제목")
+        String title,
+        @Schema(description = "링크 URL")
+        String url,
+        @Schema(description = "링크 대표 이미지 URL")
+        String imageUrl,
+        @Schema(description = "도메인 이름", example = "example.com")
+        String domain,
+        @Schema(description = "도메인 아이콘 이미지 URL")
+        String domainImageUrl,
+        @Schema(description = "카테고리 + 감정 태그 (링크의 카테고리, 저장 시 남긴 감정)", example = "[\"라이프스타일\", \"평온\"]")
+        List<String> categories
+) {}


### PR DESCRIPTION
## 🔗 관련 이슈
#431

---

## 📌 작업 내용
키워드로 해당하는 키워드가 달린 링크 목록을 조회하는 api 입니다.

---

## 📸 스크린샷 (선택)
<img width="961" height="600" alt="image" src="https://github.com/user-attachments/assets/be80838d-da53-4d67-b88c-60445b27333b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 키워드별로 사용자의 링크를 조회할 수 있는 기능을 추가했습니다.
  * 링크 제목, URL, 이미지, 도메인, 카테고리 및 감정 태그 정보를 함께 제공합니다.
  * 추천 링크의 카테고리 정보에 감정 태그가 포함됩니다.
* **개선**
  * 존재하지 않는 키워드 조회 시 명확한 오류를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->