### PR TITLE
Feat: #441 큐레이션 basemonth를 N으로 통일

### DIFF
--- a/src/main/java/com/umc/linkyou/apiPayload/code/status/linku/LinkuErrorStatus.java
+++ b/src/main/java/com/umc/linkyou/apiPayload/code/status/linku/LinkuErrorStatus.java
@@ -20,7 +20,8 @@ public enum LinkuErrorStatus implements BaseErrorCode {
     _KEYWORD_NOT_FOUND(HttpStatus.NOT_FOUND, "LINKU4042", "해당 키워드를 찾을 수 없습니다."),
     _SITUATION_NOT_MATCH_JOB(HttpStatus.BAD_REQUEST, "LINKU4004", "선택한 상황이 사용자의 직업과 맞지 않습니다."),
     _LINKU_CONFLICT(HttpStatus.CONFLICT, "LINKU4091", "링크 저장 중 충돌이 발생했습니다."),
-    _SEARCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "LINKU4043", "검색 기록이 존재하지 않습니다.");
+    _SEARCH_HISTORY_NOT_FOUND(HttpStatus.NOT_FOUND, "LINKU4043", "검색 기록이 존재하지 않습니다."),
+    _LINKU_INVALID_MONTH(HttpStatus.BAD_REQUEST, "LINKU4006", "month는 YYYY-MM 형식이어야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/linkyou/batch/curation/CurationAlarmItemReader.java
+++ b/src/main/java/com/umc/linkyou/batch/curation/CurationAlarmItemReader.java
@@ -18,7 +18,7 @@ import java.util.List;
 /**
  * 큐레이션 알림 발송 배치 reader
  *
- * <p>지난달 생성된 큐레이션 중, CURATION_UPDATED 알림이 아직 발송되지 않은 건만 조회
+ * <p>이번 달(이슈 월 N)에 생성된 큐레이션 중, CURATION_UPDATED 알림이 아직 발송되지 않은 건만 조회
  * 발송 여부는 Alarm 테이블에 (alarmType, targetId=curationId) 조합이 존재하는지로 판단하므로,
  * 이전 실행에서 알림 발송에 실패한 유저도 다음 실행에서 다시 조회 대상이 됨
  */
@@ -35,7 +35,7 @@ public class CurationAlarmItemReader extends QuerydslPagingItemReader<CurationAl
         QUsers users = QUsers.users;
         QAlarm alarm = QAlarm.alarm;
         QAlarmSetting alarmSetting = QAlarmSetting.alarmSetting;
-        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(1).toString();
+        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
 
         return queryFactory
                 .select(Projections.constructor(

--- a/src/main/java/com/umc/linkyou/batch/curation/CurationItemReader.java
+++ b/src/main/java/com/umc/linkyou/batch/curation/CurationItemReader.java
@@ -23,7 +23,7 @@ public class CurationItemReader extends QuerydslPagingItemReader<Users> {
     protected List<Users> fetchQuery(Long lastId, int pageSize) {
         QUsers users = QUsers.users;
         QCuration curation = QCuration.curation;
-        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(1).toString();
+        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
 
         return queryFactory.selectFrom(users)
                 .where(

--- a/src/main/java/com/umc/linkyou/batch/scheduler/BatchScheduler.java
+++ b/src/main/java/com/umc/linkyou/batch/scheduler/BatchScheduler.java
@@ -58,8 +58,8 @@ public class BatchScheduler {
         jobLauncher.run(deleteExpiredFcmTokenJob, buildJobParameters());
     }
 
-    // 매월 1일 새벽 0시 59분 - 큐레이션 생성
-    @Scheduled(cron = "0 59 0 1 * *", zone = "Asia/Seoul")
+    // 매월 1일 새벽 0시 5분 - 큐레이션 생성
+    @Scheduled(cron = "0 5 0 1 * *", zone = "Asia/Seoul")
     public void runGenerateMonthlyCurationJob() throws Exception {
         log.info("배치 실행 시작: 월간 큐레이션 생성");
         jobLauncher.run(generateMonthlyCurationJob, buildJobParameters());

--- a/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
+++ b/src/main/java/com/umc/linkyou/service/Linku/LinkuService.java
@@ -40,6 +40,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -168,12 +170,22 @@ public class LinkuService {
     }
 
     //저번 달 저장만 하고 열어보지 않은 링크 가져오기  /linku/last-month/unread
+    //month(YYYY-MM) 기준 저번 달을 계산한다. 
     @Transactional(readOnly = true)
-    public List<LinkuResponseDTO.LinkuSimpleDTO> getLastMonthUnreadLinkus(Long userId) {
+    public List<LinkuResponseDTO.LinkuSimpleDTO> getLastMonthUnreadLinkus(Long userId, String month) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(UserErrorStatus._USER_NOT_FOUND));
 
-        YearMonth lastMonth = YearMonth.now().minusMonths(1);
+        YearMonth baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul"));
+        if (month != null) {
+            try {
+                baseMonth = YearMonth.parse(month);
+            } catch (DateTimeParseException e) {
+                throw new GeneralException(LinkuErrorStatus._LINKU_INVALID_MONTH);
+            }
+        }
+
+        YearMonth lastMonth = baseMonth.minusMonths(1);
         LocalDateTime start = lastMonth.atDay(1).atStartOfDay();
         LocalDateTime end = lastMonth.plusMonths(1).atDay(1).atStartOfDay();
 

--- a/src/main/java/com/umc/linkyou/service/curation/CurationBatchService.java
+++ b/src/main/java/com/umc/linkyou/service/curation/CurationBatchService.java
@@ -35,7 +35,7 @@ public class CurationBatchService {
     private final ExternalRecommendMaterializer externalRecommendMaterializer;
 
     public Optional<MonthlyCurationBatchItem> toBatchItem(Users user) {
-        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(1).toString();
+        String baseMonth = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
         return Optional.of(new MonthlyCurationBatchItem(user, baseMonth));
     }
 

--- a/src/main/java/com/umc/linkyou/service/curation/ment/CurationMentWorker.java
+++ b/src/main/java/com/umc/linkyou/service/curation/ment/CurationMentWorker.java
@@ -19,6 +19,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
@@ -42,11 +43,12 @@ public class CurationMentWorker {
         Users user = curation.getUser();
         Long userId = user.getId();
         String nickname = user.getNickName();
-        String baseMonth = curation.getBaseMonth();
+        // curation.baseMonth는 이슈 월(N). 데이터 집계 기간은 N-1월이다.
+        String dataBaseMonth = YearMonth.parse(curation.getBaseMonth()).minusMonths(1).toString();
 
         // 상위 1개 감정 조회
         Optional<KeywordMonthlyCount> topEmotionCount = keywordMonthlyCountRepository
-                .findTopByUserIdAndBaseMonthAndType(userId, baseMonth, KeywordType.EMOTION, PageRequest.of(0, 1))
+                .findTopByUserIdAndBaseMonthAndType(userId, dataBaseMonth, KeywordType.EMOTION, PageRequest.of(0, 1))
                 .stream().findFirst();
 
         String emotionName;

--- a/src/main/java/com/umc/linkyou/service/curation/recommend/external/ExternalRecommendWorker.java
+++ b/src/main/java/com/umc/linkyou/service/curation/recommend/external/ExternalRecommendWorker.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.YearMonth;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,7 +61,10 @@ public class ExternalRecommendWorker {
         Users user = curation.getUser();
         Long userId = user.getId();
 
-        List<String> topTags = keywordMonthlyCountRepository.findTopByUserIdAndBaseMonth(userId, curation.getBaseMonth(), PageRequest.of(0, 3))
+        // curation.baseMonth는 이슈 월(N). 데이터 집계 기간은 N-1월이다.
+        String dataBaseMonth = YearMonth.parse(curation.getBaseMonth()).minusMonths(1).toString();
+
+        List<String> topTags = keywordMonthlyCountRepository.findTopByUserIdAndBaseMonth(userId, dataBaseMonth, PageRequest.of(0, 3))
                 .stream()
                 .map(kmc -> kmc.getType() == KeywordType.EMOTION
                         ? emotionMapper.getEmotionName(kmc.getRefId())

--- a/src/main/java/com/umc/linkyou/service/curation/recommend/internal/InternalLinkCandidateServiceImpl.java
+++ b/src/main/java/com/umc/linkyou/service/curation/recommend/internal/InternalLinkCandidateServiceImpl.java
@@ -37,29 +37,30 @@ public class InternalLinkCandidateServiceImpl implements InternalLinkCandidateSe
         Curation curation = curationRepository.findById(curationId)
                 .orElseThrow(() -> new GeneralException(CurationErrorStatus._CURATION_NOT_FOUND));
 
-        String baseMonth = curation.getBaseMonth();
+        // curation.baseMonth는 큐레이션이 해당하는 "이슈 월"(N). 실제 데이터 집계 기간은 N-1월이다.
+        YearMonth issueMonth = YearMonth.parse(curation.getBaseMonth());
+        YearMonth dataMonth = issueMonth.minusMonths(1);
+        String dataBaseMonth = dataMonth.toString();
 
-        // 큐레이션 생성 월 계산
-        YearMonth ym = YearMonth.parse(baseMonth);
-        LocalDateTime monthStart = ym.atDay(1).atStartOfDay();
-        LocalDateTime monthEnd   = ym.plusMonths(1).atDay(1).atStartOfDay();
+        LocalDateTime monthStart = dataMonth.atDay(1).atStartOfDay();
+        LocalDateTime monthEnd   = dataMonth.plusMonths(1).atDay(1).atStartOfDay();
 
-        // 유저가 해당 월에 저장한 링크 조회 (없으면 빈 리스트 반환)
+        // 유저가 해당 월(N-1)에 저장한 링크 조회 (없으면 빈 리스트 반환)
         List<UsersLinku> candidates = usersLinkuRepository
                 .findAllByUserIdAndCreatedAtBetween(userId, monthStart, monthEnd);
         if (candidates.isEmpty()) {
             return List.of();
         }
 
-        // 해당 월 상위 감정 ID 조회
+        // 해당 월(N-1) 상위 감정 ID 조회
         Optional<Long> topEmotionId = keywordMonthlyCountRepository
-                .findTopByUserIdAndBaseMonthAndType(userId, baseMonth, KeywordType.EMOTION, PageRequest.of(0, 1))
+                .findTopByUserIdAndBaseMonthAndType(userId, dataBaseMonth, KeywordType.EMOTION, PageRequest.of(0, 1))
                 .stream().findFirst()
                 .map(KeywordMonthlyCount::getRefId);
 
-        // 해당 월 상위 상황 -> 추천 카테고리 ID 목록 조회
+        // 해당 월(N-1) 상위 상황 -> 추천 카테고리 ID 목록 조회
         Optional<KeywordMonthlyCount> topSituation = keywordMonthlyCountRepository
-                .findTopByUserIdAndBaseMonthAndType(userId, baseMonth, KeywordType.SITUATION, PageRequest.of(0, 1))
+                .findTopByUserIdAndBaseMonthAndType(userId, dataBaseMonth, KeywordType.SITUATION, PageRequest.of(0, 1))
                 .stream().findFirst();
 
         Set<Long> mappedCategoryIds = topSituation.isPresent()

--- a/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
+++ b/src/main/java/com/umc/linkyou/web/api/LinkuApi.java
@@ -82,11 +82,12 @@ public interface LinkuApi {
             @RequestParam(defaultValue = "10") int limit
     );
 
-    @Operation(summary = "저번 달 미열람 링크 조회", description = "저번 달에 저장만 하고 한 번도 열어보지 않은 링크 목록을 조회합니다.")
-    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND})
+    @Operation(summary = "저번 달 미열람 링크 조회", description = "month(YYYY-MM) 기준 저번 달에 저장만 하고 한 번도 열어보지 않은 링크 목록을 조회합니다. month를 생략하면 이번 달이 month가 됩니다.")
+    @ApiErrorCode(userErrorStatus = {UserErrorStatus._USER_NOT_FOUND}, linkuErrorStatus = {LinkuErrorStatus._LINKU_INVALID_MONTH})
     @GetMapping("/unread")
     ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getLastMonthUnreadLinkus(
-            @CurrentUser CustomUserDetails userDetails
+            @CurrentUser CustomUserDetails userDetails,
+            @RequestParam(required = false) String month
     );
 
     @Operation(

--- a/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
+++ b/src/main/java/com/umc/linkyou/web/controller/LinkuController.java
@@ -60,8 +60,8 @@ public class LinkuController implements LinkuApi {
     }
 
     @Override
-    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getLastMonthUnreadLinkus(@CurrentUser CustomUserDetails userDetails) {
-        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_LAST_MONTH_UNREAD_OK, linkuService.getLastMonthUnreadLinkus(userDetails.getUserId()));
+    public ApiResponse<List<LinkuResponseDTO.LinkuSimpleDTO>> getLastMonthUnreadLinkus(@CurrentUser CustomUserDetails userDetails, @RequestParam(required = false) String month) {
+        return ApiResponse.onSuccess(LinkuSuccessStatus.LINKU_LAST_MONTH_UNREAD_OK, linkuService.getLastMonthUnreadLinkus(userDetails.getUserId(), month));
     }
 
     @Override

--- a/src/test/java/com/umc/linkyou/batch/SendCurationAlarmBatchIntegrationTest.java
+++ b/src/test/java/com/umc/linkyou/batch/SendCurationAlarmBatchIntegrationTest.java
@@ -50,10 +50,10 @@ import static org.mockito.Mockito.verify;
 @DisplayName("sendCurationAlarmStep 통합 테스트")
 class SendCurationAlarmBatchIntegrationTest {
 
-    // reader(CurationAlarmItemReader)가 Asia/Seoul 기준으로 baseMonth를 계산하므로 테스트도 맞춰야 한다.
-    // JVM 기본 타임존(YearMonth.now())을 쓰면 UTC로 도는 CI에서 매월 1일 UTC 기준 전날 하루 동안
-    // Seoul과 다른 달을 계산해 리더가 대상을 못 찾는 문제가 있었다.
-    private static final String BASE_MONTH = YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(1).toString();
+    // reader(CurationAlarmItemReader)가 Asia/Seoul 기준으로 baseMonth(이슈 월 N, 이번 달)를 계산하므로
+    // 테스트도 맞춰야 한다. JVM 기본 타임존(YearMonth.now())을 쓰면 UTC로 도는 CI에서 매월 1일 UTC 기준
+    // 전날 하루 동안 Seoul과 다른 달을 계산해 리더가 대상을 못 찾는 문제가 있었다.
+    private static final String BASE_MONTH = YearMonth.now(ZoneId.of("Asia/Seoul")).toString();
 
     @Autowired private JobLauncher jobLauncher;
     @Autowired private JobRepository jobRepository;
@@ -173,11 +173,11 @@ class SendCurationAlarmBatchIntegrationTest {
         }
 
         @Test
-        @DisplayName("지난달이 아닌 큐레이션은 대상이 되지 않는다")
-        void 지난달_아닌_큐레이션_제외() throws Exception {
+        @DisplayName("이번달이 아닌 큐레이션은 대상이 되지 않는다")
+        void 이번달_아닌_큐레이션_제외() throws Exception {
             // given
             Users user = saveUserWithSetting("유저디", true);
-            saveCuration(user, YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(2).toString());
+            saveCuration(user, YearMonth.now(ZoneId.of("Asia/Seoul")).minusMonths(1).toString());
 
             // when
             JobExecution execution = jobLauncherTestUtils.launchStep("sendCurationAlarmStep", uniqueJobParameters());

--- a/src/test/java/com/umc/linkyou/service/curation/recommend/internal/InternalLinkCandidateServiceImplTest.java
+++ b/src/test/java/com/umc/linkyou/service/curation/recommend/internal/InternalLinkCandidateServiceImplTest.java
@@ -42,7 +42,8 @@ class InternalLinkCandidateServiceImplTest {
 
     private static final Long USER_ID = 48L;
     private static final Long CURATION_ID = 181L;
-    private static final String MONTH = "2026-04";
+    private static final String MONTH = "2026-04"; // 큐레이션 이슈 월(N)
+    private static final String DATA_MONTH = "2026-03"; // 데이터 집계 월(N-1)
 
     private static final long EMOTION_JOY = 1L;
     private static final long EMOTION_EXCITEMENT = 3L;
@@ -86,7 +87,7 @@ class InternalLinkCandidateServiceImplTest {
         return KeywordMonthlyCount.builder()
                 .type(type)
                 .refId(refId)
-                .baseMonth(MONTH)
+                .baseMonth(DATA_MONTH)
                 .count(5)
                 .build();
     }
@@ -120,11 +121,11 @@ class InternalLinkCandidateServiceImplTest {
                 .thenReturn(List.of(link3, link2, link1));
 
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
                 .thenReturn(List.of(makeKmc(KeywordType.EMOTION, EMOTION_JOY)));
 
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
                 .thenReturn(List.of(makeKmc(KeywordType.SITUATION, SITUATION_ID)));
 
         when(situationCategoryRepository.findCategoryIdsBySituationId(SITUATION_ID))
@@ -152,10 +153,10 @@ class InternalLinkCandidateServiceImplTest {
         when(usersLinkuRepository.findAllByUserIdAndCreatedAtBetween(eq(USER_ID), any(), any()))
                 .thenReturn(links);
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
                 .thenReturn(List.of());
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
                 .thenReturn(List.of());
 
         List<UsersLinku> result = service.getInternalCandidates(USER_ID, CURATION_ID, 2);
@@ -176,10 +177,10 @@ class InternalLinkCandidateServiceImplTest {
         when(usersLinkuRepository.findAllByUserIdAndCreatedAtBetween(eq(USER_ID), any(), any()))
                 .thenReturn(List.of(oldLink, newLink));
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
                 .thenReturn(List.of());
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
                 .thenReturn(List.of());
 
         List<UsersLinku> result = service.getInternalCandidates(USER_ID, CURATION_ID, 4);
@@ -200,10 +201,10 @@ class InternalLinkCandidateServiceImplTest {
         when(usersLinkuRepository.findAllByUserIdAndCreatedAtBetween(eq(USER_ID), any(), any()))
                 .thenReturn(List.of(link1, link2));
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.EMOTION), any(PageRequest.class)))
                 .thenReturn(List.of());
         when(keywordMonthlyCountRepository.findTopByUserIdAndBaseMonthAndType(
-                eq(USER_ID), eq(MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
+                eq(USER_ID), eq(DATA_MONTH), eq(KeywordType.SITUATION), any(PageRequest.class)))
                 .thenReturn(List.of());
 
         List<UsersLinku> result = service.getInternalCandidates(USER_ID, CURATION_ID, 4);


### PR DESCRIPTION
## 🔗 관련 이슈
#441

---

## 📌 작업 내용
N월호 큐레이션은 N월에 받는다는 요구 사항에 맞게 basemonth를 N월로 하고 집계 기간은 N-1월로 통일했습니다.

저번 달 미열람 링크 조회 api에 month 파라미터를 추가했습니다. 디폴트로 month가 이번 달이 되도록 해두어 프론트 연동엔 영향 없습니다.

8월 큐레이션 생성 디버깅을 하며 달라진 큐레이션 배치 시간을 00:05로 돌려두었습니다. 집계 기간 중 누락 되는 데이터가 생기지 않도록 N월의 첫 날 새벽으로 설정했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 미열람 링크 조회 시 `month(YYYY-MM)`를 선택적으로 지정할 수 있습니다.
  - 월 형식이 올바르지 않으면 명확한 오류 메시지가 표시됩니다.

- **개선**
  - 큐레이션이 서울 시간 기준 현재 월에 맞춰 생성·발송됩니다.
  - 큐레이션 데이터는 기준 월의 전월 데이터를 기반으로 집계됩니다.
  - 월간 큐레이션 생성 시간이 매월 1일 00:05로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->