### PR TITLE
fix: #345 node-exporter 포트 노출 추가

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,8 @@ services:
     container_name: linku-node-exporter
     restart: unless-stopped
     pid: host
+    ports:
+      - "9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -66,6 +66,8 @@ services:
     container_name: linku-node-exporter
     restart: unless-stopped
     pid: host
+    ports:
+      - "9100:9100"
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro


### PR DESCRIPTION
## 🔗 관련 이슈
#345

---

## 📌 작업 내용
9100 포트를 모니터링 서버에게 열었습니다.
보안 그룹에서 모니터링 서버만 접속 가능하도록 하고 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 호스트에서 시스템 모니터링 지표에 접근할 수 있도록 Node Exporter 포트(9100)를 외부에 노출했습니다.
  * 운영 및 원격 환경에서 동일한 모니터링 포트 설정을 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->